### PR TITLE
PYR-435 Add GOES-16 Imagery as underlay

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -165,7 +165,10 @@
                                                                                 :filter-set #{"fire-detections" "viirs-timestamped"}}
                                                               :modis-hotspots  {:opt-label  "MODIS Hotspots"
                                                                                 :z-index    1
-                                                                                :filter-set #{"fire-detections" "modis-timestamped"}}}
+                                                                                :filter-set #{"fire-detections" "modis-timestamped"}}
+                                                              :goes-imagery    {:opt-label  "GOES-16 Imagery"
+                                                                                :z-index    0
+                                                                                :filter-set #{"fire-detections" "goes16-rgb"}}}
                                              :default-option :active-fires
                                              :options        {:active-fires    {:opt-label  "*All Active Fires"
                                                                                 :style-fn   :default


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds GOES-16 Imagery as an underlay option.

## Related Issues
Closes PYR-435

## Testing
<!-- Create a BDD style test script -->
1. Given I am a visitor, When I view the Active Fires Tab, And I enable GOES-16 Imagery, Then the GOES-16 Imagery is show underneath the active fires.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="1440" alt="Screen Shot 2021-07-07 at 3 51 43 PM" src="https://user-images.githubusercontent.com/1829313/124838214-3cbcc200-df3b-11eb-8e98-10420985b7bd.png">
