### PR TITLE
Fix Active Fires mouseover effects

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -251,7 +251,7 @@
       (mb/reset-active-layer! source style-fn (/ @active-opacity 100))
       (mb/clear-popup!)
       (when (some? style-fn)
-        (mb/add-feature-highlight! "fire-active" source init-fire-popup!))
+        (mb/add-feature-highlight! "fire-active" "fire-active" init-fire-popup!))
       (get-legend! source))
     (if clear?
       (clear-info!)


### PR DESCRIPTION
## Purpose
Fix the hover/mouse-over effects for Active Fires tab.
