### PR TITLE
PYR-597: Redirect decline button to pyregence.org

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -587,7 +587,7 @@
           [:label {:class (<class $/p-form-button)
                    :style {:padding-left  "1.75rem"
                            :padding-right "1.75rem"}
-                   :on-click #(u/jump-to-url! "/")}
+                   :on-click #(u/jump-to-url! "https://pyregence.org/")}
            "Decline"]
           [:label {:class (<class $/p-form-button)
                    :style {:margin        ".5rem"


### PR DESCRIPTION
## Purpose
Makes the decline button on the disclaimer redirect to https://pyregence.org/

## Related Issues
Closes PYR-597

