### PR TITLE
PYR-402 Limit running match drops per user to 1

### DIFF
--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -73,11 +73,11 @@
       (first)
       (sql-result->job)))
 
-(defn- get-all-running-match-drops []
-  (sql-primitive (call-sql "get_all_running_match_jobs")))
+(defn- count-all-running-match-drops []
+  (sql-primitive (call-sql "count_all_running_match_jobs")))
 
-(defn- get-running-user-match-jobs [user-id]
-  (sql-primitive (call-sql "get_running_user_match_jobs" user-id)))
+(defn- count-running-user-match-jobs [user-id]
+  (sql-primitive (call-sql "count_running_user_match_jobs" user-id)))
 
 (defn- initialize-match-job! [user-id]
   (sql-primitive (call-sql "initialize_match_job" user-id)))
@@ -129,17 +129,17 @@
     (send-to-server-wrapper! "wx.pyregence.org" 31337 job-id)
     (data-response {:job-id job-id})))
 
-;; Public API
+;;; Public API
 
 (defn initiate-md!
   "Creates a new match drop run and starts the analysis."
   [{:keys [user-id] :as params}]
   (data-response
     (cond
-      (pos? (get-running-user-match-jobs user-id))
+      (pos? (count-running-user-match-jobs user-id))
       {:error "Match drop is already running. Please wait until it has completed."}
 
-      (< 5 (get-all-running-match-drops))
+      (< 5 (count-all-running-match-drops))
       {:error "The queue is currently full. Please try again later."}
 
       :else

--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -469,10 +469,10 @@
                                  :mode   :close
                                  :action #(reset! poll? false)}) ; TODO the close button is for dev, disable on final product
       (let [{:keys [error job-id]} (edn/read-string (:body (<! match-chan)))]
-        (if (nil? error)
+        (if error
+          (set-message-box-content! {:body (str "Error: " error)})
           (do (reset! poll? true)
-              (poll-status job-id refresh-fire-names!))
-          (set-message-box-content! {:body (str "Error: " error)}))))))
+              (poll-status job-id refresh-fire-names!)))))))
 
 ;; Styles
 (defn- $match-drop-location []

--- a/src/sql/functions/match_functions.sql
+++ b/src/sql/functions/match_functions.sql
@@ -61,8 +61,8 @@ CREATE OR REPLACE FUNCTION get_user_match_jobs(_user_id integer)
 
 $$ LANGUAGE SQL;
 
--- Retrieve all running match drop jobs associated with user_rid
-CREATE OR REPLACE FUNCTION get_running_user_match_jobs(_user_id integer)
+-- Retrieve count of running match drop jobs associated with user_rid
+CREATE OR REPLACE FUNCTION count_running_user_match_jobs(_user_id integer)
  RETURNS integer AS $$
 
     SELECT COUNT(*)
@@ -72,8 +72,8 @@ CREATE OR REPLACE FUNCTION get_running_user_match_jobs(_user_id integer)
 
 $$ LANGUAGE SQL;
 
--- Retrieve all running match drop jobs
-CREATE OR REPLACE FUNCTION get_all_running_match_jobs()
+-- Retrieve count of all running match drop jobs
+CREATE OR REPLACE FUNCTION count_all_running_match_jobs()
  RETURNS integer AS $$
 
     SELECT COUNT(*)


### PR DESCRIPTION
## Purpose
Limits the max number of match drop jobs running to 1 at a time.

## Steps
* Add `get_running_user_match_drops` SQL/CLJ fns
* Modify `initiate-md!` route to check for running match drops
* Add error handling to the `map-controls/initiate-match-drop` fn

## Screenshots

Already Running Error
![Screen Shot 2021-06-03 at 10 57 57 AM](https://user-images.githubusercontent.com/1829313/120690833-90c71900-c45a-11eb-9bea-2fd6c3dafd0a.png)

Queue Full Error
![Screen Shot 2021-06-03 at 11 27 39 AM](https://user-images.githubusercontent.com/1829313/120694157-b81fe500-c45e-11eb-9dfb-099058da755d.png)
