### PR TITLE
PYR-423 Fix opacity after enabling 3D Terrain

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -361,7 +361,8 @@
         new-paint  (condp = layer-type
                      "raster" (raster-opacity opacity)
                      "circle" (circle-opacity opacity)
-                     "symbol" (symbol-opacity opacity))]
+                     "symbol" (symbol-opacity opacity)
+                     {})]
     (update layer "paint" merge new-paint)))
 
 (defn set-opacity-by-title!


### PR DESCRIPTION
## Purpose
See PR title

## Testing
1. As a Visitor, When I enable 3D terrain, And I adjust the opacity slider, Then the current layer's opacity matches the opacity slider.
