### PR TITLE
PYR-579: Fix fuels tab overlapping with the theme select.

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -48,7 +48,6 @@
 (defonce show-camera?       (r/atom false))
 (defonce show-red-flag?     (r/atom false))
 (defonce show-fire-history? (r/atom false))
-(defonce show-theme-select? (r/atom true))
 (defonce active-opacity     (r/atom 100.0))
 (defonce capabilities       (r/atom []))
 (defonce *forecast          (r/atom nil))
@@ -612,8 +611,7 @@
       (fn [_]
         (let [update-fn (fn [& _]
                           (-> js/window (.scrollTo 0 0))
-                          (reset! mobile? (> 700.0 (.-innerWidth js/window)))
-                          (reset! show-theme-select? (> (.-innerWidth js/window) 800.0))
+                          (reset! mobile? (> 800.0 (.-innerWidth js/window)))
                           (reset! height  (str (- (.-innerHeight js/window)
                                                   (-> js/document
                                                       (.getElementById "header")
@@ -635,7 +633,7 @@
          (when @loading? [loading-modal])
          [message-modal]
          [:div {:style ($/combine $app-header {:background ($/color-picker :yellow)})}
-          (when @show-theme-select? [theme-select])
+          (when-not @mobile? [theme-select])
           [:span {:style {:display "flex" :padding ".25rem 0"}}
            (doall (map (fn [[key {:keys [opt-label hover-text]}]]
                          ^{:key key}


### PR DESCRIPTION
## Purpose
Fixes a small UI bug where the Fuels tab would overlap with the theme select at certain widths.

## Related Issues
Closes PYR-579

## Screenshots
Before:
![Screenshot from 2021-09-23 18-43-29](https://user-images.githubusercontent.com/40574170/134593634-c0e1967a-8a9e-4c76-a0b8-64e0cc646ed1.png)

After:
![Screenshot from 2021-09-23 18-43-47](https://user-images.githubusercontent.com/40574170/134593648-5a9c58e8-6f3e-40e0-9a68-fa49a7fed72d.png)


