### PR TITLE
PYR-601: Create a separate set for pyregence and forecast layers.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -42,11 +42,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^:private project-layers
-  #{"fire-detections" "fire-risk-forecast" "fire-active" "fire-active-labels"
+  #{"fire-spread-forecast" "fire-detections" "fire-risk-forecast" "fire-active" "fire-active-labels"
     "fire-weather-forecast" "fuels-and-topography" "fire-cameras" "red-flag"})
 
 (def ^:private forecast-layers
-  #{"fire-detections" "fire-risk-forecast" "fire-active" "fire-active-labels"
+  #{"fire-spread-forecast" "fire-detections" "fire-risk-forecast" "fire-active" "fire-active-labels"
     "fire-weather-forecast" "fuels-and-topography"})
 
 (defn- is-project-layer?


### PR DESCRIPTION
## Purpose
Creating a separate set for all project and forecast layers. Renaming is-selectable? to is-project-layer?. Creating a separate function to check for forecast layers and using that when hiding layers on active change.

## Related Issues
Closes PYR-601

## Testing
When enabling the camera or red-flag layer and switching between tabs, the cameras and red-flag layers still show up. 

