### PR TITLE
PYR-590: Fix redundant hours unit in Fire Forecast legend.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -198,7 +198,7 @@
                                              :hover-text "This shows the areas where our models forecast the fire to spread over 3 days. Time can be advanced with the slider below, and the different colors on the map provide information about when an area is forecast to burn."
                                              :options    {:burned {:opt-label "Forecasted fire location"
                                                                    :filter    "hours-since-burned"
-                                                                   :units     "Hours"}}}
+                                                                   :units     ""}}}
                                 :burn-pct   {:opt-label      "Predicted Fire Size"
                                              :default-option :50
                                              :hover-text     "Each fire forecast is an ensemble of 1,000 separate simulations to account for uncertainty in model inputs. This leads to a range of predicted fire sizes, five of which can be selected from the dropdown menu."


### PR DESCRIPTION
## Purpose
Fixing a redundant use of units in the Fire Forecast legend.

## Related Issues
Closes PYR-590

## Screenshots
Before:
![Screenshot from 2021-09-16 10-01-11](https://user-images.githubusercontent.com/40574170/133654507-e3f6befc-1c13-45c2-95ff-9e745e351446.png)


After:
![Screenshot from 2021-09-16 09-59-06](https://user-images.githubusercontent.com/40574170/133654460-fdb0469d-2b8a-474a-a686-e3f69a72d60f.png)

