### PR TITLE
Fix up red flag warning logic

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -318,7 +318,7 @@
   "Toggle the red-flag warning layer"
   [show-red-flag?]
   (swap! show-red-flag? not)
-  (when (and @show-red-flag? (mb/layer-exists? "red-flag"))
+  (when (and @show-red-flag? (not (mb/layer-exists? "red-flag")))
     (add-red-flag-layer!))
   (mb/set-visible-by-title! "red-flag" @show-red-flag?))
 


### PR DESCRIPTION
## Purpose
Red flag warning layers were not being added to the map. Fixes up the logic to make sure it displays.