### PR TITLE
PYR-416 Re-order & simplify tabs

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -13,64 +13,64 @@
 
 (def near-term-forecast-default :fire-risk)
 (def near-term-forecast-options
-  {:fuels     {:opt-label       "Fuels"
-               :filter          "fuels"
-               :block-info?     true
-               :reverse-legend? false
-               :hover-text      "Layers related to fuel and potential fire behavior."
-               :params          {:model {:opt-label  "Source"
-                                         :hover-text "LANDFIRE data (https://landfire.gov) at 30m resolution.
+  {:fuels        {:opt-label       "Fuels"
+                  :filter          "fuels"
+                  :block-info?     true
+                  :reverse-legend? false
+                  :hover-text      "Layers related to fuel and potential fire behavior."
+                  :params          {:model {:opt-label  "Source"
+                                            :hover-text "LANDFIRE data (https://landfire.gov) at 30m resolution.
 
-                                                     California Forest Observatory - Summer 2020 at 10m resolution
-                                                     Courtesy of the California Forest Observatory (forestobservatory.com), © Salo Sciences, Inc. 2020.
+                                                        California Forest Observatory - Summer 2020 at 10m resolution
+                                                        Courtesy of the California Forest Observatory (forestobservatory.com), © Salo Sciences, Inc. 2020.
 
-                                                     California Fuelscapes prepared and provided by Pyrologix, LLC (https://pyrologix.com/), 2021."
-                                         :options    {:landfire      {:opt-label "LandFire 2.0"
-                                                                      :filter    "landfire-2.0.0"
-                                                                      :units     ""}
-                                                      :cfo           {:opt-label "California Forest Observatory"
-                                                                      :filter    "cfo-2020"
-                                                                      :units     ""}
-                                                      :ca-fuelscapes {:opt-label "California Fuelscapes"
-                                                                      :filter    "ca-fuelscapes"
-                                                                      :units     ""}}}
-                                 :layer {:opt-label  "Layer"
-                                         :hover-text "Geospatial surface and canopy fuel inputs, forecasted ember ignition probability and head fire spread rate & flame length."
-                                         :options    (array-map
-                                                      :asp    {:opt-label "Aspect"
-                                                               :filter    "asp"
-                                                               :units     ""
-                                                               :disabled  #{:cfo}}
-                                                      :slp    {:opt-label "Slope (%)"
-                                                               :filter    "slp"
-                                                               :units     "%"
-                                                               :disabled  #{:cfo}}
-                                                      :dem    {:opt-label "Elevation (ft)"
-                                                               :filter    "dem"
-                                                               :units     ""
-                                                               :disabled  #{:cfo}}
-                                                      :cc     {:opt-label "Canopy Cover (%)"
-                                                               :filter    "cc"
-                                                               :units     "%"}
-                                                      :ch     {:opt-label "Canopy Height (m)"
-                                                               :filter    "ch"
-                                                               :units     "m"}
-                                                      :cbh    {:opt-label "Canopy Base Height (m)"
-                                                               :filter    "cbh"
-                                                               :units     "m"}
-                                                      :cbd    {:opt-label "Crown Bulk Density (kg/m^3)"
-                                                               :filter    "cbd"
-                                                               :units     "kg/m^3"}
-                                                      :fbfm13 {:opt-label "Fire Behavior Fuel Model 13"
-                                                               :filter    "fbfm13"
-                                                               :units     ""
-                                                               :disabled  #{:cfo :ca-fuelscapes}}
-                                                      :fbfm40 {:opt-label "Fire Behavior Fuel Model 40"
-                                                               :filter    "fbfm40"
-                                                               :units     ""})}
-                                 :model-init {:opt-label  "Model Creation Time"
-                                              :hover-text "Time the data was created."
-                                              :options    {:loading {:opt-label "Loading..."}}}}}
+                                                        California Fuelscapes prepared and provided by Pyrologix, LLC (https://pyrologix.com/), 2021."
+                                            :options    {:landfire      {:opt-label "LandFire 2.0"
+                                                                         :filter    "landfire-2.0.0"
+                                                                         :units     ""}
+                                                         :cfo           {:opt-label "California Forest Observatory"
+                                                                         :filter    "cfo-2020"
+                                                                         :units     ""}
+                                                         :ca-fuelscapes {:opt-label "California Fuelscapes"
+                                                                         :filter    "ca-fuelscapes"
+                                                                         :units     ""}}}
+                                    :layer {:opt-label  "Layer"
+                                            :hover-text "Geospatial surface and canopy fuel inputs, forecasted ember ignition probability and head fire spread rate & flame length."
+                                            :options    (array-map
+                                                          :asp    {:opt-label "Aspect"
+                                                                   :filter    "asp"
+                                                                   :units     ""
+                                                                   :disabled  #{:cfo}}
+                                                          :slp    {:opt-label "Slope (%)"
+                                                                   :filter    "slp"
+                                                                   :units     "%"
+                                                                   :disabled  #{:cfo}}
+                                                          :dem    {:opt-label "Elevation (ft)"
+                                                                   :filter    "dem"
+                                                                   :units     ""
+                                                                   :disabled  #{:cfo}}
+                                                          :cc     {:opt-label "Canopy Cover (%)"
+                                                                   :filter    "cc"
+                                                                   :units     "%"}
+                                                          :ch     {:opt-label "Canopy Height (m)"
+                                                                   :filter    "ch"
+                                                                   :units     "m"}
+                                                          :cbh    {:opt-label "Canopy Base Height (m)"
+                                                                   :filter    "cbh"
+                                                                   :units     "m"}
+                                                          :cbd    {:opt-label "Crown Bulk Density (kg/m^3)"
+                                                                   :filter    "cbd"
+                                                                   :units     "kg/m^3"}
+                                                          :fbfm13 {:opt-label "Fire Behavior Fuel Model 13"
+                                                                   :filter    "fbfm13"
+                                                                   :units     ""
+                                                                   :disabled  #{:cfo :ca-fuelscapes}}
+                                                          :fbfm40 {:opt-label "Fire Behavior Fuel Model 40"
+                                                                   :filter    "fbfm40"
+                                                                   :units     ""})}
+                                    :model-init {:opt-label  "Model Creation Time"
+                                                 :hover-text "Time the data was created."
+                                                 :options    {:loading {:opt-label "Loading..."}}}}}
    :fire-weather {:opt-label       "Weather"
                   :filter          "fire-weather-forecast"
                   :reverse-legend? true
@@ -112,108 +112,108 @@
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}
-   :fire-risk {:opt-label       "Risk"
-               :filter          "fire-risk-forecast"
-               :reverse-legend? true
-               :hover-text      "5-day forecast of fire consequence maps. Every day over 500 million hypothetical fires are ignited across California to evaluate potential fire risk.\n"
-               :params          {:output     {:opt-label  "Output"
-                                              :hover-text "Key fire spread model outputs based on modeling 6-hours of fire spread without fire suppression activities within 6 hours of time shown in time slider. Options include:\n
-                                                           Relative Burn Probability - Relative likelihood that an area is burned by fires that have not yet ignited within the next six hours of time shown in time slider.\n
-                                                           Impacted Structures - Approximate number of residential structures within fire perimeter for fires starting at specific location and time in the future.\n
-                                                           Fire Area - Modeled fire size in acres by ignition location and time of ignition.\n
-                                                           Fire Volume - Modeled fire volume (fire area in acres multiplied by flame length in feet) by ignition location and time of ignition."
-                                              :options    {:times-burned {:opt-label "Relative burn probability"
-                                                                          :filter    "times-burned"
-                                                                          :units     "Times"}
-                                                           :impacted     {:opt-label "Impacted structures"
-                                                                          :filter    "impacted-structures"
-                                                                          :units     "Structures"}
-                                                           :fire-area    {:opt-label "Fire area"
-                                                                          :filter    "fire-area"
-                                                                          :units     "Acres"}
-                                                           :fire-volume  {:opt-label "Fire volume"
-                                                                          :filter    "fire-volume"
-                                                                          :units     "Acre-ft"}}}
-                                 :pattern    {:opt-label  "Ignition Pattern"
-                                              :hover-text "Fires are ignited randomly across California at various times in the future so their impacts can be modeled. Patterns include:\n
-                                                           Human Caused - Anthropogenic fires (fires from all causes except lightning).\n
-                                                           Transmission Lines - Fires ignited in close proximity to overhead electrical transmission lines.\n"
-                                              :options    {:all        {:opt-label    "Human-caused ignitions"
-                                                                        :filter       "all"}
-                                                           :tlines     {:opt-label    "Transmission lines"
-                                                                        :filter       "tlines"
-                                                                        :clear-point? true}}}
-                                 :fuel       {:opt-label  "Fuel"
-                                              :hover-text "Source of surface and canopy fuel inputs:\n
-                                                           LANDFIRE data (https://landfire.gov) at 30-m resolution customized by Pyrologix (http://pyrologix.com) for the United States Forest Service, Pacific Southwest Region (https://www.fs.usda.gov/r5).\n
-                                                           California Forest Observatory (https://forestobservatory.com) 10 m fuels measured by satellite."
-                                              :options    {:landfire {:opt-label "Custom LANDFIRE"
-                                                                      :filter    "landfire"}
-                                                           :cfo      {:opt-label "California Forest Observatory"
-                                                                      :filter    "cfo"}}}
-                                 :model      {:opt-label  "Model"
-                                              :hover-text "Computer fire spread model used to generate active fire and risk forecasts.\n
-                                                           ELMFIRE - Cloud-based operational fire spread model developed at Reax Engineering Inc. (https://doi.org/10.1016/j.firesaf.2013.08.014)."
-                                              :options    {:elmfire {:opt-label "ELMFIRE"
-                                                                     :filter    "elmfire"}}}
-                                 :model-init {:opt-label  "Forecast Start Time"
-                                              :hover-text "Start time for forecast cycle. New data is created every 12 hours."
-                                              :options    {:loading {:opt-label "Loading..."}}}}}
-   :active-fire {:opt-label   "Active Fires"
-                 :filter      "fire-spread-forecast"
-                 :block-info? true
-                 :hover-text  "3-day forecasts of active fires with burning areas established from satellite-based heat detection."
-                 :params      {:fire-name  {:opt-label      "Fire Name"
-                                            :auto-zoom?     true
-                                            :sort?          true
-                                            :hover-text     "Provides a list of active fires for which forecasts are available. To zoom to a specific fire, select it from the dropdown menu."
-                                            :underlays      {:nifs-perimeters {:opt-label  "NIFS Perimeters"
-                                                                               :z-index    3
-                                                                               :filter-set #{"fire-detections" "nifs-perimeters"}}
-                                                             :viirs-hotspots  {:opt-label  "VIIRS Hotspots"
-                                                                               :z-index    2
-                                                                               :filter-set #{"fire-detections" "viirs-timestamped"}}
-                                                             :modis-hotspots  {:opt-label  "MODIS Hotspots"
-                                                                               :z-index    1
-                                                                               :filter-set #{"fire-detections" "modis-timestamped"}}}
-                                            :default-option :active-fires
-                                            :options        {:active-fires    {:opt-label  "*All Active Fires"
-                                                                               :style-fn   :default
-                                                                               :filter-set #{"fire-detections" "active-fires"}
-                                                                               :auto-zoom? false}}}
-                               :output     {:opt-label  "Output"
-                                            :hover-text "This shows the areas where our models forecast the fire to spread over 3 days. Time can be advanced with the slider below, and the different colors on the map provide information about when an area is forecast to burn."
-                                            :options    {:burned {:opt-label "Forecasted fire location"
-                                                                  :filter    "hours-since-burned"
-                                                                  :units     "Hours"}}}
-                               :burn-pct   {:opt-label      "Burn Probability"
-                                            :default-option :50
-                                            :hover-text     "To develop an active fire forecast, we run 1,000 simulations, inputting a variety of factors for consideration. 'Burn Probability' shows the percentage of time the simulations followed the same path. To see the path taken in 90% of our simulations, for example, select 90% from the dropdown menu."
-                                            :options        {:90 {:opt-label "90%"
-                                                                  :filter    "90"}
-                                                             :70 {:opt-label "70%"
-                                                                  :filter    "70"}
-                                                             :50 {:opt-label "50%"
-                                                                  :filter    "50"}
-                                                             :30 {:opt-label "30%"
-                                                                  :filter    "30"}
-                                                             :10 {:opt-label "10%"
-                                                                  :filter    "10"}}}
-                               :fuel       {:opt-label  "Fuel"
-                                            :hover-text "Source of surface and canopy fuel inputs:\n
-                                                         LANDFIRE data (https://landfire.gov) at 30-m resolution customized by Pyrologix (http://pyrologix.com) for the United States Forest Service, Pacific Southwest Region (https://www.fs.usda.gov/r5)."
-                                            :options    {:landfire {:opt-label "Custom LANDFIRE"
-                                                                    :filter    "landfire"}}}
-                               :model      {:opt-label  "Model"
-                                            :hover-text "ELMFIRE is a new predictive model developed by Chris Lautenberger of Reax Engineering. It uses artificial intelligence to generate a active fire forecast.\n
-                                                         GridFire is a fire behavior model developed by Gary Johnson of Spatial Informatics Group. It combines empirical equations from the wildland fire science literature with the performance of a raster-based spread algorithm using the method of adaptive time steps and fractional distances."
-                                            :options    {:elmfire  {:opt-label "ELMFIRE"
-                                                                    :filter    "elmfire"}
-                                                         :gridfire {:opt-label "GridFire"
-                                                                    :filter    "gridfire"}}}
-                               :model-init {:opt-label  "Forecast Start Time"
-                                            :hover-text "This shows the date and time (24 hour time) from which the prediction starts. To view a different start time, select one from the dropdown menu. This data is automatically updated when active fires are sensed by satellites."
-                                            :options    {:loading {:opt-label "Loading..."}}}}}})
+   :fire-risk    {:opt-label       "Risk"
+                  :filter          "fire-risk-forecast"
+                  :reverse-legend? true
+                  :hover-text      "5-day forecast of fire consequence maps. Every day over 500 million hypothetical fires are ignited across California to evaluate potential fire risk.\n"
+                  :params          {:output     {:opt-label  "Output"
+                                                 :hover-text "Key fire spread model outputs based on modeling 6-hours of fire spread without fire suppression activities within 6 hours of time shown in time slider. Options include:\n
+                                                             Relative Burn Probability - Relative likelihood that an area is burned by fires that have not yet ignited within the next six hours of time shown in time slider.\n
+                                                             Impacted Structures - Approximate number of residential structures within fire perimeter for fires starting at specific location and time in the future.\n
+                                                             Fire Area - Modeled fire size in acres by ignition location and time of ignition.\n
+                                                             Fire Volume - Modeled fire volume (fire area in acres multiplied by flame length in feet) by ignition location and time of ignition."
+                                                 :options    {:times-burned {:opt-label "Relative burn probability"
+                                                                             :filter    "times-burned"
+                                                                             :units     "Times"}
+                                                              :impacted     {:opt-label "Impacted structures"
+                                                                             :filter    "impacted-structures"
+                                                                             :units     "Structures"}
+                                                              :fire-area    {:opt-label "Fire area"
+                                                                             :filter    "fire-area"
+                                                                             :units     "Acres"}
+                                                              :fire-volume  {:opt-label "Fire volume"
+                                                                             :filter    "fire-volume"
+                                                                             :units     "Acre-ft"}}}
+                                    :pattern    {:opt-label  "Ignition Pattern"
+                                                 :hover-text "Fires are ignited randomly across California at various times in the future so their impacts can be modeled. Patterns include:\n
+                                                             Human Caused - Anthropogenic fires (fires from all causes except lightning).\n
+                                                             Transmission Lines - Fires ignited in close proximity to overhead electrical transmission lines.\n"
+                                                 :options    {:all        {:opt-label    "Human-caused ignitions"
+                                                                           :filter       "all"}
+                                                              :tlines     {:opt-label    "Transmission lines"
+                                                                           :filter       "tlines"
+                                                                           :clear-point? true}}}
+                                    :fuel       {:opt-label  "Fuel"
+                                                 :hover-text "Source of surface and canopy fuel inputs:\n
+                                                             LANDFIRE data (https://landfire.gov) at 30-m resolution customized by Pyrologix (http://pyrologix.com) for the United States Forest Service, Pacific Southwest Region (https://www.fs.usda.gov/r5).\n
+                                                             California Forest Observatory (https://forestobservatory.com) 10 m fuels measured by satellite."
+                                                 :options    {:landfire {:opt-label "Custom LANDFIRE"
+                                                                         :filter    "landfire"}
+                                                              :cfo      {:opt-label "California Forest Observatory"
+                                                                         :filter    "cfo"}}}
+                                    :model      {:opt-label  "Model"
+                                                 :hover-text "Computer fire spread model used to generate active fire and risk forecasts.\n
+                                                             ELMFIRE - Cloud-based operational fire spread model developed at Reax Engineering Inc. (https://doi.org/10.1016/j.firesaf.2013.08.014)."
+                                                 :options    {:elmfire {:opt-label "ELMFIRE"
+                                                                        :filter    "elmfire"}}}
+                                    :model-init {:opt-label  "Forecast Start Time"
+                                                 :hover-text "Start time for forecast cycle. New data is created every 12 hours."
+                                                 :options    {:loading {:opt-label "Loading..."}}}}}
+   :active-fire  {:opt-label   "Active Fires"
+                  :filter      "fire-spread-forecast"
+                  :block-info? true
+                  :hover-text  "3-day forecasts of active fires with burning areas established from satellite-based heat detection."
+                  :params      {:fire-name  {:opt-label      "Fire Name"
+                                             :auto-zoom?     true
+                                             :sort?          true
+                                             :hover-text     "Provides a list of active fires for which forecasts are available. To zoom to a specific fire, select it from the dropdown menu."
+                                             :underlays      {:nifs-perimeters {:opt-label  "NIFS Perimeters"
+                                                                                :z-index    3
+                                                                                :filter-set #{"fire-detections" "nifs-perimeters"}}
+                                                              :viirs-hotspots  {:opt-label  "VIIRS Hotspots"
+                                                                                :z-index    2
+                                                                                :filter-set #{"fire-detections" "viirs-timestamped"}}
+                                                              :modis-hotspots  {:opt-label  "MODIS Hotspots"
+                                                                                :z-index    1
+                                                                                :filter-set #{"fire-detections" "modis-timestamped"}}}
+                                             :default-option :active-fires
+                                             :options        {:active-fires    {:opt-label  "*All Active Fires"
+                                                                                :style-fn   :default
+                                                                                :filter-set #{"fire-detections" "active-fires"}
+                                                                                :auto-zoom? false}}}
+                                :output     {:opt-label  "Output"
+                                             :hover-text "This shows the areas where our models forecast the fire to spread over 3 days. Time can be advanced with the slider below, and the different colors on the map provide information about when an area is forecast to burn."
+                                             :options    {:burned {:opt-label "Forecasted fire location"
+                                                                   :filter    "hours-since-burned"
+                                                                   :units     "Hours"}}}
+                                :burn-pct   {:opt-label      "Burn Probability"
+                                             :default-option :50
+                                             :hover-text     "To develop an active fire forecast, we run 1,000 simulations, inputting a variety of factors for consideration. 'Burn Probability' shows the percentage of time the simulations followed the same path. To see the path taken in 90% of our simulations, for example, select 90% from the dropdown menu."
+                                             :options        {:90 {:opt-label "90%"
+                                                                   :filter    "90"}
+                                                              :70 {:opt-label "70%"
+                                                                   :filter    "70"}
+                                                              :50 {:opt-label "50%"
+                                                                   :filter    "50"}
+                                                              :30 {:opt-label "30%"
+                                                                   :filter    "30"}
+                                                              :10 {:opt-label "10%"
+                                                                   :filter    "10"}}}
+                                :fuel       {:opt-label  "Fuel"
+                                             :hover-text "Source of surface and canopy fuel inputs:\n
+                                                          LANDFIRE data (https://landfire.gov) at 30-m resolution customized by Pyrologix (http://pyrologix.com) for the United States Forest Service, Pacific Southwest Region (https://www.fs.usda.gov/r5)."
+                                             :options    {:landfire {:opt-label "Custom LANDFIRE"
+                                                                     :filter    "landfire"}}}
+                                :model      {:opt-label  "Model"
+                                             :hover-text "ELMFIRE is a new predictive model developed by Chris Lautenberger of Reax Engineering. It uses artificial intelligence to generate a active fire forecast.\n
+                                                          GridFire is a fire behavior model developed by Gary Johnson of Spatial Informatics Group. It combines empirical equations from the wildland fire science literature with the performance of a raster-based spread algorithm using the method of adaptive time steps and fractional distances."
+                                             :options    {:elmfire  {:opt-label "ELMFIRE"
+                                                                     :filter    "elmfire"}
+                                                          :gridfire {:opt-label "GridFire"
+                                                                     :filter    "gridfire"}}}
+                                :model-init {:opt-label  "Forecast Start Time"
+                                             :hover-text "This shows the date and time (24 hour time) from which the prediction starts. To view a different start time, select one from the dropdown menu. This data is automatically updated when active fires are sensed by satellites."
+                                             :options    {:loading {:opt-label "Loading..."}}}}}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; WG4 Scenario Planning


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Re-order and simplify tabs to 'Fuels', 'Weather', 'Risk', and 'Active Fires' so tabs on mobile devices take up less screen space and are more ordered.

## Related Issues
Closes PYR-416

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="387" alt="Screen Shot 2021-06-10 at 2 15 27 PM" src="https://user-images.githubusercontent.com/1829313/121598114-50394380-c9f6-11eb-9bd3-399ecee30450.png">
