### PR TITLE
PYR-606: Reduce margin-top for data link.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -298,8 +298,7 @@
 
 (defn- help-section []
   [:section#help-section {:style {:width "100%"}}
-   [:article {:style {:margin-bottom "0.5rem"
-                      :margin-top    "4rem"
+   [:article {:style {:margin        "0.5rem 0"
                       :padding-left  "1rem"
                       :padding-right "1rem"}}
     [:div {:style {:background      ($/color-picker :transparent)


### PR DESCRIPTION
## Purpose
Reduces the margin on top of the data link.

## Related Issues
Closes PYR-606

## Screenshots
Before:
![image-20210924-185443](https://user-images.githubusercontent.com/40574170/134731426-7a902299-1b59-47a3-8147-73cdd5ad0939.png)

After:
![Screenshot from 2021-09-24 15-40-35](https://user-images.githubusercontent.com/40574170/134731335-540e7d60-1f85-4abf-8b34-b690016954b3.png) 

