### PR TITLE
Align columns for HTML attributes in register.cljs, reset_password.cljs, verify_email.cljs, client.cljs

### DIFF
--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -1,6 +1,6 @@
 (ns ^:figwheel-hooks pyregence.client
-  (:require [goog.dom :as dom]
-            [reagent.dom :refer [render]]
+  (:require [goog.dom                           :as dom]
+            [reagent.dom                        :refer [render]]
             [pyregence.config                   :as c]
             [pyregence.pages.admin              :as admin]
             [pyregence.pages.dashboard          :as dashboard]

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -1,8 +1,8 @@
 (ns pyregence.pages.register
-  (:require [reagent.core :as r]
+  (:require [reagent.core       :as r]
             [clojure.core.async :refer [go <! timeout]]
-            [pyregence.utils  :as u]
-            [pyregence.styles :as $]
+            [pyregence.utils    :as u]
+            [pyregence.styles   :as $]
             [pyregence.components.common    :refer [simple-form]]
             [pyregence.components.messaging :refer [toast-message!
                                                     toast-message

--- a/src/cljs/pyregence/pages/reset_password.cljs
+++ b/src/cljs/pyregence/pages/reset_password.cljs
@@ -1,8 +1,8 @@
 (ns pyregence.pages.reset-password
-  (:require [reagent.core :as r]
+  (:require [reagent.core       :as r]
             [clojure.core.async :refer [go <! timeout]]
-            [pyregence.utils  :as u]
-            [pyregence.styles :as $]
+            [pyregence.utils    :as u]
+            [pyregence.styles   :as $]
             [pyregence.components.common    :refer [simple-form]]
             [pyregence.components.messaging :refer [toast-message!
                                                     toast-message

--- a/src/cljs/pyregence/pages/verify_email.cljs
+++ b/src/cljs/pyregence/pages/verify_email.cljs
@@ -1,7 +1,7 @@
 (ns pyregence.pages.verify-email
-  (:require [reagent.core :as r]
+  (:require [reagent.core       :as r]
             [clojure.core.async :refer [go <! timeout]]
-            [pyregence.utils :as u]))
+            [pyregence.utils    :as u]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State


### PR DESCRIPTION
## Purpose
Align columns for HTML attributes in register.cljs, reset_password.cljs, verify_email.cljs, client.cljs

## Related Issues
Part of multiple PRs (spread out for merge-conflict reasons) for PYR-521

