### PR TITLE
PYR-553: Add link to data repository.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -268,7 +268,7 @@
       (let [selected-param-set (->> *params (vals) (filter keyword?) (set))]
         [:div#collapsible-panel {:style ($collapsible-panel @show-panel? mobile?)}
          [:div#layer-selection {:style {:padding "1rem"}}
-          [:div {:style {:display         "flex" :justify-content "center"}}
+          [:div {:style {:display "flex" :justify-content "center"}}
            [:label {:style ($layer-selection)} "Layer Selection"]
            [:span {:style {:margin-right "-.5rem"}}
             [tool-button :close #(reset! show-panel? false)]]]


### PR DESCRIPTION
## Purpose
Added a link to the https://pyregence.org/wildfire-forecasting/fire-forecasting-data/ from the layer sidebar as a way to provide help/more information to users. 

Note that this is a WIP until we get the proper link set up by Andrea.

## Related Issues
Closes PYR-553
 
## Screenshots
Sidebar addition:
![Screenshot from 2021-08-24 17-24-56](https://user-images.githubusercontent.com/40574170/130706918-790a5bc5-e2c8-4f8a-910a-49f7909c9da0.png)



