### PR TITLE
PYR-534: Remove :key and :group meta data from Herb classes

### DIFF
--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -108,9 +108,7 @@
       (merge base-style
              (to-merge? modifiers :flex-style  flex-style)
              (to-merge? modifiers :multi-style multi-style))
-      {:key    (str/join "-" (sort modifiers))
-       :group  true
-       :pseudo {:disabled disabled-style}})))
+      {:pseudo {:disabled disabled-style}})))
 
 (defn p-button-hover
   "Background of button is highlighted when `active?` is true or on hover."
@@ -138,9 +136,7 @@
                         :pointer-events   "none"}]
     (with-meta
       base-style
-      {:key    (str/join "-" (sort [bg-color border-color font-color bg-hover-color font-hover-color]))
-       :group  true
-       :pseudo {:disabled disabled-style
+      {:pseudo {:disabled disabled-style
                 :hover    {:background-color (color-picker bg-hover-color)
                            :color            (color-picker font-hover-color)}
                 :focus    {:outline "none"}}})))


### PR DESCRIPTION
## Purpose
Removing the :key and :group meta data tags from Herb classes as they are now completely removed from Herb. All Herb classes still work as expected after removing :key and :group.

See [here](https://github.com/roosta/herb/blob/master/CHANGELOG.md) for the Herb changelog info.

## Related Issues
Closes PYR-534

