### PR TITLE
PYR-468: Adding a help page.

### DIFF
--- a/src/clj/pyregence/handler.clj
+++ b/src/clj/pyregence/handler.clj
@@ -34,6 +34,7 @@
 (def dynamic-routes #{"/"
                       "/admin"
                       "/dashboard"
+                      "/help"
                       "/login"
                       "/forecast"
                       "/long-term-forecast"

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -4,6 +4,7 @@
             [pyregence.config                   :as c]
             [pyregence.pages.admin              :as admin]
             [pyregence.pages.dashboard          :as dashboard]
+            [pyregence.pages.help               :as help]
             [pyregence.pages.login              :as login]
             [pyregence.pages.near-term-forecast :as ntf]
             [pyregence.pages.register           :as register]
@@ -17,6 +18,7 @@
    "/admin"              admin/root-component
    "/dashboard"          dashboard/root-component
    "/forecast"           #(ntf/root-component (merge % {:forecast-type :near-term}))
+   "/help"               help/root-component
    "/login"              login/root-component
    "/long-term-forecast" #(ntf/root-component (merge % {:forecast-type :long-term}))
    "/near-term-forecast" #(ntf/root-component (merge % {:forecast-type :near-term}))

--- a/src/cljs/pyregence/pages/help.cljs
+++ b/src/cljs/pyregence/pages/help.cljs
@@ -1,0 +1,27 @@
+(ns pyregence.pages.help)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; UI Components
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn root-component [_]
+  [:div {:id "help-page"}
+   [:h1 {:style {:margin     "5rem 2.5rem"
+                 :text-align "center"}}
+    "This page is under construction. Please check back later!"]
+   [:footer {:style {:background    "#60411f"
+                     :margin-bottom "0"
+                     :padding       "1rem"}}
+    [:p {:style {:color          "white"
+                 :font-size      "0.9rem"
+                 :margin-bottom  "0"
+                 :text-align     "center"
+                 :text-transform "uppercase"}}
+     (str "\u00A9 "
+          (.getFullYear (js/Date.))
+          " Pyregence - All Rights Reserved | ")
+     [:a {:href  "/terms-of-use"
+          :style {:border-bottom "none"
+                  :color         "#ffffff"
+                  :font-weight   "400"}}
+      "Terms"]]]])


### PR DESCRIPTION
## Purpose
Adding a skeleton of a help page that should be filled in and linked to at a later point.

## Related Issues
Closes PYR-468

## Screenshots
![Screenshot from 2021-09-02 11-51-48](https://user-images.githubusercontent.com/40574170/131900482-0e75804a-5120-4c9d-9a9e-c12e091898bd.png)


