### PR TITLE
PYR-526: Change camera zoom in icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .nrepl-port
 .rebel_readline_history
 .vscode
-Makefile
 
 # Build Directories and Files
 .key

--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -624,23 +624,23 @@
 
           (some? @*image)
           [:div
-            [:div {:style {:position "absolute" :top "2rem" :width "100%" :display "flex" :justify-content "center"}}
-             [:label (str "Camera: " (:name @*camera))]]
-            [:img {:src "images/awf_logo.png" :style ($/combine $awf-logo-style)}]
-            [tool-tip-wrapper
-             "Zoom Map to Camera"
-             :right
-             [:button {:class    "btn btn-sm btn-secondary"
-                       :on-click zoom-camera
-                       :style    {:position "absolute"
-                                  :bottom   "1.25rem"
-                                  :right    "1rem"
-                                  :padding  "2px"}}
-              [:div {:style {:width  "32px"
-                             :height "32px"
-                             :fill   "white"}}
-               [svg/binoculars]]]]
-            [:img {:style {:width "100%" :height "auto"} :src @*image}]]
+           [:div {:style {:position "absolute" :top "2rem" :width "100%" :display "flex" :justify-content "center"}}
+            [:label (str "Camera: " (:name @*camera))]]
+           [:img {:src "images/awf_logo.png" :style ($/combine $awf-logo-style)}]
+           [tool-tip-wrapper
+            "Zoom Map to Camera"
+            :right
+            [:button {:class    "btn btn-sm btn-secondary"
+                      :on-click zoom-camera
+                      :style    {:position "absolute"
+                                 :bottom   "1.25rem"
+                                 :right    "1rem"
+                                 :padding  "2px"}}
+             [:div {:style {:width  "32px"
+                            :height "32px"
+                            :fill   "white"}}
+              [svg/binoculars]]]]
+           [:img {:style {:width "100%" :height "auto"} :src @*image}]]
 
           :else
           [:div {:style {:padding "1.2em"}}


### PR DESCRIPTION
## Purpose
Changes the icon in the camera tool from a magnifying glass to a pair of binoculars. 

## Related Issues
Closes PYR-526

## Screenshots
![Screenshot from 2021-08-10 12-09-21](https://user-images.githubusercontent.com/40574170/128921014-40b84aff-7265-44a7-a6ef-c87d1cf11b99.png) 

