### PR TITLE
PYR-446 Add View forecast on Active Fires Popup

### DIFF
--- a/src/cljs/pyregence/components/fire_popup.cljs
+++ b/src/cljs/pyregence/components/fire_popup.cljs
@@ -6,7 +6,7 @@
 ;; Styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- $btn []
+(defn- $popup-btn []
   (with-meta
     {:background    ($/color-picker :yellow)
      :color         ($/color-picker :white)
@@ -36,7 +36,7 @@
   [:div [:strong property ": "] value])
 
 (defn- fire-link [on-click]
-  [:button {:class (<class $btn)
+  [:button {:class    (<class $popup-btn)
             :on-click on-click}
    "Click to View Forecast"])
 

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -237,11 +237,10 @@
    be either HTML string a hiccup style vector."
   [[lng lat] body {:keys [classname width] :or {width "200px" classname ""}}]
   (clear-popup!)
-  (let [popup       (Popup. #js {:className classname :maxWidth width})
-        placeholder [:div#mb-popup]]
+  (let [popup       (Popup. #js {:className classname :maxWidth width})]
     (doto popup
       (.setLngLat #js [lng lat])
-      (.setHTML (rs/render-to-string placeholder))
+      (.setHTML "<div id='mb-popup'></div>")
       (.addTo @the-map))
     (render body (dom/getElement "mb-popup"))
     (reset! the-popup popup)))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -21,8 +21,6 @@
                                                     process-toast-messages!]]
             [pyregence.components.svg-icons :refer [pin]]))
 
-(declare select-param!) ;; FIXME: Look at ways to decouple callbacks
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Spec
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -250,10 +248,12 @@
   (when (get-forecast-opt :block-info?)
     (reset! show-info? false)))
 
+(declare select-param!) ;; FIXME: Look at ways to decouple callbacks
+
 (defn- init-fire-popup! [feature _]
-  (let [properties (-> feature (aget "properties") (js->clj :keywordize-keys true))
-        lnglat     (-> properties (select-keys [:longitude :latitude]) (vals))
-        {:keys [name prettyname containper acres]} properties
+  (let [properties (-> feature (aget "properties") (js->clj))
+        lnglat     (-> properties (select-keys ["longitude" "latitude"]) (vals))
+        {:strs [name prettyname containper acres]} properties
         body       (fp/fire-popup prettyname containper acres #(select-param! (keyword name) :fire-name))]
     (mb/init-popup! lnglat body {:width "200px"})
     (mb/set-center! lnglat 0)))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds a "View Forecast" button to the Active Fires Popup. Clicking on the View Forecast button selects the fire and shows the current forecast.

## Related Issues
Closes PYR-446

## Testing
<!-- Create a BDD style test script -->
1. Given I am a visitor, When I am viewing the Active Fires tab, And I click on a Fire point, And I click "View Forecast", Then the most recent forecast for that fire is shown.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="1436" alt="Screen Shot 2021-06-24 at 1 50 54 PM" src="https://user-images.githubusercontent.com/1829313/123330702-35d19080-d4f3-11eb-9a74-46241d7db053.png">