### PR TITLE
PYR-521: Align columns for HTML attributes in map_controls.cljs

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -319,11 +319,11 @@
               :read-only  true
               :type       (if mobile? "hidden" "text")
               :value      share-link}]
-     [:input {:on-click on-click
-              :class    (<class $/p-form-button)
+     [:input {:class    (<class $/p-form-button)
               :style    (when-not mobile? {:margin-left "0.9rem"})
               :type     "button"
-              :value    (if @copied "Copied!" "Copy URL")}]]))
+              :value    (if @copied "Copied!" "Copy URL")
+              :on-click on-click}]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Red Flag Warning


### PR DESCRIPTION
## Purpose
Aligning columns for HTML attributes, sorting style tags in alphabetical order.

## Related Issues
Part of multiple PRs (spread out for merge-conflict reasons) for PYR-521 

