### PR TITLE
PYR-522 Changing GOES label

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -167,7 +167,7 @@
                                                               :modis-hotspots  {:opt-label  "MODIS Hotspots"
                                                                                 :z-index    1
                                                                                 :filter-set #{"fire-detections" "modis-timestamped"}}
-                                                              :goes-imagery    {:opt-label  "GOES-16 Imagery"
+                                                              :goes-imagery    {:opt-label  "Live satellite (GOES-16)"
                                                                                 :z-index    0
                                                                                 :filter-set #{"fire-detections" "goes16-rgb"}}}
                                              :default-option :active-fires


### PR DESCRIPTION
## Purpose
Changing the "GOES-16 Imagery" label to "Live satellite (GOES-16)".

## Related Issues
Closes PYR-522 

## Screenshots 
![Screenshot from 2021-08-05 12-20-11](https://user-images.githubusercontent.com/40574170/128408947-c1cce9ff-5332-4ae2-81af-23232fbb8c59.png)

