### PR TITLE
PYR-400 Fix camera zoom/3D terrain bug

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -334,6 +334,9 @@
 (defn hs-str [hide?]
   (if hide? "Hide" "Show"))
 
+(defn ed-str [enabled?]
+  (if enabled? "Disable" "Enable"))
+
 (defn tool-bar [show-info? show-match-drop? show-camera? show-red-flag? set-show-info! mobile? user-id]
   [:div#tool-bar {:style ($/combine $/tool $tool-bar {:top "16px"})}
    (->> [[:layers
@@ -376,9 +379,8 @@
                                   :right
                                   [tool-button icon on-click active?]])))])
 
-(defn zoom-bar [get-current-layer-extent mobile? create-share-link]
-  (r/with-let [terrain?     (r/atom false)
-               minZoom      (r/atom 0)
+(defn zoom-bar [get-current-layer-extent mobile? create-share-link terrain?]
+  (r/with-let [minZoom      (r/atom 0)
                maxZoom      (r/atom 28)
                *zoom        (r/atom 10)
                select-zoom! (fn [zoom]
@@ -403,7 +405,7 @@
                                                 :body  [share-inner-modal create-share-link]
                                                 :mode  :close})]
                    [:terrain
-                    "Toggle 3D terrain"
+                    (str (ed-str @terrain?) " 3D terrain")
                     #(do
                        (swap! terrain? not)
                        (mb/toggle-dimensions! @terrain?)
@@ -558,11 +560,12 @@
          (:body)
          (js/URL.createObjectURL))))
 
-(defn camera-tool [cameras parent-box close-fn!]
+(defn camera-tool [cameras parent-box terrain? close-fn!]
   (r/with-let [*camera     (r/atom nil)
                *image      (r/atom nil)
                zoom-camera (fn []
                              (let [{:keys [longitude latitude tilt pan]} @*camera]
+                               (reset! terrain? true)
                                (mb/toggle-dimensions! true)
                                (mb/fly-to! {:center [longitude latitude]
                                             :zoom 15

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -56,6 +56,7 @@
 (defonce *layer-idx        (r/atom 0))
 (defonce the-cameras       (r/atom nil))
 (defonce loading?          (r/atom true))
+(defonce terrain?          (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Data Processing Functions
@@ -436,7 +437,7 @@
             (when @show-match-drop?
               [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-fire-names! user-id])
             (when @show-camera?
-              [mc/camera-tool @the-cameras @my-box #(reset! show-camera? false)])])
+              [mc/camera-tool @the-cameras @my-box terrain? #(reset! show-camera? false)])])
          [mc/legend-box @legend-list (get-forecast-opt :reverse-legend?) @mobile?]
          [mc/tool-bar
           show-info?
@@ -447,7 +448,7 @@
           @mobile?
           user-id]
          [mc/scale-bar @mobile?]
-         [mc/zoom-bar get-current-layer-extent @mobile? create-share-link]
+         [mc/zoom-bar get-current-layer-extent @mobile? create-share-link terrain?]
          [mc/time-slider
           param-layers
           *layer-idx


### PR DESCRIPTION

## Purpose
Fixes the bug where zooming into a camera, then "toggling" the 3D terrain would leave 3D terrain enabled. Also the label updates now when the terrain is enabled/disabled.

## Screenshots
After 'Zooming' to a camera's position 
![Screen Shot 2021-06-07 at 11 15 57 AM](https://user-images.githubusercontent.com/1829313/121068962-bd906e80-c781-11eb-8181-2f2a92d706d9.png)

After clicking 'Disable 3D Terrain'
![Screen Shot 2021-06-07 at 11 16 14 AM](https://user-images.githubusercontent.com/1829313/121068976-c84b0380-c781-11eb-894a-d316b8972555.png)
