### PR TITLE
Fixing the spacing of units on the vega graph.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -745,9 +745,7 @@
     (fn [_]
       [:div {:style {:bottom "0" :position "absolute" :width "100%"}}
        [:label {:style {:margin-top ".5rem" :text-align "center" :width "100%"}}
-        (str (:band (get last-clicked-info @*layer-idx))
-             " "
-             units)]])}))
+        (str (:band (get last-clicked-info @*layer-idx)) (u/clean-units units))]])}))
 
 (defn vega-information [box-height box-width *layer-idx select-layer! units cur-hour legend-list last-clicked-info]
   (r/with-let [info-height (r/atom 0)]
@@ -885,10 +883,7 @@
                        ^{:key i}
                        [:div {:style ($/combine {:display "flex" :justify-content "flex-start"})}
                         [:div {:style ($legend-color (get leg "color"))}]
-                        [:label (str (get leg "label")
-                                     (if (or (= units "%") (= units "\u00B0F"))
-                                       units
-                                       (str " " units)))]])
+                        [:label (str (get leg "label") (u/clean-units units))]])
                      (if reverse?
                        (reverse legend-list)
                        legend-list))]])))

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -481,3 +481,10 @@
            (if (< v s)
              (take 2 coll)
              (recur (next coll)))))))
+
+(defn clean-units
+  "Cleans units by adding/not adding a space when needed for units."
+  [units]
+  (if (or (= units "%") (= units "\u00B0F"))
+    units
+    (str " " units)))


### PR DESCRIPTION
## Purpose
Removing a space from % and degrees Fahrenheit units on the Vega graph.

## Screenshots
Before:
![Screenshot from 2021-09-08 17-39-08](https://user-images.githubusercontent.com/40574170/132604151-2e34d02d-0e1c-4088-895b-545b6df173a4.png)

After: 
![Screenshot from 2021-09-08 17-38-32](https://user-images.githubusercontent.com/40574170/132604148-018bfd38-70bd-48b8-9a26-5775583822b6.png)


