### PR TITLE
PYR-516: Add dev-mode to config.edn

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -5,6 +5,7 @@
               :dbname   "pyregence"
               :user     "pyregence"
               :password "pyregence"}
+ :dev-mode   <true/false>
  :features   {:match-drop false}
  :geoserver  {:base-url "https://data.pyregence.org/geoserver"}
  :match-drop {:app-host      "app.pyregence.org"

--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -79,6 +79,7 @@
                 [:script {:type "text/javascript"}
                  (str "window.onload = function () { pyregence.client.init("
                       (json/write-str (assoc params
+                                             :dev-mode  (get-config :dev-mode)
                                              :mapbox    (get-config :mapbox)
                                              :features  (get-config :features)
                                              :geoserver (get-config :geoserver)))

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -36,6 +36,7 @@
                      (reset! original-params
                              (js->clj params :keywordize-keys true))
                      @original-params)]
+    (c/set-dev-mode! (get-in cur-params [:dev-mode]))
     (c/set-feature-flags! cur-params)
     (c/set-geoserver-base-url! (get-in cur-params [:geoserver :base-url]))
     (c/set-mapbox-access-token! (get-in cur-params [:mapbox :access-token]))

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -434,3 +434,12 @@
 (def base-map-default :mapbox-topo)
 
 (def mapbox-dem-url "mapbox://mapbox.mapbox-terrain-dem-v1")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Dev-mode Configuration
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce dev-mode? (atom nil))
+
+(defn set-dev-mode! [val]
+  (reset! dev-mode? val))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -519,7 +519,7 @@
    [radio "Dark"  $/light? false #(reset! $/light? %)]])
 
 (defn message-modal []
-  (r/with-let [show-me? (r/atom (not (str/includes? (-> js/window .-location .-origin) "local")))]
+  (r/with-let [show-me? (r/atom (not @c/dev-mode?))] 
     (when @show-me?
       [:div#message-modal {:style ($/modal)}
        [:div {:style ($message-modal @mobile?)}


### PR DESCRIPTION
## Purpose
Adding a dev-mode option to `config.edn` to toggle whether or not the disclaimer pops up. 

## Related Issues
Closes PYR-516
 
## Testing
Toggling the `:dev-mode` option between true and false leads to expected behavior (no disclaimer pop-up when true and a disclaimer pop-up when false). 

