### PR TITLE
PYR-549: Add red flag warning button to mobile.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -395,10 +395,9 @@
                  (set-show-info! false)
                  (reset! show-match-drop? false))
             @show-camera?])
-         (when-not mobile?
-           [:flag
-            (str (hs-str @show-red-flag?) " red flag warnings")
-            #(toggle-red-flag-layer! show-red-flag?)])
+         [:flag
+          (str (hs-str @show-red-flag?) " red flag warnings")
+          #(toggle-red-flag-layer! show-red-flag?)]
          (when-not mobile?
            [:clock
             (str (hs-str @show-fire-history?) " fire history")


### PR DESCRIPTION
## Purpose
Adds back the red flag warning tool button to mobile since it doesn't take up additional space or mess up mobile formatting when activated (things like the camera tool button mess up mobile formatting).

## Related Issues
Closes PYR-549

