### PR TITLE
Update the way figwheel reloads to keep current config from config.edn

### DIFF
--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -1,7 +1,6 @@
 (ns ^:figwheel-hooks pyregence.client
   (:require [goog.dom :as dom]
             [reagent.dom :refer [render]]
-            [clojure.string :as str]
             [pyregence.config                   :as c]
             [pyregence.pages.admin              :as admin]
             [pyregence.pages.dashboard          :as dashboard]
@@ -11,7 +10,9 @@
             [pyregence.pages.reset-password     :as reset-password]
             [pyregence.pages.verify-email       :as verify-email]))
 
-(def uri->root-component
+(defonce ^:private original-params (atom {}))
+
+(def ^:private uri->root-component
   {"/"                   #(ntf/root-component (merge % {:forecast-type :near-term}))
    "/admin"              admin/root-component
    "/dashboard"          dashboard/root-component
@@ -23,30 +24,25 @@
    "/reset-password"     reset-password/root-component
    "/verify-email"       verify-email/root-component})
 
-(defn render-root [params]
+(defn ^:private render-root [params]
   (let [root-component (-> js/window .-location .-pathname uri->root-component)]
     (render [root-component params] (dom/getElement "app"))))
 
-(defn ^:export init [params]
-  (let [clj-params (js->clj params :keywordize-keys true)]
-    (c/set-feature-flags! clj-params)
-    (c/set-geoserver-base-url! (get-in clj-params [:geoserver :base-url]))
-    (c/set-mapbox-access-token! (get-in clj-params [:mapbox :access-token]))
-    (render-root clj-params)))
+(defn ^:export init
+  "Define the init function to be called from window.onload()."
+  [params]
+  (let [clj-params (js->clj params :keywordize-keys true)
+        cur-params (if (seq clj-params)
+                     (reset! original-params
+                             (js->clj params :keywordize-keys true))
+                     @original-params)]
+    (c/set-feature-flags! cur-params)
+    (c/set-geoserver-base-url! (get-in cur-params [:geoserver :base-url]))
+    (c/set-mapbox-access-token! (get-in cur-params [:mapbox :access-token]))
+    (render-root cur-params)))
 
-(defn safe-split [str pattern]
-  (if (str/blank? str)
-    []
-    (str/split str pattern)))
-
-;; TODO This needs to be updated for passing server side params through the init function.
-(defn ^:after-load mount-root! []
-  (.log js/console "Rerunning init function for figwheel.")
-  (let [params (reduce (fn [acc cur]
-                         (let [[k v] (str/split cur "=")]
-                           (assoc acc (keyword k) v)))
-                       {}
-                       (-> (-> js/window .-location .-search)
-                           (str/replace #"^\?" "")
-                           (safe-split "&")))]
-    (init params)))
+(defn ^:after-load mount-root!
+  "A hook for figwheel to call the init function again."
+  []
+  (println "Rerunning init function for figwheel.")
+  (init {}))

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -590,21 +590,22 @@
 (defn create-wms-layer!
   "Adds WMS layer to the map."
   [id source visible?]
-  (if (is-selectable? id)
-    (set-visible-by-title! id visible?)
-    (let [[new-source new-layers] (build-wms id source 1.0 visible?)
-          style                   (get-style)
-          layers                  (get style "layers")
-          zero-idx                (->> layers
-                                       (keep-indexed (fn [idx layer]
-                                                       (when (is-selectable? (get layer "id")) idx)))
-                                       (first))
-          [before after]          (split-at zero-idx layers)
-          final-layers            (vec (concat before new-layers after))]
-      (swap! custom-layers conj id)
-      (update-style! (get-style)
-                     :new-sources new-source
-                     :layers final-layers))))
+  (when id
+    (if (is-selectable? id)
+      (set-visible-by-title! id visible?)
+      (let [[new-source new-layers] (build-wms id source 1.0 visible?)
+            style                   (get-style)
+            layers                  (get style "layers")
+            zero-idx                (->> layers
+                                         (keep-indexed (fn [idx layer]
+                                                         (when (is-selectable? (get layer "id")) idx)))
+                                         (first))
+            [before after]          (split-at zero-idx layers)
+            final-layers            (vec (concat before new-layers after))]
+        (swap! custom-layers conj id)
+        (update-style! style
+                       :new-sources new-source
+                       :layers final-layers)))))
 
 (defn create-camera-layer!
   "Adds wildfire camera layer to the map."

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -282,7 +282,7 @@
 ;; WFS/WMS Configuration
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def ^:private geoserver-base-url (atom nil))
+(defonce ^:private geoserver-base-url (atom nil))
 (defn- wms-url [] (str (u/end-with @geoserver-base-url "/") "wms"))
 (defn- wfs-url [] (str (u/end-with @geoserver-base-url "/") "wfs"))
 (defn- mvt-url [] (str (u/end-with @geoserver-base-url "/") "gwc/service/wmts"))
@@ -383,7 +383,7 @@
 ;; Feature Flags
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def ^:private features (atom nil))
+(defonce ^:private features (atom nil))
 
 (defn set-feature-flags! [config]
   (reset! features (:features config)))
@@ -412,7 +412,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Mapbox Configuration
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(def mapbox-access-token (atom nil))
+
+(defonce mapbox-access-token (atom nil))
 
 (defn set-mapbox-access-token! [token]
   (reset! mapbox-access-token token))


### PR DESCRIPTION
## Purpose
Update the way figwheel reloads to keep current config from config.edn

## Related Issues
Closes PYR-541

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `PYR-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
1. As a developer, when I save a file, figwheel reloads with no console errors related to mapbox api key.