### PR TITLE
change layer selection help text

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -225,7 +225,13 @@
                    :type "range" :min "0" :max "100" :value @active-opacity
                    :on-change #(do (reset! active-opacity (u/input-int-value %))
                                    (ol/set-opacity-by-title! "active" (/ @active-opacity 100.0)))}]]
-         [panel-dropdown "Base Map" "Provided courtesy of Mapbox, we offer three map views. Select from the dropdown menu according to your preference." @*base-map c/base-map-options false select-base-map!]
+         [panel-dropdown 
+            "Base Map" 
+            "Provided courtesy of Mapbox, we offer three map views. Select from the dropdown menu according to your preference." 
+            @*base-map 
+            c/base-map-options 
+            false 
+            select-base-map!]
          [:div {:style {:margin-top ".5rem" :padding "0 .5rem"}}
           [:div {:style {:display "flex"}}
            [:input {:style {:margin ".25rem .5rem 0 0"}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -91,7 +91,7 @@
                                             :options    {:elmfire {:opt-label "ELMFIRE"
                                                                    :filter    "elmfire"}}}
                                :model-init {:opt-label  "Forecast Start Time"
-                                            :hover-text "This shows the date and time (in military time) from which the prediction starts. To view a different start time, select one from the dropdown menu. This data is automatically updated when active fires are sensed by satellites."
+                                            :hover-text "This shows the date and time (24 hour time) from which the prediction starts. To view a different start time, select one from the dropdown menu. This data is automatically updated when active fires are sensed by satellites."
                                             :options    {:loading {:opt-label "Loading..."}}}}}
    :fire-risk {:opt-label       "Risk Forecast"
                :filter          "fire-risk-forecast"


### PR DESCRIPTION
Resolves issue #214, however will open another issue regarding the tooltip display for "Base Map" label being aligned to first label "Fire Name" as referenced by Heather in changes slide deck.

I know the change is trivial, using this as a familiarization exercise. Feel free to send _**progressively**_ more challenging work my way. 

![Alt Text](https://media.giphy.com/media/cdNSp4L5vCU7aQrYnV/source.gif)



