### PR TITLE
PYR-604: Fix small light mode UI bugs.

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -52,12 +52,12 @@ h2 {
 }
 p a:link, p a:visited {
     font-weight: 700;
-    border-bottom: 1px solid #333;
-    color: #60411f;
+    color: #007bff;
     text-decoration: none;
 }
 p a:hover, p a:active {
-    text-decoration: none;
+    color: #0056b3;
+    text-decoration: underline;
 }
 #content p {
     display: inline-block;

--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -310,7 +310,7 @@
                    :padding         "0.5em"}}
      [:a {:href   "https://pyregence.org/wildfire-forecasting/data-repository/"
           :target "_blank"
-          :style  {:color       ($/color-picker :white)
+          :style  {:color       ($/color-picker :font-color)
                    :font-family "Avenir"
                    :font-style  "italic"
                    :margin      "0"


### PR DESCRIPTION
## Purpose
Fixes bug where the link to the data repository and URLs in tooltips wouldn't show up in light mode.

## Related Issues
Closes PYR-604
 
## Screenshots
### Link to Data Repository
Before:
![Screenshot from 2021-09-24 11-59-42](https://user-images.githubusercontent.com/40574170/134706254-83bc72f0-6b39-4910-ba12-c740c166203d.png)
After:
![Screenshot from 2021-09-24 12-01-19](https://user-images.githubusercontent.com/40574170/134706257-59c3467c-31c6-4e2f-8182-95461dee0111.png)
### URLs in Tooltips
Before:
![Screenshot from 2021-09-24 12-02-48](https://user-images.githubusercontent.com/40574170/134706258-de2a31b6-4dcf-4fcc-a3bd-2f677385f8f1.png)
After:
![Screenshot from 2021-09-24 12-04-03](https://user-images.githubusercontent.com/40574170/134706260-2a279f3d-e23a-4a04-8b18-3e2d0b2ed1f6.png)


