### PR TITLE
Fix Match Drop queue errors - only search jobs within last hour

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -367,13 +367,13 @@
                  (reset! show-camera? false))
             @show-info?])
          ;; Remove access to Match-Drop for Prod
-         ;; (when (and (number? user-id) (not mobile?))
-         ;;   [:flame
-         ;;    (str (hs-str @show-match-drop?) " match drop tool")
-         ;;    #(do (swap! show-match-drop? not)
-         ;;         (set-show-info! false)
-         ;;         (reset! show-camera? false))
-         ;;    @show-match-drop?])
+         (when (and (number? user-id) (not mobile?))
+           [:flame
+            (str (hs-str @show-match-drop?) " match drop tool")
+            #(do (swap! show-match-drop? not)
+                 (set-show-info! false)
+                 (reset! show-camera? false))
+            @show-match-drop?])
          (when-not mobile?
            [:camera
             (str (hs-str @show-camera?) " cameras")

--- a/src/sql/functions/match_functions.sql
+++ b/src/sql/functions/match_functions.sql
@@ -69,6 +69,7 @@ CREATE OR REPLACE FUNCTION count_running_user_match_jobs(_user_id integer)
     FROM match_jobs
     WHERE user_rid = _user_id
         AND md_status = 2
+        AND updated_at > now() - interval '1 hour'
 
 $$ LANGUAGE SQL;
 
@@ -79,6 +80,7 @@ CREATE OR REPLACE FUNCTION count_all_running_match_jobs()
     SELECT count(*)::integer
     FROM match_jobs
     WHERE md_status = 2
+        AND updated_at > now() - interval '1 hour'
 
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Fix Match Drop errors that have to do with rate-limiting and queueing. Only look at jobs within the last hour.
