### PR TITLE
Add clj-kondo/config.edn to version control and add linters

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,5 @@
+{:linters {:shadowed-var      {:level :warning}
+           :single-key-in     {:level :warning}
+           :missing-docstring {:level :warning}}
+ :lint-as {reagent.core/with-let clojure.core/let
+           herb.core/defglobal clj-kondo.lint-as/def-catch-all}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,16 @@
 # Developer Tool Config Files
-.clj-kondo
 .cpcache
 .DS_Store
 .nrepl-port
 .rebel_readline_history
 .vscode
+.clj-kondo/*
+!.clj-kondo/config.edn
 
 # Build Directories and Files
-.key
-email-server.edn
-logs
-target
+/.key
+/logs
+/target
 
 # Configuration files
-config.edn
-email-server.edn
-camera-config.edn
+/config.edn


### PR DESCRIPTION
## Purpose
Add clj-kondo/config.edn to version control and add linters.  This should let all devs use the same settings.