### PR TITLE
Dump Match-Drop logs to console on error

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -408,9 +408,9 @@
   (go
     (while @poll?
       (let [{:keys [message md-status log]} (-> (u/call-clj-async! "get-md-status" job-id)
-                                            (<!)
-                                            (:body)
-                                            (edn/read-string))]
+                                                (<!)
+                                                (:body)
+                                                (edn/read-string))]
         (case md-status
           0 (do
               (refresh-capabilities!)


### PR DESCRIPTION
## Purpose
Displays the logs in the browser console when Match Drop errors out.

## Related Issues
N/A