### PR TITLE
PYR-412 Fix the Base Map selector for Active Fires

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -412,8 +412,8 @@
    `z-index` allows layers to be rendered on-top (positive z-index) or below
    (negative z-index) Mapbox base map layers."
   [id source opacity]
-  (let [new-source {source (wms-source source)}
-        new-layer  (wms-layer id source opacity)]
+  (let [new-source {id (wms-source source)}
+        new-layer  (wms-layer id id opacity)]
     [new-source [new-layer]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
## Purpose
Fixes the Base Map selector when viewing the Active Fires tab.

## Testing
1. As a Visitor, When I view the Active Fires Tab, and I change the base map to "Satellite," Then the base map is updated to use satellite imagery.

