### PR TITLE
PYR-494 Reversing sort order on match drop dashboard

### DIFF
--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -82,8 +82,8 @@
            "Elapsed Time"
            "Logs"]]
    [:tbody
-    (doall (map (fn [{:keys [job-id] :as md}] ^{:key job-id} [match-drop-item md])
-                @match-drops))]])
+    (reverse (map (fn [{:keys [job-id] :as md}] ^{:key job-id} [match-drop-item md])
+                  @match-drops))]])
 
 (defn- redirect-to-login! []
   (u/set-session-storage! {:redirect-from "/dashboard"})


### PR DESCRIPTION
## Purpose
Changed the way the match drop dashboard is sorted. The newest match drop job is now listed at the top (first).

## Related Issues
Closes PYR-494 

## Screenshots
![Screenshot from 2021-08-04 15-48-44](https://user-images.githubusercontent.com/40574170/128265842-8f71c317-4877-427e-8e43-d562fe82e463.png)

