### PR TITLE
PYR-326 Restrict match-drop to logged-in users

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -279,7 +279,7 @@
 (defn hs-str [hide?]
   (if hide? "Hide" "Show"))
 
-(defn tool-bar [show-info? show-match-drop? show-camera? set-show-info! mobile?]
+(defn tool-bar [{:keys [show-info? show-match-drop? show-camera? set-show-info! mobile? user-id]}]
   [:div#tool-bar {:style ($/combine $/tool $tool-bar {:top "16px"})}
    (->> [[:layers
           (str (hs-str @show-panel?) " layer selection")
@@ -292,7 +292,7 @@
                  (reset! show-match-drop? false)
                  (reset! show-camera? false))
             @show-info?])
-         (when-not mobile?
+         (when (and (number? user-id) (not mobile?))
            [:flame
             (str (hs-str @show-match-drop?) " match drop tool")
             #(do (swap! show-match-drop? not)
@@ -398,12 +398,13 @@
 
 (defn- initiate-match-drop
   "Initiates the match drop run and initiates polling for updates."
-  [[lon lat] datetime refresh-capabilities!]
+  [[lon lat] datetime refresh-capabilities! user-id]
   (go
     (let [match-chan (u/call-clj-async! "initiate-md"
                                         {:ignition-time (u/time-zone-iso-date datetime true)
                                          :lon           lon
-                                         :lat           lat})]
+                                         :lat           lat
+                                         :user-id       user-id})]
       (reset! poll? true)
       (set-message-box-content! {:title  "Processing Match Drop"
                                  :body   "Initiating match drop run."
@@ -439,7 +440,7 @@
 (defn match-drop-tool
   "Match Drop Tool view. Enables a user to start a simulated fire at a particular
    location and date/time."
-  [parent-box close-fn! refresh-capabilities!]
+  [parent-box close-fn! refresh-capabilities! user-id]
   (r/with-let [lon-lat        (r/atom [0 0])
                datetime       (r/atom "")
                moving-lon-lat (r/atom [0 0])
@@ -464,7 +465,7 @@
           [:div {:style {:display "flex" :justify-content "flex-end" :align-self "flex-end" :margin-left "auto"}}
            [:button {:class    "mx-3 mb-1 btn btn-sm text-white"
                      :style    ($/disabled-group (or (= [0 0] @lon-lat) (= "" @datetime)))
-                     :on-click #(initiate-match-drop @lon-lat @datetime refresh-capabilities!)}
+                     :on-click #(initiate-match-drop @lon-lat @datetime refresh-capabilities! user-id)}
             "Submit"]]]])]]
     (finally
       (mb/remove-event! click-event)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -393,7 +393,7 @@
 ;; UI Components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn control-layer []
+(defn control-layer [user-id]
   (let [my-box (r/atom #js {})]
     (r/create-class
      {:component-did-mount
@@ -427,11 +427,16 @@
                @last-clicked-info
                #(set-show-info! false)])
             (when @show-match-drop?
-              [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-capabilities!])
+              [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-capabilities! user-id])
             (when @show-camera?
               [mc/camera-tool @the-cameras @my-box #(reset! show-camera? false)])])
          [mc/legend-box @legend-list (get-forecast-opt :reverse-legend?) @mobile?]
-         [mc/tool-bar show-info? show-match-drop? show-camera? set-show-info! @mobile?]
+         [mc/tool-bar {:show-info?       show-info?
+                       :show-match-drop? show-match-drop?
+                       :show-camera?     show-camera?
+                       :set-show-info!   set-show-info!
+                       :mobile           @mobile?
+                       :user-id          user-id}]
          [mc/scale-bar @mobile?]
          [mc/zoom-bar get-current-layer-extent @mobile? create-share-link]
          [mc/time-slider
@@ -562,12 +567,11 @@
                                         (-> js/window .-location .reload)))}
                 "Log Out"]]
               [:span {:style {:position "absolute" :right "3rem" :display "flex"}}
-                ;; TODO, this is commented out until we are ready for users to create an account
-                ;;  [:label {:style {:margin-right "1rem" :cursor "pointer"}
-                ;;           :on-click #(u/jump-to-url! "/register")} "Register"]
+               [:label {:style {:margin-right "1rem" :cursor "pointer"}
+                        :on-click #(u/jump-to-url! "/register")} "Register"]
                [:label {:style {:cursor "pointer"}
                         :on-click #(u/jump-to-url! "/login")} "Log In"]]))]
          [:div {:style {:height "100%" :position "relative" :width "100%"}}
-          (when @mb/the-map [control-layer])
+          (when @mb/the-map [control-layer user-id])
           [map-layer]
           [pop-up]]])})))


### PR DESCRIPTION
## Purpose
Only show match-drop tool when logged in, and track user-id with match-drop job.

## Related Issues
Closes PYR-326

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `PYR-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
<!-- Create a BDD style test script -->
1. Given a visitor, Then the match drop tool is hidden.
1. Given a logged-in user, Then the match drop tool is shown.

