### PR TITLE
Fixing the path to the Twitter image.

### DIFF
--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -32,7 +32,7 @@
    [:meta {:property "og:image" :content "/images/pyrecast-logo-social-media.png"}]
    [:meta {:property "og:url" :content "https://pyrecast.org/"}]
    [:meta {:property "twitter:title" :content "Pyrecast"}]
-   [:meta {:property "twitter:image" :content "/images/pyrecast-logo-social-media.png"}]
+   [:meta {:property "twitter:image" :content "https://pyrecast.org/images/pyrecast-logo-social-media.png"}]
    [:meta {:property "twitter:card" :content "summary_large_image"}]
    (include-css "/css/style.css")
    [:link {:rel "icon" :type "image/png" :href "/images/favicon.png"}]


### PR DESCRIPTION
## Purpose
Changing the path to the image for Twitter from `"/images/pyrecast-logo-social-media.png"` to `"https://pyrecast.org/images/pyrecast-logo-social-media.png"` due to Twitter being very specific about the path to the image.

## Screenshots
Tested locally using `ngrok`:
![Screenshot from 2021-09-30 15-43-22](https://user-images.githubusercontent.com/40574170/135520551-ffe33af5-2677-4ea6-9b81-e95e727829d9.png)


