### PR TITLE
Align columns for HTML attributes in config.cljs, styles.cljs, utils.cljs

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -222,48 +222,48 @@
                     :filter     "wg4_FireSim"
                     :hover-text "Wildfire scenario projections for area burned with varied emissions and population scenarios."
                     :block-info? true
-                    :params     {:model   {:opt-label  "Global Climate Model"
-                                           :hover-text "Four climate models selected by the California's Climate Action Team as priority models for research contributing to California's Fourth Climate Change Assessment.\n
+                    :params     {:model      {:opt-label  "Global Climate Model"
+                                              :hover-text "Four climate models selected by the California's Climate Action Team as priority models for research contributing to California's Fourth Climate Change Assessment.\n
                                                         Projected future climate from these four models can be described as producing:
                                                         HadGEM2-ES - A warmer/dry simulation
                                                         CNRM-CM5 - A cooler/wetter simulation
                                                         CanESM2 - An average simulation
                                                         MIROC5 - A model that is most unlike the first three to offer the best coverage of different possibilities."
-                                           :auto-zoom? true
-                                           :options    {:can-esm2   {:opt-label "CanESM2"
-                                                                     :filter    "CanESM2"
-                                                                     :units     ""}
-                                                        :hadgem2-es {:opt-label "HadGEM2-ES"
-                                                                     :filter    "HadGEM2-ES"
-                                                                     :units     ""}
-                                                        :cnrm-cm5   {:opt-label "CNRM-CM5"
-                                                                     :filter    "CNRM-CM5"
-                                                                     :units     ""}
-                                                        :miroc5     {:opt-label "MIROC5"
-                                                                     :filter    "MIROC5"
-                                                                     :units     ""}}}
-                                 :prob    {:opt-label  "RCP Scenario"
-                                           :hover-text "Representative Concentration Pathway (RCP) is the greenhouse gas concentration trajectory adopted by the IPCC.\n
+                                              :auto-zoom? true
+                                              :options    {:can-esm2   {:opt-label "CanESM2"
+                                                                        :filter    "CanESM2"
+                                                                        :units     ""}
+                                                           :hadgem2-es {:opt-label "HadGEM2-ES"
+                                                                        :filter    "HadGEM2-ES"
+                                                                        :units     ""}
+                                                           :cnrm-cm5   {:opt-label "CNRM-CM5"
+                                                                        :filter    "CNRM-CM5"
+                                                                        :units     ""}
+                                                           :miroc5     {:opt-label "MIROC5"
+                                                                        :filter    "MIROC5"
+                                                                        :units     ""}}}
+                                 :prob       {:opt-label  "RCP Scenario"
+                                              :hover-text "Representative Concentration Pathway (RCP) is the greenhouse gas concentration trajectory adopted by the IPCC.\n
                                                         Options include:
                                                         4.5 - emissions start declining starting in 2045 to reach half the levels of CO2 of 2050 by 2100.
                                                         8.5 - emissions keep rising throughout the 2100."
-                                           :options    {:p45 {:opt-label "4.5"
-                                                              :filter    "45"
-                                                              :units     ""}
-                                                        :p85 {:opt-label "8.5"
-                                                              :filter    "85"
-                                                              :units     ""}}}
-                                 :measure {:opt-label  "Population Growth Scenario"
-                                           :hover-text "Vary population growth."
-                                           :options    {:bau  {:opt-label "Central"
-                                                               :filter    "bau"
-                                                               :units     ""}
-                                                        :high {:opt-label "High"
-                                                               :filter    "H"
-                                                               :units     ""}
-                                                        :low  {:opt-label "Low"
-                                                               :filter    "L"
-                                                               :units     ""}}}
+                                              :options    {:p45 {:opt-label "4.5"
+                                                                 :filter    "45"
+                                                                 :units     ""}
+                                                           :p85 {:opt-label "8.5"
+                                                                 :filter    "85"
+                                                                 :units     ""}}}
+                                 :measure    {:opt-label  "Population Growth Scenario"
+                                              :hover-text "Vary population growth."
+                                              :options    {:bau  {:opt-label "Central"
+                                                                  :filter    "bau"
+                                                                  :units     ""}
+                                                           :high {:opt-label "High"
+                                                                  :filter    "H"
+                                                                  :units     ""}
+                                                           :low  {:opt-label "Low"
+                                                                  :filter    "L"
+                                                                  :units     ""}}}
                                  :model-init {:opt-label  "Scenario Year"
                                               :hover-text "Year"
                                               :options    {:loading {:opt-label "Loading..."}}}}}})

--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -39,18 +39,18 @@
      :font-hover-color (if @light?
                          (color-picker :white)
                          (color-picker :black))
-     :yellow           (str "rgba(249, 175, 59, "  alpha ")")
-     :blue             (str "rgba(0, 0, 175, "     alpha ")")
      :black            (str "rgba(0, 0, 0, "       alpha ")")
-     :brown            (str "rgba(96, 65, 31, "    alpha ")")
+     :blue             (str "rgba(0, 0, 175, "     alpha ")")
      :box-tan          (str "rgba(249, 248, 242, " alpha ")")
+     :brown            (str "rgba(96, 65, 31, "    alpha ")")
+     :dark-gray        (str "rgba(50, 50, 50, "    alpha ")")
      :dark-green       (str "rgba(0, 100, 0, "     alpha ")")
      :light-gray       (str "rgba(230, 230, 230, " alpha ")")
-     :dark-gray        (str "rgba(50, 50, 50, "    alpha ")")
      :orange           (str "rgba(249, 104, 65, "  alpha ")")
      :red              (str "rgba(200, 0, 0, "     alpha ")")
-     :white            (str "rgba(255, 255, 255, " alpha ")")
      :transparent      (str "rgba(0, 0, 0, 0)")
+     :white            (str "rgba(255, 255, 255, " alpha ")")
+     :yellow           (str "rgba(249, 175, 59, "  alpha ")")
      color)))
 
 (defn to-merge? [modifiers key return]
@@ -62,17 +62,17 @@
 
 (defglobal general
   [:* {:box-sizing "border-box"
-       :padding    "0px"
-       :margin     "0px"}]
+       :margin     "0px"
+       :padding    "0px"}]
 
   [:label {:font-size     "1rem"
            :font-weight   "bold"
            :margin-bottom "0"}])
 
 (defglobal body-and-content-divs
-  [:body {:background-color "white"
-          :position         "relative"
-          :height           "100vh"}]
+  [:body {:background-color (color-picker :white)
+          :height           "100vh"
+          :position         "relative"}]
   [:#app {:height "100%"}]
   [:#near-term-forecast {:display        "flex"
                          :flex-direction "column"
@@ -91,7 +91,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn p-bordered-input [& modifiers]
-  (let [base-style     {:background-color "white"
+  (let [base-style     {:background-color (color-picker :white)
                         :border           "1px solid"
                         :border-color     (color-picker :brown)
                         :border-radius    "2px"
@@ -115,7 +115,7 @@
   [& [active?]]
   (let [highlight-color (color-picker :border-color 0.2)]
     (with-meta
-      {:background-color (if active? highlight-color "transparent")
+      {:background-color (if active? highlight-color (color-picker :transparent))
        :border-radius    "4px"}
       {:pseudo {:hover {:background-color highlight-color}}})))
 
@@ -144,10 +144,10 @@
     (with-meta
       base-style
       {:pseudo {:disabled disabled-style
+                :focus    {:outline "none"}
                 :hover    {:background-color (color-picker bg-color-hover)
                            :color            (color-picker color-hover)
-                           :fill             (color-picker color-hover)}
-                :focus    {:outline "none"}}})))
+                           :fill             (color-picker color-hover)}}})))
 
 (defn p-form-button
   "Styling for form buttons (e.g. the Refresh button on the Match Drop Dashboard)"
@@ -285,17 +285,17 @@
     {}))
 
 (defn root []
-  {:display        "flex"
-   :flex-direction "column"
-   :padding        "0 1rem"
-   :align-items    "center"
+  {:align-items    "center"
+   :display        "flex"
    :flex           "1 1 0"
-   :overflow       "auto"})
+   :flex-direction "column"
+   :overflow       "auto"
+   :padding        "0 1rem"})
 
 (defn modal []
   {:background-color "rgba(0,0,0,0.4)"
-   :left             "0"
    :height           "100%"
+   :left             "0"
    :position         "absolute"
    :top              "0"
    :width            "100%"
@@ -303,15 +303,15 @@
 
 (defn outline [color]
   (let [rgb (color-picker color)]
-    {:background   "white"
+    {:background   (color-picker :white)
      :border-color rgb
      :border-style "solid"
      :color        rgb}))
 
 (defn text-ellipsis []
-  {:white-space   "nowrap"
-   :overflow      "hidden"
-   :text-overflow "ellipsis"})
+  {:overflow      "hidden"
+   :text-overflow "ellipsis"
+   :white-space   "nowrap"})
 
 (defn fixed-size [size]
   {:float      "left"
@@ -335,17 +335,17 @@
   {:background-color (color-picker :white)
    :border           light-border
    :border-radius    "5px"
-   :overflow         "hidden"
    :display          "flex"
    :flex-direction   "column"
    :height           "100%"
+   :overflow         "hidden"
    :padding          "0"
    :width            "100%"})
 
 (defn action-header []
-  {:background-color (color-picker :yellow)
+  {:align-items      "center"
+   :background-color (color-picker :yellow)
    :border-bottom    light-border
-   :align-items      "center"
    :display          "flex"
    :flex-direction   "row"
    :flex-wrap        "nowrap"

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -1,7 +1,7 @@
 (ns pyregence.utils
-  (:require [cljs.reader :as edn]
-            [clojure.string :as str]
-            [clojure.set    :as sets]
+  (:require [cljs.reader        :as edn]
+            [clojure.string     :as str]
+            [clojure.set        :as sets]
             [clojure.core.async :refer [alts! go <! timeout go-loop]]
             [cljs.core.async.interop :refer-macros [<p!]]))
 
@@ -140,7 +140,7 @@
                             (map (fn [[k v]] (str (pr-str k) "=" (pr-str v))))
                             (str/join "&")
                             (js/encodeURIComponent))
-          fetch-params {:method "get"
+          fetch-params {:method  "get"
                         :headers {"Accept" "application/edn"
                                   "Content-Type" "application/edn"}}
           edn-string   (<! (fetch-and-process (str url
@@ -153,16 +153,16 @@
 ;; Combines status and error message into return value
 (defmethod call-remote! :post [_ url data]
   (go
-    (let [fetch-params {:method "post"
+    (let [fetch-params {:method  "post"
                         :headers (merge {"Accept" "application/edn"}
                                         (when-not (= (type data) js/FormData)
                                           {"Content-Type" "application/edn"}))
-                        :body (cond
-                                (= js/FormData (type data)) data
-                                data                        (pr-str data)
-                                :else                       nil)}
-          response      (<! (fetch (str url "?auth-token=883kljlsl36dnll9s9l2ls8xksl")
-                                   fetch-params))]
+                        :body    (cond
+                                   (= js/FormData (type data)) data
+                                   data                        (pr-str data)
+                                   :else                       nil)}
+          response     (<! (fetch (str url "?auth-token=883kljlsl36dnll9s9l2ls8xksl")
+                                  fetch-params))]
       (if response
         {:success (.-ok response)
          :status  (.-status response)
@@ -173,16 +173,16 @@
 
 (defmethod call-remote! :post-text [_ url data]
   (go
-    (let [fetch-params {:method "post"
+    (let [fetch-params {:method  "post"
                         :headers (merge {"Accept" "application/transit+json"}
                                         (when-not (= (type data) js/FormData)
                                           {"Content-Type" "application/edn"}))
-                        :body (cond
-                                (= js/FormData (type data)) data
-                                data                        (pr-str data)
-                                :else                       nil)}
-          response      (<! (fetch (str url "?auth-token=883kljlsl36dnll9s9l2ls8xksl")
-                                   fetch-params))]
+                        :body    (cond
+                                   (= js/FormData (type data)) data
+                                   data                        (pr-str data)
+                                   :else                       nil)}
+          response     (<! (fetch (str url "?auth-token=883kljlsl36dnll9s9l2ls8xksl")
+                                  fetch-params))]
       (if response
         {:success (.-ok response)
          :status  (.-status response)
@@ -193,16 +193,16 @@
 
 (defmethod call-remote! :post-blob [_ url data]
   (go
-    (let [fetch-params {:method "post"
+    (let [fetch-params {:method  "post"
                         :headers (merge {"Accept" "application/transit+json"}
                                         (when-not (= (type data) js/FormData)
                                           {"Content-Type" "application/edn"}))
-                        :body (cond
-                                (= js/FormData (type data)) data
-                                data                        (pr-str data)
-                                :else                       nil)}
-          response      (<! (fetch (str url "?auth-token=883kljlsl36dnll9s9l2ls8xksl")
-                                   fetch-params))]
+                        :body    (cond
+                                   (= js/FormData (type data)) data
+                                   data                        (pr-str data)
+                                   :else                       nil)}
+          response     (<! (fetch (str url "?auth-token=883kljlsl36dnll9s9l2ls8xksl")
+                                  fetch-params))]
       (if response
         {:success (.-ok response)
          :status  (.-status response)
@@ -290,8 +290,8 @@
   (js-date->iso-string (js-date-from-string date-str) show-utc?))
 
 (defn ms->hhmmss [ms]
-  (let [sec (/ ms 1000)
-        hours (js/Math.round (/ sec 3600))
+  (let [sec     (/ ms 1000)
+        hours   (js/Math.round (/ sec 3600))
         minutes (js/Math.round (/ (mod sec 3600) 60))
         seconds (js/Math.round (mod (mod sec 3600) 60))]
     (str (pad-zero hours)
@@ -461,8 +461,8 @@
   "Converts degrees to a direction."
   [degrees]
   (condp >= degrees
-    22.5 "North"
-    67.5 "Northeast"
+    22.5  "North"
+    67.5  "Northeast"
     112.5 "East"
     157.5 "Southeast"
     202.5 "South"


### PR DESCRIPTION
## Purpose
Align columns for HTML attributes in config.cljs, styles.cljs, utils.cljs. Note that geo_utils.cljs did not need any alignment.

## Related Issues
Part of multiple PRs (spread out for merge-conflict reasons) for PYR-521