### PR TITLE
PYR-336: Update Clojurescript version and associated packages.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,14 +10,14 @@
         herb/herb                  {:mvn/version "0.10.0"}
         hiccup/hiccup              {:mvn/version "2.0.0-alpha2"}
         org.clojure/clojure        {:mvn/version "1.10.1"}
-        org.clojure/clojurescript  {:mvn/version "1.10.773"}
+        org.clojure/clojurescript  {:mvn/version "1.10.866"}
         org.clojure/core.async     {:mvn/version "1.2.603"}
         org.clojure/data.json      {:mvn/version "1.0.0"}
         org.clojure/data.xml       {:mvn/version "0.0.8"}
         org.clojure/tools.cli      {:mvn/version "1.0.194"}
         org.postgresql/postgresql  {:mvn/version "42.2.14"}
         reagent/reagent            {:mvn/version "0.10.0"}
-        ring/ring                  {:mvn/version "1.8.2"}
+        ring/ring                  {:mvn/version "1.9.4"}
         ring/ring-headers          {:mvn/version "0.3.0"}
         ring/ring-ssl              {:mvn/version "0.3.0"}
         ring/ring-json             {:mvn/version "0.5.0"}
@@ -28,8 +28,8 @@
  :aliases {:build-db         {:main-opts ["-m" "pyregence.build-db"]}
            :https            {:main-opts ["-m" "pyregence.https"]}
            :compile-cljs     {:main-opts ["-m" "pyregence.compile-cljs" "compile-prod.cljs.edn"]}
-           :figwheel-lib     {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.11"}}}
-           :figwheel         {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.11"}
+           :figwheel-lib     {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.13"}}}
+           :figwheel         {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.13"}
                                            com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
                               :main-opts ["-m" "figwheel.main" "-b" "compile-dev" "-r"]}
            :rebel            {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}


### PR DESCRIPTION
## Purpose
Updates Clojurescript to version 1.10.866 from version 1.10.773. 
Updates Ring to version 1.9.4 from version 1.8.2.
Updates Figwheel to version 0.2.13 from version 0.2.11.

## Related Issues
Closes PYR-336 

## Testing
When running with Figwheel and doing a fresh compile, the site works as expected. 

