### PR TITLE
PYR-413 Remove Match-drop from Prod

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -366,13 +366,14 @@
                  (reset! show-match-drop? false)
                  (reset! show-camera? false))
             @show-info?])
-         (when (and (number? user-id) (not mobile?))
-           [:flame
-            (str (hs-str @show-match-drop?) " match drop tool")
-            #(do (swap! show-match-drop? not)
-                 (set-show-info! false)
-                 (reset! show-camera? false))
-            @show-match-drop?])
+         ;; Remove access to Match-Drop for Prod
+         ;; (when (and (number? user-id) (not mobile?))
+         ;;   [:flame
+         ;;    (str (hs-str @show-match-drop?) " match drop tool")
+         ;;    #(do (swap! show-match-drop? not)
+         ;;         (set-show-info! false)
+         ;;         (reset! show-camera? false))
+         ;;    @show-match-drop?])
          (when-not mobile?
            [:camera
             (str (hs-str @show-camera?) " cameras")

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -597,8 +597,9 @@
                                         (-> js/window .-location .reload)))}
                 "Log Out"]]
               [:span {:style {:position "absolute" :right "3rem" :display "flex"}}
-               [:label {:style {:margin-right "1rem" :cursor "pointer"}
-                        :on-click #(u/jump-to-url! "/register")} "Register"]
+               ;; Remove for the time being
+               ;; [:label {:style {:margin-right "1rem" :cursor "pointer"}
+               ;;          :on-click #(u/jump-to-url! "/register")} "Register"]
                [:label {:style {:cursor "pointer"}
                         :on-click #(u/jump-to-url! "/login")} "Log In"]]))]
          [:div {:style {:height "100%" :position "relative" :width "100%"}}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Remove register link from header and match-drop icon from the toolbar to disable Match Drop on Production.

## Related Issues
Closes PYR-413

