### PR TITLE
Use built in interpolation for adjusting the size

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -442,10 +442,12 @@
    :layout {:visibility "visible"}
    :paint  {:circle-color        ["interpolate-lab" ["linear"] ["get" "containper"] 0 "#FF0000" 100 "#000000"]
             :circle-opacity      opacity
-            :circle-radius       (zoom-interp ["*" 0.4 ["min" 30 ["max" 8 ["*" 30 ["/" ["get" "acres"] 10000]]]]]
-                                              ["min" 30 ["max" 8 ["*" 30 ["/" ["get" "acres"] 10000]]]]
-                                              5
-                                              20)
+            :circle-radius       (zoom-interp 6
+                                              ["interpolate" ["linear"] ["get" "acres"]
+                                               10000 10
+                                               300000 100]
+                                              4
+                                              12)
             :circle-stroke-color (on-hover "#FFFF00" "#000000")
             :circle-stroke-width (on-hover 4 2)}})
 


### PR DESCRIPTION
## Purpose
Use built in interpolation for adjusting the size of markers

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/125674884-4607f1f6-11c6-47b6-a2b4-e21d3b4854bc.png)

