### PR TITLE
PYR-595: Check if announcement.txt exists before slurping it in.

### DIFF
--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -1,4 +1,5 @@
 (ns pyregence.views
+  (:import java.io.ByteArrayOutputStream)
   (:require [clojure.edn       :as edn]
             [clojure.string    :as str]
             [clojure.data.json :as json]
@@ -132,7 +133,7 @@
                      "Terms"]]]])})))
 
 (defn body->transit [body]
-  (let [out    (io/ByteArrayOutputStream. 4096)
+  (let [out    (ByteArrayOutputStream. 4096)
         writer (transit/writer out :json)]
     (transit/write writer body)
     (.toString out)))


### PR DESCRIPTION
## Purpose
Checks if the `announcement.txt` file exists before trying to read it in.

## Related Issues
Closes PYR-595

## Testing
When deleting and adding back in the `announcement.txt` file (at the base directory level), the banner shows up (or doesn't) as expected.

