### PR TITLE
PYR-547: Highlighting active fire circle on click.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -455,8 +455,8 @@
                                                300000 100]
                                               4
                                               12)
-            :circle-stroke-color (on-hover "#FFFF00" "#000000")
-            :circle-stroke-width (on-hover 4 2)}})
+            :circle-stroke-color (on-selected "#FFFF00" "#FFFF00" "#000000")
+            :circle-stroke-width (on-selected 4 4 2)}})
 
 (defn- incident-labels-layer [layer-name source-name opacity]
   {:id     layer-name


### PR DESCRIPTION
## Purpose
Highlights the active fire circle when clicked. 

Note that I would also like to add functionality such that clicking on the map anywhere outside of the already selected circle will then de-select the circle, but I am not sure how to do so within MapBox. I imagine that a call to `mb/clear-highlight! "fire-active" :selected` is needed but I'm not sure the appropriate place to put this. 

## Related Issues
Closes PYR-547

## Screenshots
![Screenshot from 2021-08-20 17-21-39](https://user-images.githubusercontent.com/40574170/130304413-b2dba117-7914-4828-bab4-343e8ada7e80.png)
