### PR TITLE
PYR-449 Fix auto-zoom when changing active fire params

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -177,8 +177,9 @@
        (distinct)
        (mapcat (fn [fire-name]
                  [(keyword fire-name)
-                  {:opt-label (fire-name-capitalization fire-name)
-                   :filter    fire-name}]))
+                  {:opt-label  (fire-name-capitalization fire-name)
+                   :filter     fire-name
+                   :auto-zoom? true}]))
        (apply array-map)))
 
 (defn get-user-layers [user-id]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -158,7 +158,6 @@
                   :block-info? true
                   :hover-text  "3-day forecasts of active fires with burning areas established from satellite-based heat detection."
                   :params      {:fire-name  {:opt-label      "Fire Name"
-                                             :auto-zoom?     true
                                              :sort?          true
                                              :hover-text     "Provides a list of active fires for which forecasts are available. To zoom to a specific fire, select it from the dropdown menu."
                                              :underlays      {:nifs-perimeters {:opt-label  "NIFS Perimeters"

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -125,6 +125,11 @@
        (remove nil?)
        (first)))
 
+(defn get-current-option-key
+  "Retreive the value for a particular parameter's option."
+  [param-key option-key key-name]
+  (get-in (get-forecast-opt :params) [param-key :options option-key key-name]))
+
 (defn get-options-key [key-name]
   (some #(get % key-name)
         (vals (get-forecast-opt :params))))
@@ -276,7 +281,7 @@
     (let [main-key (first keys)]
       (change-type! (not (= main-key :model-init))
                     (get-current-layer-key :clear-point?)
-                    (get-any-level-key     :auto-zoom?)
+                    (get-current-option-key main-key val :auto-zoom?)
                     (get-any-level-key     :max-zoom)))))
 
 (defn select-forecast! [key]


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Disable auto-zoom when changing Active Fire parameters, but keep auto-zoom when changing which active fire is selected.

## Related Issues
Closes PYR-449

## Testing
<!-- Create a BDD style test script -->
1. Given I am a visitor, And I have selected an active fire, When I change the Predicted Fire Size, Then the map stays at the same zoom level and location.
1. Given I am a visitor, And I have selected an active fire, And I select a different active fire, Then the map zooms to the new fire.
