### PR TITLE
Set max zoom in case of 1 fire

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -1,7 +1,6 @@
 (ns pyregence.components.mapbox
   (:require [reagent.core       :as r]
             [reagent.dom.server :as rs]
-            [clojure.string :as str]
             [clojure.core.async :refer [go <!]]
             [pyregence.config    :as c]
             [pyregence.utils     :as u]
@@ -101,9 +100,12 @@
 
 (defn zoom-to-extent!
   "Pans/zooms the map to the provided extents."
-  [[minx miny maxx maxy]]
-  (let [bounds (LngLatBounds. (clj->js [[minx miny] [maxx maxy]]))]
-    (.fitBounds @the-map bounds #js {:linear true})))
+  [[minx miny maxx maxy] & [max-zoom]]
+  (.fitBounds @the-map
+              (LngLatBounds. (clj->js [[minx miny] [maxx maxy]]))
+              (-> {:linear true}
+                  (merge (when max-zoom {:maxZoom max-zoom}))
+                  (clj->js))))
 
 (defn set-center!
   "Centers the map on `center` with a minimum zoom value of `min-zoom`."
@@ -637,12 +639,12 @@
                    "Please use the latest version of Chrome, Safari, or Firefox.")))
   (reset! the-map
           (Map.
-            (clj->js (merge {:container   container-id
-                             :dragRotate  false
-                             :maxZoom     20
-                             :minZoom     3
-                             :style       (-> c/base-map-options c/base-map-default :source)
-                             :touchPitch  false
-                             :trackResize true
-                             :transition  {:duration 500 :delay 0}}
-                            opts)))))
+           (clj->js (merge {:container   container-id
+                            :dragRotate  false
+                            :maxZoom     20
+                            :minZoom     3
+                            :style       (-> c/base-map-options c/base-map-default :source)
+                            :touchPitch  false
+                            :trackResize true
+                            :transition  {:duration 500 :delay 0}}
+                           opts)))))

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -69,10 +69,12 @@
                                             :default-option :calfire-incidents
                                             :options        {:calfire-incidents {:opt-label  "*CALFIRE Incidents"
                                                                                  :style-fn   :default
-                                                                                 :filter-set #{"fire-detections" "calfire-incidents"}}
+                                                                                 :filter-set #{"fire-detections" "calfire-incidents"}
+                                                                                 :max-zoom   7}
                                                              :nifc-large-fires  {:opt-label  "*NIFC Large Fires"
                                                                                  :style-fn   :default
-                                                                                 :filter-set #{"fire-detections" "nifc-large-fires"}}}}
+                                                                                 :filter-set #{"fire-detections" "nifc-large-fires"}
+                                                                                 :max-zoom   7}}}
                                :output     {:opt-label  "Output"
                                             :hover-text "This shows the areas where our models forecast the fire to spread over 3 days. Time can be advanced with the slider below, and the different colors on the map provide information about when an area is forecast to burn."
                                             :options    {:burned {:opt-label "Forecasted fire location"


### PR DESCRIPTION
## Purpose
When there is a low number of fires for the fire overview layer, it zooms in too far.  Instead of an extent, I made this more generic with a max-zoom level.

## Related Issues
Closes PYR-346

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `PYR-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. When selecting active fires, then the map does not zoom in all the way on the one fire.

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/121402210-77b4e100-c90e-11eb-99c7-c23ba8775538.png)


