### PR TITLE
Fix loading app via figwheel

### DIFF
--- a/src/clj/pyregence/assets.clj
+++ b/src/clj/pyregence/assets.clj
@@ -1,0 +1,34 @@
+(ns pyregence.assets
+  (:require [clojure.java.io :as io]
+            [clojure.string  :as str]
+            [clojure.edn     :as edn]))
+
+(def ^:private assets-dir "target/public/cljs/")
+(def ^:private manifest-file (str assets-dir "manifest.edn"))
+
+;;; Cache
+
+(def manifest-cache (atom nil))
+
+;;; Helper Fns
+
+(defn- read-manifest []
+  (if (nil? @manifest-cache)
+    (when (.exists (io/file manifest-file))
+      (->> (slurp manifest-file)
+           (edn/read-string)
+           (reset! manifest-cache)))
+    @manifest-cache))
+
+(defn- fingerprinted-asset [f]
+  (get (read-manifest) f f))
+
+(defn- restructure-path [path]
+  (str "/cljs/" (last (str/split path #"/"))))
+
+;;; Public Fns
+
+(defn app-js []
+  (-> (fingerprinted-asset (str assets-dir "app.js"))
+      (restructure-path)))
+

--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -1,20 +1,11 @@
 (ns pyregence.views
-  (:require [clojure.edn       :as edn]
-            [clojure.string    :as str]
-            [clojure.data.json :as json]
+  (:require [clojure.data.json :as json]
             [cognitect.transit :as transit]
             [hiccup.page :refer [html5 include-css include-js]]
             [pl.danieljanus.tagsoup :refer [parse]]
-            [pyregence.config :refer [get-config]])
+            [pyregence.config :refer [get-config]]
+            [pyregence.assets :refer [app-js]])
   (:import java.io.ByteArrayOutputStream))
-
-(defn- find-app-js []
-  (as-> (slurp "target/public/cljs/manifest.edn") app
-    (edn/read-string app)
-    (get app "target/public/cljs/app.js")
-    (str/split app #"/")
-    (last app)
-    (str "/cljs/" app)))
 
 (defn render-dynamic []
   (fn [request]
@@ -27,7 +18,7 @@
                 [:meta {:name "description"
                         :content "Open source wildfire forecasting tool to assess wildfire risk for electric grid safety."}]
                 (include-css "/css/mapbox-gl-v2.2.0.css")
-                (include-js "/js/mapbox-gl-v2.2.0.js" (find-app-js))]
+                (include-js "/js/mapbox-gl-v2.2.0.js" (app-js))]
                [:body
                 [:div#near-term-forecast
                  (slurp "resources/html/~header.html")


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Add assets.clj to read manifest.edn file only when it exists (not produced in dev workflow).

