### PR TITLE
Update versions in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,8 +16,8 @@ behavior models:
 
 - [[https://jdk.java.net][Java Development Kit (version 11+)]]
 - [[https://clojure.org/guides/getting_started][Clojure CLI tools]]
-- [[https://www.postgresql.org/download][Postgresql (version 11+)]]
-- [[https://postgis.net/install][PostGIS (version 3+)]]
+- [[https://www.postgresql.org/download][Postgresql (version 12)]]
+- [[https://postgis.net/install][PostGIS (version 3)]]
 
 ** Environment Variable Setup
 


### PR DESCRIPTION
postgres 11 -> 12

I don't think the + is appropriate for postgres and postgis, the next major version tends to make breaking changes.