### PR TITLE
PYR-614: Apply Zoom to Fit padding on a layer by layer basis (Oct testing bug fix)

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -488,7 +488,7 @@
                                   :right
                                   [tool-button icon on-click active?]])))])
 
-(defn zoom-bar [get-current-layer-extent current-layer mobile? create-share-link terrain?]
+(defn zoom-bar [current-layer-extent current-layer mobile? create-share-link terrain?]
   (r/with-let [minZoom      (r/atom 0)
                maxZoom      (r/atom 28)
                *zoom        (r/atom 10)
@@ -529,7 +529,7 @@
                    ;;   #(mb/center-on-overlay!)]
                    [:extent
                     "Zoom to fit layer"
-                    #(mb/zoom-to-extent! (get-current-layer-extent) (current-layer))]
+                    #(mb/zoom-to-extent! current-layer-extent current-layer)]
                    [:zoom-in
                     "Zoom in"
                     #(select-zoom! (inc @*zoom))]

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -43,8 +43,8 @@
 ;; Map Information
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- convert-layer-id
-  "Converts a layer id from something like
+(defn- get-layer-type
+  "Gets the layer type from the id string. Example:
    fire-detections_active-fires:active-fires_20210929_155400 => fire-detections"
   [id]
   (first (str/split id #"_")))
@@ -52,17 +52,17 @@
 (defn- is-project-layer?
   "Checks whether or not a layer is a custom project layer."
   [id]
-  ((:project-layers @layer-sets) (convert-layer-id id)))
+  ((:project-layers @layer-sets) (get-layer-type id)))
 
 (defn- is-forecast-layer?
   "Checks whether or not a layer is a forceast layer."
   [id]
-  ((:forecast-layers @layer-sets) (convert-layer-id id)))
+  ((:forecast-layers @layer-sets) (get-layer-type id)))
 
 (defn- should-opacity-change?
   "Checks whether or not a layer's opacity should change."
   [id]
-  ((:opacity-change-layers @layer-sets) (convert-layer-id id)))
+  ((:opacity-change-layers @layer-sets) (get-layer-type id)))
 
 (defn- get-style
   "Returns the Mapbox style object."
@@ -130,7 +130,7 @@
   (.fitBounds @the-map
               (LngLatBounds. (clj->js [[minx miny] [maxx maxy]]))
               (-> {:linear  true
-                   :padding (if (#{"fire-risk-forecast" "fire-detections"} (convert-layer-id (:layer current-layer)))
+                   :padding (if (#{"fire-risk-forecast" "fire-detections"} (get-layer-type (:layer current-layer)))
                               {:top 30 :bottom 150 :left 0 :right 0}
                               0)}
                   (merge (when max-zoom {:maxZoom max-zoom}))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -516,7 +516,7 @@
           user-id]
          [mc/scale-bar @mobile?]
          (when-not @mobile? [mc/mouse-lng-lat])
-         [mc/zoom-bar get-current-layer-extent current-layer @mobile? create-share-link terrain?]
+         [mc/zoom-bar (get-current-layer-extent) (current-layer) @mobile? create-share-link terrain?]
          (when (get-forecast-opt :time-slider?)
            [mc/time-slider
             param-layers


### PR DESCRIPTION
## Purpose
The Zoom to Fit button now applies padding depending on the layer. The Fuels and Weather layers don't need any padding, but the Risk and Active Fire layers do.

## Related Issues
Closes PYR-614
Fixes [PYR-573](https://github.com/pyregence/pyregence/pull/551/)

## Screenshots
### Active Fires
Before:

![Screenshot from 2021-09-29 14-17-09](https://user-images.githubusercontent.com/40574170/135327357-d1ad43ae-6f6c-4484-8ecb-f5c0e24a5278.png)

After:
![Screenshot from 2021-09-29 14-16-43](https://user-images.githubusercontent.com/40574170/135327297-348dcb46-faf1-4a6d-9338-e449fee66221.png)

### Risk 
Before:
![Screenshot from 2021-09-29 14-17-21](https://user-images.githubusercontent.com/40574170/135327303-71a1fae9-dc98-4fb7-b0f0-d8d14b467f3b.png)

After:

![Screenshot from 2021-09-29 14-16-21](https://user-images.githubusercontent.com/40574170/135327353-13dffc90-ad4f-4b20-963b-1823928fb809.png)

