### PR TITLE
PYR-472 Sort model times chronologically

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -66,12 +66,13 @@
   (get-in @capabilities [@*forecast key-name]))
 
 (defn process-model-times! [model-times]
-  (let [processed-times (u/mapm (fn [utc-time]
-                                  [(keyword utc-time)
-                                   {:opt-label (u/time-zone-iso-date utc-time @show-utc?)
-                                    :utc-time  utc-time ; TODO is utc-time redundant?
-                                    :filter    utc-time}])
-                                model-times)]
+  (let [processed-times (into (u/reverse-sorted-map)
+                              (map (fn [utc-time]
+                                     [(keyword utc-time)
+                                      {:opt-label (u/time-zone-iso-date utc-time @show-utc?)
+                                       :utc-time  utc-time ; TODO is utc-time redundant?
+                                       :filter    utc-time}])
+                                   model-times))]
     (reset! processed-params
             (assoc-in (get-forecast-opt :params)
                       [:model-init :options]

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -415,3 +415,8 @@
     (.focus)
     (.select))
   (js/document.execCommand "copy"))
+
+(defn reverse-sorted-map
+  "Creates a sorted-map where the keys are sorted in reverse order."
+  []
+  (sorted-map-by (fn [a b] (* -1 (compare a b)))))


### PR DESCRIPTION
## Purpose
Sorts the model initialization params in reverse chronological order (most recent date first).

## Related Issues
Closes PYR-472
