### PR TITLE
Fixes from Chris' doc

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -10,7 +10,7 @@
 (defonce out-str      (atom []))
 
 (defn java-date-from-string [date-str]
-  (.parse (java.text.SimpleDateFormat. "yyyyMMdd_hhmmss") date-str))
+  (.parse (java.text.SimpleDateFormat. "yyyyMMdd_HHmmss") date-str))
 
 (defn split-risk-layer-name [name-string]
   (let [[workspace layer]           (str/split name-string #":")
@@ -21,8 +21,9 @@
      :filter-set  (into #{forecast init-timestamp} (str/split layer-group #"_"))
      :model-init  init-timestamp
      :sim-time    sim-timestamp
-     :hour        (- (/ (- (.getTime (java-date-from-string sim-timestamp))
-                           (.getTime (java-date-from-string (str init-timestamp "0000")))) 1000 60 60) 6)}))
+     :hour        (/ (- (.getTime (java-date-from-string sim-timestamp))
+                        (.getTime (java-date-from-string (str init-timestamp "0000"))))
+                     1000 60 60)}))
 
 (defn split-active-layer-name [name-string]
   (let [[workspace layer]                      (str/split name-string #":")

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -105,7 +105,7 @@
                              (fn [_ data]
                                (when-let [hour (or (u/try-js-aget data "datum" "datum" "hour")
                                                    (u/try-js-aget data "datum" "hour"))]
-                                 (layer-click! (dec ^js/integer hour)))))))
+                                 (layer-click! hour))))))
         (catch ExceptionInfo e (js/console.log (ex-cause e)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -235,7 +235,7 @@
 
 (defn time-zone-iso-date [date-str show-utc?]
   (let [js-date (js-date-from-string date-str)]
-    (str (get-date-from-js js-date show-utc?) "-" (get-time-from-js js-date show-utc?))))
+    (str (get-date-from-js js-date show-utc?) " " (get-time-from-js js-date show-utc?))))
 
 ;;; ->map HOF
 


### PR DESCRIPTION
• Change time stamp format to “2020-07-05 18:00 UTC” (no dash after day of month)
• Capitalization in active fire forecast names, i.e. “az-polles” should be “AZ Polles”
• Risk forecast popup graph should start at hour 7 and go through hour 114 (instead of hour 0 – 108). 