### PR TITLE
PYR-484/PYR-486 Use acres/containper to style active fires

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -441,7 +441,7 @@
    :type   "circle"
    :source source-name
    :layout {:visibility "visible"}
-   :paint  {:circle-color        "#FF0000"
+   :paint  {:circle-color        ["interpolate-lab" ["linear"] ["get" "containper"] 0 "#FF0000" 100 "#000000"]
             :circle-opacity      opacity
             :circle-radius       (zoom-interp ["*" 0.4 ["min" 30 ["max" 8 ["*" 30 ["/" ["get" "acres"] 10000]]]]]
                                               ["min" 30 ["max" 8 ["*" 30 ["/" ["get" "acres"] 10000]]]]


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Uses the `acres` and `containper` properties to adjust the active fires circle size and color, respectively.

## Related Issues
Closes PYR-484, PYR-486

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="1440" alt="Screen Shot 2021-07-01 at 3 32 18 PM" src="https://user-images.githubusercontent.com/1829313/124196555-8744c700-da81-11eb-8f0a-f80c6c87076d.png">

