### PR TITLE
PYR-326 Restrict match-drop to logged-in users

### DIFF
--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -62,25 +62,30 @@
 
 ;; FIXME take in a map instead of having so many overloads
 (defn labeled-input
-  ([label-text state]
-   [labeled-input label-text state "text" false #(reset! state (input-value %))])
-  ([label-text state type]
-   [labeled-input label-text state type false #(reset! state (input-value %))])
-  ([label-text state type disabled?]
-   [labeled-input label-text state type disabled? #(reset! state (input-value %))])
-  ([label-text state type disabled? call-back]
+  ([{:keys [label state type autocomplete disabled? call-back autoFocus?]
+     :or {type "text" disabled? false call-back #(reset! state (input-value %))}}]
    [:div {:style ($labeled-input)}
-    [:label label-text]
+    [:label label]
     [:input {:class (style->class $/p-bordered-input)
+             :autocomplete autocomplete
+             :autoFocus autoFocus?
              :disabled disabled?
              :type type
              :value @state
-             :on-change call-back}]]))
+             :on-change call-back}]])
+  ([label state]
+   [labeled-input {:label label :state state}])
+  ([label state type]
+   [labeled-input {:label label :state state :type type}])
+  ([label state type disabled?]
+   [labeled-input {:label label :state state :type type :disabled? disabled?}])
+  ([label state type disabled? call-back]
+   [labeled-input {:label label :state state :type type :disabled? disabled? :call-back call-back}]))
 
 (defn input-datetime
   "Creates a labeled datetime input."
   [label id value on-change]
-  [:div
+  [:section
    [:label {:for id :style {:font-wieight "bold" :font-size "0.9rem"}} label]
    [:input {:id id :style {:width "100%"} :type "datetime-local" :value value :on-change on-change}]])
 
@@ -88,21 +93,26 @@
   ([title button-text fields on-click]
    (simple-form title button-text fields on-click nil))
   ([title button-text fields on-click footer]
-   [:div {:style {:height "fit-content" :width "25rem"}}
+   [:form {:style {:height "fit-content" :width "25rem"}
+           :action "#"
+           :on-submit #(do (.preventDefault %) (.stopPropagation %) (on-click %))}
     [:div {:style ($/action-box)}
      [:div {:style ($/action-header)}
       [:label {:style ($/padding "1px" :l)} title]]
      [:div {:style ($/combine {:overflow "auto"})}
       [:div
        [:div {:style ($/combine $/flex-col [$/margin "1.5rem"])}
-        (doall (map-indexed (fn [i [label state type]]
-                              ^{:key i} [labeled-input label state type])
+        (doall (map-indexed (fn [i [label state type autocomplete]]
+                              ^{:key i} [labeled-input {:label        label
+                                                        :autocomplete autocomplete
+                                                        :state        state
+                                                        :type         type
+                                                        :autoFocus?   (= 0 i)}])
                             fields))
         [:input {:class "btn border-yellow text-brown"
                  :style ($/combine ($/align :block :right) {:margin-top ".5rem"})
-                 :type "button"
-                 :value button-text
-                 :on-click on-click}]
+                 :type "submit"
+                 :value button-text}]
         (when footer (footer))]]]]]))
 
 (defn $arrow [arrow-x arrow-y arrow-position show?]

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -70,12 +70,16 @@
         [simple-form
          "Request New Password"
          "Submit"
-         [["Email" email "text"]]
+         [["Email" email "email" "email"]]
          request-password!]
         [simple-form
          "Log in"
          "Log in"
-         [["Email"    email    "text"]
-          ["Password" password "password"]]
+         [["Email"    email    "email"    "email"]
+          ["Password" password "password" "current-password"]]
          log-in!
-         reset-link])]]))
+         reset-link])]
+     [:div {:style ($/combine ($/align "flex" "center"))}
+      "Don't have an account?  "
+      [:a {:href "/register" :style {:margin-left "0.2rem"}} "Register here"]
+      "."]]))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -393,7 +393,7 @@
 ;; UI Components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn control-layer []
+(defn control-layer [user-id]
   (let [my-box (r/atom #js {})]
     (r/create-class
      {:component-did-mount
@@ -426,12 +426,17 @@
                @legend-list
                @last-clicked-info
                #(set-show-info! false)])
-            (when @show-match-drop?
-              [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-capabilities!])
+            (when (and (number? user-id) @show-match-drop?)
+              [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-capabilities! user-id])
             (when @show-camera?
               [mc/camera-tool @the-cameras @my-box #(reset! show-camera? false)])])
          [mc/legend-box @legend-list (get-forecast-opt :reverse-legend?) @mobile?]
-         [mc/tool-bar show-info? show-match-drop? show-camera? set-show-info! @mobile?]
+         [mc/tool-bar {:show-info? show-info?
+                       :show-match-drop? show-match-drop?
+                       :show-camera? show-camera?
+                       :set-show-info! set-show-info!
+                       :mobile @mobile?
+                       :user-id user-id}]
          [mc/scale-bar @mobile?]
          [mc/zoom-bar get-current-layer-extent @mobile? create-share-link]
          [mc/time-slider
@@ -562,12 +567,11 @@
                                         (-> js/window .-location .reload)))}
                 "Log Out"]]
               [:span {:style {:position "absolute" :right "3rem" :display "flex"}}
-                ;; TODO, this is commented out until we are ready for users to create an account
-                ;;  [:label {:style {:margin-right "1rem" :cursor "pointer"}
-                ;;           :on-click #(u/jump-to-url! "/register")} "Register"]
+               [:label {:style {:margin-right "1rem" :cursor "pointer"}
+                        :on-click #(u/jump-to-url! "/register")} "Register"]
                [:label {:style {:cursor "pointer"}
                         :on-click #(u/jump-to-url! "/login")} "Log In"]]))]
          [:div {:style {:height "100%" :position "relative" :width "100%"}}
-          (when @mb/the-map [control-layer])
+          (when @mb/the-map [control-layer user-id])
           [map-layer]
           [pop-up]]])})))

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -70,8 +70,12 @@
       [simple-form
        "Register"
        "Register"
-       [["Email"             email       "text"]
-        ["Full Name"         full-name   "text"]
-        ["Password"          password    "password"]
-        ["Re-enter Password" re-password "password"]]
-       register!]]]))
+       [["Email"            email       "email"    "email"]
+        ["Full Name"        full-name   "text"     "name"]
+        ["Password"         password    "password" "new-password"]
+        ["Confirm Password" re-password "password" "confirm-password"]]
+       register!]]
+     [:div {:style ($/combine ($/align "flex" "center"))}
+      "Already have an account?  "
+      [:a {:href "/login" :style {:margin-left "0.2rem"}} "Log in here"]
+      "."]]))

--- a/src/cljs/pyregence/pages/reset_password.cljs
+++ b/src/cljs/pyregence/pages/reset_password.cljs
@@ -65,7 +65,7 @@
       [simple-form
        "Reset Password"
        "Reset Password"
-       [["Email"                 email       "text"]
-        ["New Password"          password    "password"]
-        ["Re-enter New Password" re-password "password"]]
+       [["Email"                 email       "email"    "email"]
+        ["New Password"          password    "password" "new-password"]
+        ["Re-enter New Password" re-password "password" "confirm-password"]]
        reset-password!]]]))


### PR DESCRIPTION
## Purpose
Only show match-drop tool when logged in. Tracks the `:user-id` with the job, and tracks all messages in `logs`. Updates `label-input` to accept a hash-map,  including :autoFocus?, :autocomplete

## Related Issues
Closes PYR-326

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `PYR-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
<!-- Create a BDD style test script -->
1. Given a visitor, Then the match drop tool is hidden.
2. Given a logged-in user, Then the match drop tool is shown.
