### PR TITLE
PYR-550: Add Smoke forecast to weather tab.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -94,9 +94,9 @@
                                                                   :filter    "cbh"
                                                                   :units     "m"
                                                                   :convert   #(u/to-precision 1 (/ % 10))}
-                                                         :cbd    {:opt-label "Crown Bulk Density (kg/m^3)"
+                                                         :cbd    {:opt-label "Crown Bulk Density (kg/m\u00b3)"
                                                                   :filter    "cbd"
-                                                                  :units     "kg/m^3"
+                                                                  :units     "kg/m\u00b3"
                                                                   :convert   #(u/to-precision 2 %)})}
                                     :model-init {:opt-label  "Model Creation Time"
                                                  :hover-text "Time the data was created."
@@ -148,7 +148,10 @@
                                                                        :units     "hPa"}
                                                               :hdw    {:opt-label "Hot-Dry-Windy Index (hPa*m/s)"
                                                                        :filter    "hdw"
-                                                                       :units     "hPa*m/s"})}
+                                                                       :units     "hPa*m/s"}
+                                                              :smoke  {:opt-label "Smoke density (\u00b5g/m\u00b3)"
+                                                                       :filter    "smoke"
+                                                                       :units     "\u00b5g/m\u00b3"})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}


### PR DESCRIPTION
## Purpose
Adds the Smoke forecast to the Weather tab. Fixes the units for the Crown Bulk Density layer.

## Related Issues
Closes PYR-550

## Screenshots
![Screenshot from 2021-09-27 13-31-42](https://user-images.githubusercontent.com/40574170/134957456-62950be2-2879-4904-abcd-796ac5f1ffb6.png)

