### PR TITLE
PYR-612: Fix truncated fuels legend on Firefox (Oct testing bug fix)

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -939,17 +939,20 @@
   {:background-color color
    :height           "1rem"
    :margin-right     ".5rem"
-   :width            "1rem"})
+   :min-width        "1rem"})
 
 (defn $legend-location [show? mobile?]
-  {:left       (if show? "19rem" "1rem")
-   :max-height (if mobile?
-                 "calc(100% - 100px)"
-                 "calc(100% - 32px)")
-   :padding    ".25rem"
-   :overflow-y "auto"
-   :top        "16px"
-   :transition "all 200ms ease-in"})
+  {:left          (if show? "19rem" "1rem")
+   :max-height    (if mobile?
+                    "calc(100% - 100px)"
+                    "calc(100% - 32px)")
+   :overflow-x    "hidden"
+   :overflow-y    "auto"
+   :padding-left  ".5rem"
+   :padding-right ".75rem"
+   :padding-top   ".5rem"
+   :top           "16px"
+   :transition    "all 200ms ease-in"})
 
 (defn legend-box [legend-list reverse? mobile? units]
   (reset! show-legend? (not mobile?))
@@ -957,8 +960,7 @@
     (when (and @show-legend? (seq legend-list))
       [:div#legend-box {:style ($/combine $/tool ($legend-location @show-panel? mobile?))}
        [:div {:style {:display        "flex"
-                      :flex-direction "column"
-                      :padding-right  "0.5rem"}}
+                      :flex-direction "column"}}
         (map-indexed (fn [i leg]
                        ^{:key i}
                        [:div {:style ($/combine {:display "flex" :justify-content "flex-start"})}


### PR DESCRIPTION
## Purpose
Fixes a [known Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=764076) where an element that uses `:overflow auto` doesn't grow to accommodate the scrollbar. 

The only issue with this fix is that any legends that don't have a scrollbar will have some extra padding on the right hand side.

## Related Issues
Closes PYR-612

## Screenshots
Before:
![Screenshot from 2021-09-29 17-49-49](https://user-images.githubusercontent.com/40574170/135354044-a657e69f-f802-41d7-be8e-73eb928c36ac.png)

After:
![Screenshot from 2021-09-29 17-48-20](https://user-images.githubusercontent.com/40574170/135354055-eedd7cdc-209c-4b43-8e86-0c6105dac00e.png)


