### PR TITLE
Fixing incorrect path to style.css

### DIFF
--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -25,7 +25,7 @@
    [:meta {:charset "utf-8"}]
    [:meta {:name    "viewport"
            :content "width=device-width, initial-scale=1, shrink-to-fit=no"}]
-   (include-css "css/style.css")
+   (include-css "/css/style.css")
    [:link {:rel "icon" :type "image/png" :href "/images/favicon.png"}]
    [:script {:async true :src "https://www.googletagmanager.com/gtag/js?id UA-168639214-1"}]
    [:script "window.name = 'pyrecast'"]


### PR DESCRIPTION
## Purpose
The path to style.css was incorrect, leading to styles not being loaded everywhere.
 
## Screenshots
Before (you can see the styles not being loaded):
![Screenshot from 2021-09-02 12-11-28](https://user-images.githubusercontent.com/40574170/131902945-a63c2a74-d20e-400a-a98c-c8e86bee64d9.png)

After (now the correct styles are loaded):
![Screenshot from 2021-09-02 12-11-42](https://user-images.githubusercontent.com/40574170/131902992-d26f912b-b814-414d-a0a7-2c4ec0811a36.png)

