### PR TITLE
PYR-554: Fix link to Terms of Use in footer of static pages.

### DIFF
--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -103,7 +103,12 @@
                                 :text-transform "uppercase"}}
                     (str "\u00A9 "
                          (+ 1900 (.getYear (java.util.Date.)))
-                         " Pyregence - All Rights Reserved | Terms")]]])})))
+                         " Pyregence - All Rights Reserved | ")
+                    [:a {:href  "/terms-of-use"
+                         :style {:border-bottom "none"
+                                 :color         "#ffffff"
+                                 :font-weight   "400"}}
+                     "Terms"]]]])})))
 
 (defn body->transit [body]
   (let [out    (ByteArrayOutputStream. 4096)


### PR DESCRIPTION
## Purpose
Fixing the link to the terms-of-use page in the footer of static pages. Previously, the word "Terms" did not link to anything. The styling of the word "Terms" remains the same as it was previously except there is now a pointer cursor when hovering over the word. 

## Related Issues
Closes PYR-554

