### PR TITLE
PYR-430: Adding units to the legend.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -843,9 +843,9 @@
    :top        "16px"
    :transition "all 200ms ease-in"})
 
-(defn legend-box [legend-list reverse? mobile?]
+(defn legend-box [legend-list reverse? mobile? units]
   (reset! show-legend? (not mobile?))
-  (fn [legend-list reverse? mobile?]
+  (fn [legend-list reverse? mobile? units]
     (when (and @show-legend? (seq legend-list))
       [:div#legend-box {:style ($/combine $/tool ($legend-location @show-panel?))}
        [:div {:style {:display "flex" :flex-direction "column"}}
@@ -853,7 +853,10 @@
                        ^{:key i}
                        [:div {:style ($/combine {:display "flex" :justify-content "flex-start"})}
                         [:div {:style ($legend-color (get leg "color"))}]
-                        [:label (get leg "label")]])
+                        [:label (str (get leg "label")
+                                     (if (or (= units "%") (= units "\u00B0F"))
+                                       units
+                                       (str " " units)))]])
                      (if reverse?
                        (reverse legend-list)
                        legend-list))]])))

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -87,7 +87,7 @@
                                                  :options    (array-map
                                                               :tmpf   {:opt-label "Temperature (F)"
                                                                        :filter    "tmpf"
-                                                                       :units     "deg F"}
+                                                                       :units     "\u00B0F"}
                                                               :ffwi   {:opt-label "Fosberg Fire Weather Index"
                                                                        :filter    "ffwi"
                                                                        :units     ""}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -491,7 +491,11 @@
               [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-fire-names! user-id])
             (when @show-camera?
               [mc/camera-tool @the-cameras @my-box @mobile? terrain? #(reset! show-camera? false)])])
-         [mc/legend-box @legend-list (get-forecast-opt :reverse-legend?) @mobile?]
+         [mc/legend-box
+          @legend-list
+          (get-forecast-opt :reverse-legend?)
+          @mobile?
+          (get-current-layer-key :units)]
          [mc/tool-bar
           show-info?
           show-match-drop?


### PR DESCRIPTION
## Purpose
Adding inline units to the legend. The "\u00B0F is the Unicode number for the degree symbol and then the letter F for Fahrenheit. 

## Related Issues
Closes PYR-430 

## Screenshots 
![Screenshot from 2021-09-02 15-49-25](https://user-images.githubusercontent.com/40574170/131927862-1c4cff61-9646-46e6-8503-21fd85c57e04.png)
![Screenshot from 2021-09-02 15-49-15](https://user-images.githubusercontent.com/40574170/131927865-3d74d612-f77f-4ad5-aebe-277cf17aa9a5.png)
