### PR TITLE
PYR-457 Fix model time when other params change

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -76,7 +76,8 @@
             (assoc-in (get-forecast-opt :params)
                       [:model-init :options]
                       processed-times))
-    (swap! *params assoc-in [@*forecast :model-init] (ffirst processed-times))))
+    (when-not (contains? processed-times (get-in @*params [@*forecast :model-init]))
+      (swap! *params assoc-in [@*forecast :model-init] (ffirst processed-times)))))
 
 (defn get-layers! [get-model-times?]
   (go


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Avoid changing the model time when switching other parameters. Specifically meant for when looking at an active fire, the model time would change when the Predicted Fire Size parameter would change. This makes it easier to see how the different percentiles differ within the same model time.

## Related Issues
Closes PYR-457

## Testing
<!-- Create a BDD style test script -->
1. Given I am a visitor, And I have select an active fire, And I select a different model time, When I change the Predicted Fire Size, Then the model time stays the same.
