### PR TITLE
PYR-396 Replace MB hash with lat/lng/zoom query params

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -628,21 +628,20 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn init-map!
-  "Initializes the Mapbox map inside of container (defaults to div with id 'map')."
-  ([] (init-map! "map"))
-  ([container-id & [opts]]
-   (set! (.-accessToken mapbox) c/mapbox-access-token)
-   (when-not (.supported mapbox)
-     (js/alert (str "Your browser does not support Pyregence Forecast.\n"
-                    "Please use the latest version of Chrome, Safari, or Firefox.")))
-   (reset! the-map
-           (Map.
-             (clj->js (merge {:container   container-id
-                              :dragRotate  false
-                              :maxZoom     20
-                              :minZoom     3
-                              :style       (-> c/base-map-options c/base-map-default :source)
-                              :touchPitch  false
-                              :trackResize true
-                              :transition  {:duration 500 :delay 0}}
-                             opts))))))
+  "Initializes the Mapbox map inside of `container` (e.g. \"map\")."
+  [container-id & [opts]]
+  (set! (.-accessToken mapbox) c/mapbox-access-token)
+  (when-not (.supported mapbox)
+    (js/alert (str "Your browser does not support Pyregence Forecast.\n"
+                   "Please use the latest version of Chrome, Safari, or Firefox.")))
+  (reset! the-map
+          (Map.
+            (clj->js (merge {:container   container-id
+                             :dragRotate  false
+                             :maxZoom     20
+                             :minZoom     3
+                             :style       (-> c/base-map-options c/base-map-default :source)
+                             :touchPitch  false
+                             :trackResize true
+                             :transition  {:duration 500 :delay 0}}
+                            opts)))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -137,15 +137,15 @@
                                {:forecast  @*forecast
                                 :layer-idx @*layer-idx
                                 :zoom      zoom})]
-    (as-> page-params $
-      (map (fn [[k v]] (cond
-                         (keyword? v)
-                         (str (name k) "=" (name v))
+    (->> page-params
+         (map (fn [[k v]] (cond
+                            (keyword? v)
+                            (str (name k) "=" (name v))
 
-                         (or (string? v) (number? v))
-                         (str (name k) "=" v))) $)
-      (str/join "&" $)
-      (str js/location.origin js/location.pathname "?" $))))
+                            (or (string? v) (number? v))
+                            (str (name k) "=" v))))
+         (str/join "&")
+         (str js/location.origin js/location.pathname "?"))))
 
 (defn get-data
   "Asynchronously fetches the JSON or XML resource at url. Returns a


### PR DESCRIPTION
## Purpose
When attempting to share a map, we were relying a URL hash (#) that Mapbox generated. This replaces that functionality with query params (lat/lng/zoom).

## Testing
1. As a Visitor, When I click the "Share" icon, Then a modal appears with the share URL, And I can copy the URL.
2. As a Visitor, When I use a Share URL in my browser, Then the map shows the layer and timestamp that I had shared.