### PR TITLE
Aligning columns in clj directory.

### DIFF
--- a/src/clj/pyregence/build_db.clj
+++ b/src/clj/pyregence/build_db.clj
@@ -1,8 +1,8 @@
 (ns pyregence.build-db
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io    :as io]
             [clojure.java.shell :as sh]
-            [clojure.string :as str]
-            [pyregence.config :refer [get-config]]))
+            [clojure.string     :as str]
+            [pyregence.config   :refer [get-config]]))
 
 (def path-env (System/getenv "PATH"))
 

--- a/src/clj/pyregence/database.clj
+++ b/src/clj/pyregence/database.clj
@@ -1,10 +1,10 @@
 (ns pyregence.database
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str]
-            [pyregence.config  :refer [get-config]]
-            [pyregence.logging :refer [log-str]]
-            [pyregence.views   :refer [data-response]]
-            [next.jdbc :as jdbc]
+  (:require [clojure.data.json    :as json]
+            [clojure.string       :as str]
+            [pyregence.config     :refer [get-config]]
+            [pyregence.logging    :refer [log-str]]
+            [pyregence.views      :refer [data-response]]
+            [next.jdbc            :as jdbc]
             [next.jdbc.result-set :as rs]))
 
 ;;; Helper Functions

--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -1,9 +1,9 @@
 (ns pyregence.email
   (:import java.util.UUID)
   (:require [pyregence.database :refer [call-sql]]
-            [pyregence.views :refer [data-response]]
-            [pyregence.config :refer [get-config]]
-            [postal.core :refer [send-message]]))
+            [pyregence.views    :refer [data-response]]
+            [pyregence.config   :refer [get-config]]
+            [postal.core        :refer [send-message]]))
 
 ;; TODO get name for greeting line.
 (defn get-password-reset-message [url email reset-key]

--- a/src/clj/pyregence/herb_patch.clj
+++ b/src/clj/pyregence/herb_patch.clj
@@ -1,6 +1,6 @@
 (ns pyregence.herb-patch
   (:require [clojure.spec.alpha :as s]
-            [herb.core :as herb]))
+            [herb.core          :as herb]))
 
 (s/def ::style (s/spec
                 (s/cat :identifier   (s/+ (s/alt :kw keyword? :str string?))

--- a/src/clj/pyregence/logging.clj
+++ b/src/clj/pyregence/logging.clj
@@ -13,7 +13,7 @@
   (subs string 0 (min length (count string))))
 
 (defn log [data & {:keys [newline? pprint? force-stdout?]
-                   :or {newline? true pprint? false force-stdout? false}}]
+                   :or   {newline? true pprint? false force-stdout? false}}]
   (let [timestamp    (.format (SimpleDateFormat. "MM/dd HH:mm:ss") (Date.))
         log-filename (str (.format (SimpleDateFormat. "YYYY-MM-dd") (Date.)) ".log")
         max-data     (max-length data 500)

--- a/src/clj/pyregence/remote_api.clj
+++ b/src/clj/pyregence/remote_api.clj
@@ -1,7 +1,7 @@
 (ns pyregence.remote-api
   (:require [clojure.data.json :as json]
-            [clojure.repl :refer [demunge]]
-            [clojure.string :as str]
+            [clojure.repl      :refer [demunge]]
+            [clojure.string    :as str]
             [pyregence.authentication :refer [add-new-user
                                               add-org-user
                                               get-org-list

--- a/src/clj/pyregence/server.clj
+++ b/src/clj/pyregence/server.clj
@@ -39,14 +39,14 @@
 
 (def cli-options
   [["-p" "--http-port PORT" "Port for http, default 8080"
-    :default 8080
+    :default  8080
     :parse-fn #(if (int? %) % (Integer/parseInt %))
     :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
    ["-P" "--https-port PORT" "Port for https (e.g. 8443)"
     :parse-fn #(if (int? %) % (Integer/parseInt %))
     :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
    ["-m" "--mode MODE" "Production (prod) or development (dev) mode, default prod"
-    :default "prod"
+    :default  "prod"
     :validate [#{"prod" "dev"} "Must be \"prod\" or \"dev\""]]
    ["-o" "--output-dir DIR" "Output directory for log files. When a directory is not provided, output will be to stdout."
     :default ""]])

--- a/src/clj/pyregence/sockets.clj
+++ b/src/clj/pyregence/sockets.clj
@@ -1,8 +1,8 @@
 (ns pyregence.sockets
-  (:import (java.io BufferedReader)
+  (:import (java.io  BufferedReader)
            (java.net Socket ServerSocket))
-  (:require [clojure.java.io :as io]
-            [clojure.string  :as s]
+  (:require [clojure.java.io   :as io]
+            [clojure.string    :as s]
             [pyregence.logging :refer [log log-str]]))
 
 ;;=================================

--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -1,12 +1,12 @@
 (ns pyregence.views
+  (:import java.io.ByteArrayOutputStream)
   (:require [clojure.edn       :as edn]
             [clojure.string    :as str]
             [clojure.data.json :as json]
             [cognitect.transit :as transit]
-            [hiccup.page :refer [html5 include-css include-js]]
+            [hiccup.page            :refer [html5 include-css include-js]]
             [pl.danieljanus.tagsoup :refer [parse]]
-            [pyregence.config :refer [get-config]])
-  (:import java.io.ByteArrayOutputStream))
+            [pyregence.config       :refer [get-config]]))
 
 (defn- find-app-js []
   (as-> (slurp "target/public/cljs/manifest.edn") app
@@ -33,26 +33,26 @@
 
 (defn header [server-name]
   (let [pyrecast? (str/ends-with? server-name "pyrecast.org")]
-    [:div {:id "header"
-           :style {:display         "flex"
-                   :justify-content "space-between"
-                   :align-items     "center"}}
-      [:a {:rel "home"
-           :href (if pyrecast? "/" "https://pyregence.org")
+    [:div {:id    "header"
+           :style {:align-items     "center"
+                   :display         "flex"
+                   :justify-content "space-between"}}
+      [:a {:rel   "home"
+           :href  (if pyrecast? "/" "https://pyregence.org")
            :title "Pyregence"
-           :style {:margin-left   "10%"
-                   :margin-top    "0.3125rem"
-                   :margin-bottom "0.3125rem"}}
-       [:img {:src (str "/images/" (if pyrecast? "pyrecast" "pyregence") "-logo.svg")
-              :alt "Pyregence Logo"
+           :style {:margin-bottom "0.3125rem"
+                   :margin-left   "10%"
+                   :margin-top    "0.3125rem"}}
+       [:img {:src   (str "/images/" (if pyrecast? "pyrecast" "pyregence") "-logo.svg")
+              :alt   "Pyregence Logo"
               :style {:height "40px"
                       :width  "auto"}}]]
       (when pyrecast?
-        [:a {:href "https://pyregence.org"
+        [:a {:href   "https://pyregence.org"
              :target "pyregence"
-             :style {:margin-right "5%"}}
-         [:img {:src "/images/powered-by-pyregence.svg"
-                :alt "Powered by Pyregence Logo"
+             :style  {:margin-right "5%"}}
+         [:img {:src   "/images/powered-by-pyregence.svg"
+                :alt   "Powered by Pyregence Logo"
                 :style {:height "1.25rem"
                         :width  "auto"}}]])]))
 
@@ -64,7 +64,7 @@
                [:head
                 (head-meta-css)
                 [:title "Wildfire Forecasts"]
-                [:meta {:name "description"
+                [:meta {:name    "description"
                         :content "Open source wildfire forecasting tool to assess wildfire risk for electric grid safety."}]
                 (include-css "/css/mapbox-gl-v2.3.1.css")
                 (include-js "/js/mapbox-gl-v2.3.1.js" (find-app-js))]
@@ -119,8 +119,8 @@
   ([body]
    (data-response body {}))
   ([body {:keys [status type session]
-          :or {status 200 type :edn}
-          :as params}]
+          :or   {status 200 type :edn}
+          :as   params}]
    (merge (when (contains? params :session) {:session session})
           {:status  status
            :headers {"Content-Type" (condp = type


### PR DESCRIPTION
## Purpose
Aligning columns for HTML attributes, sorting style tags in alphabetical order for all files within the `clj` directory. Any files that were not changed in the `clj` directory had no issues.

## Related Issues
Part of multiple PRs (spread out for merge-conflict reasons) for PYR-521