### PR TITLE
Dont zoom on point click

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -217,8 +217,7 @@
 (defn add-point-on-click!
   "Callback for `click` listener."
   [[lng lat]]
-  (init-point! lng lat)
-  (center-on-overlay!))
+  (init-point! lng lat))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Popup


### PR DESCRIPTION
## Purpose
Do not zoom in on the marker when clicking. 

## Related Issues
Closes PYR-417

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `PYR-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. When clicking a point for point information, the zoom does not change.


