### PR TITLE
PYR-527 Add tooltip to camera button zoom

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -624,14 +624,20 @@
            [:div {:style {:position "absolute" :top "2rem" :width "100%" :display "flex" :justify-content "center"}}
             [:label (str "Camera: " (:name @*camera))]]
            [:img {:src "images/awf_logo.png" :style ($/combine $awf-logo-style)}]
-           [:span {:style {:bottom   "2rem"
-                           :padding  "2px"
-                           :position "absolute"
-                           :right    "2rem"}}
-            [tool-tip-wrapper
-             "Zoom Map to Camera"
-             :bottom
-             [tool-button :magnify-zoom-in zoom-camera]]]
+           [tool-tip-wrapper
+            "Zoom Map to Camera"
+            :right
+            [:button {:type     "button"
+                      :class    "btn btn-sm btn-secondary"
+                      :on-click zoom-camera
+                      :style    {:position "absolute"
+                                 :bottom   "1.25rem"
+                                 :right    "1rem"
+                                 :padding  "2px"}}
+             [:div {:style {:width  "32px"
+                            :height "32px"
+                            :fill   "white"}}
+              [svg/magnify-zoom-in]]]]
            [:img {:style {:width "100%" :height "auto"} :src @*image}]]
 
           :else


### PR DESCRIPTION
## Purpose
Adding a tooltip with `tool-tip-wrapper` to the camera feature's zoom button.

## Related Issues
Closes PYR-527

## Screenshots
![Screenshot from 2021-08-05 18-42-49](https://user-images.githubusercontent.com/40574170/128443175-39ce6846-1d0e-4118-9ecf-a31c58581e9f.png)


