### PR TITLE
Fix hiding toolbar icons on mobile

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -334,7 +334,7 @@
 (defn hs-str [hide?]
   (if hide? "Hide" "Show"))
 
-(defn tool-bar [{:keys [show-info? show-match-drop? show-camera? show-red-flag? set-show-info! mobile? user-id]}]
+(defn tool-bar [show-info? show-match-drop? show-camera? show-red-flag? set-show-info! mobile? user-id]
   [:div#tool-bar {:style ($/combine $/tool $tool-bar {:top "16px"})}
    (->> [[:layers
           (str (hs-str @show-panel?) " layer selection")
@@ -361,9 +361,10 @@
                  (set-show-info! false)
                  (reset! show-match-drop? false))
             @show-camera?])
-         [:flag
-          (str (hs-str @show-red-flag?) " red flag warnings")
-          #(toggle-red-flag-layer! show-red-flag?)]
+         (when-not mobile?
+           [:flag
+            (str (hs-str @show-red-flag?) " red flag warnings")
+            #(toggle-red-flag-layer! show-red-flag?)])
          [:legend
           (str (hs-str @show-legend?) " legend")
           #(swap! show-legend? not)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -432,13 +432,14 @@
             (when @show-camera?
               [mc/camera-tool @the-cameras @my-box #(reset! show-camera? false)])])
          [mc/legend-box @legend-list (get-forecast-opt :reverse-legend?) @mobile?]
-         [mc/tool-bar {:show-info?       show-info?
-                       :show-match-drop? show-match-drop?
-                       :show-camera?     show-camera?
-                       :show-red-flag?   show-red-flag?
-                       :set-show-info!   set-show-info!
-                       :mobile           @mobile?
-                       :user-id          user-id}]
+         [mc/tool-bar
+          show-info?
+          show-match-drop?
+          show-camera?
+          show-red-flag?
+          set-show-info!
+          @mobile?
+          user-id]
          [mc/scale-bar @mobile?]
          [mc/zoom-bar get-current-layer-extent @mobile? create-share-link]
          [mc/time-slider


### PR DESCRIPTION
## Purpose
Hide certain toolbar icons on mobile (Red Flag warning, Wildfire Cameras, Point Info).

## Steps
Replace hash-map style args. Reagent doesn't like that for some reason.
