### PR TITLE
PYR-406: Hide URL textbox on mobile in Share Modal.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -297,20 +297,21 @@
 ;; Share Tool
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn share-inner-modal [create-share-link]
+(defn share-inner-modal [create-share-link mobile?]
   (r/with-let [copied     (r/atom false)
                share-link (create-share-link)
                on-click   #(do
                              (u/copy-input-clipboard! "share-link")
                              (reset! copied true))]
     [:div {:style ($/combine $/flex-row {:width "100%"})}
-     [:input {:auto-focus true
-              :on-click   on-click
-              :id         "share-link"
-              :style      {:width "100%"}
-              :read-only  true
-              :type       "text"
-              :value      share-link}]
+     (when-not mobile?
+       [:input {:auto-focus true
+                :on-click   on-click
+                :id         "share-link"
+                :style      {:width "100%"}
+                :read-only  true
+                :type       "text"
+                :value      share-link}])
      [:input {:on-click on-click
               :style    ($/combine ($/bg-color :yellow)
                                    {:border-radius "3px"
@@ -421,7 +422,7 @@
                   [[:share
                     "Share current map"
                     #(set-message-box-content! {:title "Share Current Map"
-                                                :body  [share-inner-modal create-share-link]
+                                                :body  [share-inner-modal create-share-link mobile?]
                                                 :mode  :close})]
                    [:terrain
                     (str (ed-str @terrain?) " 3D terrain")


### PR DESCRIPTION
## Purpose
Hides the URL textbox on mobile for the Share Modal. 

## Related Issues
Closes PYR-406 

## Screenshots
Note that the Copy URL button's styling is messed up, but I'm working on a separate ticket that restyles the Copy URL button so I'm not going to format it in this PR.
![Screenshot from 2021-08-11 17-02-37](https://user-images.githubusercontent.com/40574170/129118908-0849f5e0-ec22-428d-a693-e762774f2376.png)


