### PR TITLE
PYR-521: Align columns for HTML attributes in mapbox.cljs, messaging.cljs, and resizable_window.cljs

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -1,8 +1,8 @@
 (ns pyregence.components.mapbox
-  (:require [goog.dom           :as dom]
-            [reagent.core       :as r]
-            [reagent.dom        :refer [render]]
-            [clojure.core.async :refer [go <!]]
+  (:require [goog.dom            :as dom]
+            [reagent.core        :as r]
+            [reagent.dom         :refer [render]]
+            [clojure.core.async  :refer [go <!]]
             [pyregence.config    :as c]
             [pyregence.utils     :as u]
             [pyregence.geo-utils :as g]))
@@ -616,7 +616,7 @@
         (swap! custom-layers conj id)
         (update-style! style
                        :new-sources new-source
-                       :layers final-layers)))))
+                       :layers      final-layers)))))
 
 (defn create-camera-layer!
   "Adds wildfire camera layer to the map."
@@ -627,9 +627,9 @@
                      :source id
                      :type   "symbol"
                      :layout {:icon-image              "video-icon"
-                              :icon-size               0.5
                               :icon-rotate             ["-" ["get" "pan"] 90]
-                              :icon-rotation-alignment "map"}
+                              :icon-rotation-alignment "map"
+                              :icon-size               0.5}
                      :paint  {:icon-color (on-selected "#f47a3e" "#c24b29" "#000000")}}]]
     (update-style! (get-style) :new-sources new-source :new-layers new-layers)))
 
@@ -652,18 +652,18 @@
   "Adds red flag warning layer to the map."
   [id layer-name]
   (let [new-source {id (mvt-source layer-name)}
-        new-layers [{:id     id
-                     :source id
+        new-layers [{:id           id
+                     :source       id
                      :source-layer "fire-history"
-                     :type   "fill"
-                     :paint  {:fill-color         ["step" ["get" "Decade"]
-                                                   "#cccccc"  ; Default
-                                                   1990 "#ffffb2"
-                                                   2000 "#fecc5c"
-                                                   2010 "#fd8d3c"
-                                                   2020 "#f03b20"]
-                              :fill-outline-color "#ff0000"
-                              :fill-opacity 0.3}}]]
+                     :type         "fill"
+                     :paint        {:fill-color         ["step" ["get" "Decade"]
+                                                         "#cccccc"  ; Default
+                                                         1990 "#ffffb2"
+                                                         2000 "#fecc5c"
+                                                         2010 "#fd8d3c"
+                                                         2020 "#f03b20"]
+                                    :fill-opacity       0.3
+                                    :fill-outline-color "#ff0000"}}]]
     (update-style! (get-style) :new-sources new-source :new-layers new-layers)))
 
 (defn remove-layer!

--- a/src/cljs/pyregence/components/messaging.cljs
+++ b/src/cljs/pyregence/components/messaging.cljs
@@ -1,9 +1,9 @@
 (ns pyregence.components.messaging
-  (:require [herb.core :refer [<class]]
-            [reagent.core :as r]
+  (:require [herb.core          :refer [<class]]
+            [reagent.core       :as r]
             [clojure.core.async :refer [chan go >! <! timeout]]
-            [clojure.string :as str]
-            [pyregence.styles :as $]))
+            [clojure.string     :as str]
+            [pyregence.styles   :as $]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State
@@ -70,12 +70,12 @@
 
 (defn $alert-transition [show-full?]
   (if show-full?
-    {:transition "opacity 500ms ease-in"
-     :opacity    "1"
-     :top        "1rem"}
-    {:transition "opacity 500ms ease-out"
-     :opacity    "0"
-     :top        "-100rem"}))
+    {:opacity    "1"
+     :top        "1rem"
+     :transition "opacity 500ms ease-in"}
+    {:opacity    "0"
+     :top        "-100rem"
+     :transition "opacity 500ms ease-out"}))
 
 (defn $p-alert-close []
   (with-meta
@@ -86,9 +86,9 @@
     {:pseudo {:hover {:background-color ($/color-picker :black 0.15)}}}))
 
 (defn $message-box []
-  {:min-width "35%"
+  {:margin    "15% auto"
    :max-width "55%"
-   :margin    "15% auto"
+   :min-width "35%"
    :width     "fit-content"})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -118,15 +118,15 @@
         [:div#toast-message {:style ($/combine $alert-box [$alert-transition message?])}
          [:span {:style ($/padding ".5rem")}
           (show-line-break @message)]
-         [:span {:class (<class $p-alert-close)
+         [:span {:class    (<class $p-alert-close)
                  :on-click #(reset! toast-message-text nil)}
           "\u274C"]]))))
 
 (defn button [label & callback]
-  [:input {:class (<class $/p-form-button)
-           :style ($/margin "1rem" :h)
-           :type "button"
-           :value label
+  [:input {:class    (<class $/p-form-button)
+           :style    ($/margin "1rem" :h)
+           :type     "button"
+           :value    label
            :on-click (when (seq callback) (first callback))}])
 
 (defn message-box-modal []

--- a/src/cljs/pyregence/components/resizable_window.cljs
+++ b/src/cljs/pyregence/components/resizable_window.cljs
@@ -21,8 +21,8 @@
    ($/fixed-size "1.5rem")
    {:bottom   "0"
     :cursor   "sw-resize"
-    :position "absolute"
     :left     "0"
+    :position "absolute"
     :z-index  "3"}))
 
 (defn $sw-drag-icon []
@@ -37,9 +37,9 @@
 
 (defn $close-button [height]
   {:fill     ($/color-picker :font-color)
-   :right    ".25rem"
    :height   height
    :position "absolute"
+   :right    ".25rem"
    :width    height})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -62,10 +62,10 @@
                        (reset! box-height (- mouse-y p-top 12)))))
        :on-drag-start #(reset! drag-started? true)}]
      [:div {:style ($sw-drag-icon)}
-      [:span {:style {:height       "100%"
+      [:span {:style {:border-right (str "1px solid " ($/color-picker :border-color))
                       :display      "flex"
-                      :margin-right "2px"
-                      :border-right (str "1px solid " ($/color-picker :border-color))}}]]]))
+                      :height       "100%"
+                      :margin-right "2px"}}]]]))
 
 (defn title-div [title title-height on-click]
   (r/create-class
@@ -81,8 +81,8 @@
     (fn [_]
       [:div {:style {:border-bottom (str "1px solid " ($/color-picker :border-color)) :width "100%"}}
        [:label {:style {:margin-left ".5rem" :margin-top ".25rem"}} title]
-       [:span {:class (<class $/p-add-hover)
-               :style ($close-button @title-height)
+       [:span {:class    (<class $/p-add-hover)
+               :style    ($close-button @title-height)
                :on-click on-click}
         [close]]])}))
 


### PR DESCRIPTION
## Purpose
Aligning columns for HTML attributes, sorting style tags in alphabetical order.

## Related Issues
Part of multiple PRs (spread out for merge-conflict reasons) for PYR-521

