### PR TITLE
PYR-408 Add unsupported browser alert

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -625,6 +625,9 @@
   ([] (init-map! "map"))
   ([container-id]
    (set! (.-accessToken mapbox) c/mapbox-access-token)
+   (when-not (.supported mapbox)
+     (js/alert (str "Your browser does not support Pyregence Forecast.\n"
+                    "Please use the latest version of Chrome, Safari, or Firefox.")))
    (reset! the-map
            (Map.
             (clj->js {:container   container-id


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Show an alert if the user is using a browser that does not support WebGL.

## Related Issues
Closes PYR-408

## Testing
<!-- Create a BDD style test script -->
1. Given I am a Visitor using an unsupported browser, When I visit the forecast tool, Then I am shown an alert that my browser is not supported.
