### PR TITLE
Align columns for HTML attributes in not-found.edn and terms-of-use.edn

### DIFF
--- a/resources/pages/not-found.edn
+++ b/resources/pages/not-found.edn
@@ -1,8 +1,8 @@
 {:title "404 Not Found - Pyregence Wildfire Risk Models"
  :head [:meta {:name "description" :content "Page not found."}]
  :body [:div {:style {:margin-top "100px"}}
-        [:div {:style {:display         "flex"
-                       :align-content   "center"
+        [:div {:style {:align-content   "center"
+                       :display         "flex"
                        :justify-content "center"
                        :margin-bottom   "6rem"}}
          [:h1 {:style {:text-align "center"}}

--- a/resources/pages/terms-of-use.edn
+++ b/resources/pages/terms-of-use.edn
@@ -98,19 +98,31 @@
            [:p
             [:strong [:u "Informal Dispute Resolution."]]
             " To give us an opportunity to resolve informally any disputes between you and us arising out of or relating in any way to our Site, these Terms, or any services or products provided (“Claims”), you agree to communicate your Claim to us by emailing us at by emailing us at "
-            [:a {:href "mailto:contact@pyregence.org" :target "_blank" :rel "noreferrer noopener"} "contact@pyregence.org"]
+            [:a {:href   "mailto:contact@pyregence.org"
+                 :target "_blank"
+                 :rel    "noreferrer noopener"}
+             "contact@pyregence.org"]
             " You agree not to bring any suit or to initiate arbitration proceedings until 60 days after the date on which you communicated your Claim to us have elapsed. If we are not able to resolve your Claim within 60 days, you may seek relief through arbitration or in small claims court, as set forth in this Section VII."]
            [:p
             [:strong [:u "Choice of Arbitrator and Rules"]]
             " Any disputes, claims, and causes of action arising out of or connected with your use of the Site (each, a “Dispute”) must be submitted exclusively to the American Arbitration Association (AAA) to be heard under their "
-            [:a {:href "https://www.adr.org/sites/default/files/Consumer_Rules_Web_0.pdf" :target "_blank" :rel "noreferrer noopener"} "Consumer Arbitration Rules"]
+            [:a {:href   "https://www.adr.org/sites/default/files/Consumer_Rules_Web_0.pdf"
+                 :target "_blank"
+                 :rel    "noreferrer noopener"}
+             "Consumer Arbitration Rules"]
             " The AAA’s rules and filing instructions are available at www.adr.org or by calling 1-800-778-7879.  If for any reason,  AAA is unable or unwilling to conduct the arbitration consistent with these terms, you and we will pick another arbitrator pursuant to "
-            [:a {:href "https://www.law.cornell.edu/uscode/text/9/5" :target "_blank" :rel "noreferrer noopener"} "9 U.S. Code § 5"]
+            [:a {:href   "https://www.law.cornell.edu/uscode/text/9/5"
+                 :target "_blank"
+                 :rel    "noreferrer noopener"}
+             "9 U.S. Code § 5"]
             "."]
            [:p
             [:strong [:u "Mandatory Arbitration"]]
             " You agree that any Dispute between us shall be resolved exclusively in individual (non-class action) arbitration.  The parties intend to be bound to the "
-            [:a {:href "https://www.law.cornell.edu/uscode/text/9/chapter-1" :target "_blank" :rel "noreferrer noopener"} "Federal Arbitration Act"]
+            [:a {:href   "https://www.law.cornell.edu/uscode/text/9/chapter-1"
+                 :target "_blank"
+                 :rel    "noreferrer noopener"}
+             "Federal Arbitration Act"]
             ", 9 U.S.C. § 1 "
             [:em "et seq"]
             ".  An arbitration means there will be no jury and no judge."]
@@ -129,7 +141,10 @@
            [:p
             [:strong [:u "Choice of Law"]]
             " These Terms and your use of the Site are governed by the laws of the State of California, U.S.A., without regard to its choice of law provisions.  However, any determination as to whether a Dispute is subject to arbitration, or as to the conduct of the arbitration, shall be governed exclusively by the "
-            [:a {:href "https://www.law.cornell.edu/uscode/text/9/chapter-1" :target "_blank" :rel "noreferrer noopener"} "Federal Arbitration Act"]
+            [:a {:href   "https://www.law.cornell.edu/uscode/text/9/chapter-1"
+                 :target "_blank"
+                 :rel    "noreferrer noopener"}
+             "Federal Arbitration Act"]
             ", 9 U.S.C. § 1 "
             [:em "et seq"]
             "."]


### PR DESCRIPTION
## Purpose
Align columns for HTML attributes in not-found.edn and terms-of-use.edn. Note that privacy-policy did not need any alignment. 

## Related Issues
Part of multiple PRs (spread out for merge-conflict reasons) for PYR-521