### PR TITLE
PYR-454 Enable ASP/SLP/DEM layers for CFO

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -39,16 +39,13 @@
                                                                   :units     ""}
                                                          :asp    {:opt-label "Aspect"
                                                                   :filter    "asp"
-                                                                  :units     ""
-                                                                  :disabled  #{:cfo}}
+                                                                  :units     ""}
                                                          :slp    {:opt-label "Slope (degrees)"
                                                                   :filter    "slp"
-                                                                  :units     "degrees"
-                                                                  :disabled  #{:cfo}}
+                                                                  :units     "degrees"}
                                                          :dem    {:opt-label "Elevation (ft)"
                                                                   :filter    "dem"
-                                                                  :units     ""
-                                                                  :disabled  #{:cfo}}
+                                                                  :units     ""}
                                                          :cc     {:opt-label "Canopy Cover (%)"
                                                                   :filter    "cc"
                                                                   :units     "%"}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds support for new CFO layers: Aspect, Slope, Elevation.

## Related Issues
Closes PYR-454

## Testing
<!-- Create a BDD style test script -->
1. Given I am a visitor, When I visit the Fuels tab, And I select "California Forest Obs." as the source, And I select any Layer option, Then the layer appears on the map.

## Screenshots
Aspect
<img width="1440" alt="Screen Shot 2021-06-14 at 12 24 24 PM" src="https://user-images.githubusercontent.com/1829313/121947913-766b2600-cd0b-11eb-9460-231174fcfb20.png">

Slope
<img width="1440" alt="Screen Shot 2021-06-14 at 12 23 58 PM" src="https://user-images.githubusercontent.com/1829313/121947859-66534680-cd0b-11eb-8215-582c0dec0b79.png">

Elevation
<img width="1439" alt="Screen Shot 2021-06-14 at 12 24 40 PM" src="https://user-images.githubusercontent.com/1829313/121947946-8125bb00-cd0b-11eb-862b-b89f369b5263.png">
