### PR TITLE
PYR-594: Fix vertical scrolling on mobile.

### DIFF
--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -74,7 +74,7 @@
 
 (defglobal body-and-content-divs
   [:body {:background-color (color-picker :white)
-          :height           "100vh"
+          :height           "100%"
           :position         "relative"}]
   [:#app {:height "100%"}]
   [:#near-term-forecast {:display        "flex"


### PR DESCRIPTION
## Purpose
Fixes a bug on Chrome on mobile where a user could scroll vertically past the map. It seems the issue is with how Chrome calculates vertical height units. See [here](https://css-tricks.com/some-things-you-oughta-know-when-working-with-viewport-units/) for more information. Switching `100vh` to `100%` for the `height` of the `body` fixes the issue.

## Related Issues
Closes PYR-594

## Testing
As a user on Chrome on mobile, when scrolling downwards (while touching the header of the webpage), the page does not scroll past the map. 

