### PR TITLE
PYR-603: Add a toast message when there are no red flag warnings.

### DIFF
--- a/src/cljs/pyregence/components/popups.cljs
+++ b/src/cljs/pyregence/components/popups.cljs
@@ -54,7 +54,7 @@
   [:div {:style {:text-align "right" :width "100%"}}
    [:button {:class    (<class $popup-btn)
              :on-click #(js/window.open url)}
-    "Click for More Details"]])
+    "Click for More Info"]])
 
 (defn red-flag-popup
   "Popup body for red-flag warning layer."


### PR DESCRIPTION
## Purpose
Adds a toast message when there are no red flag warnings. When there are no red flag warnings, the tooltip text is kept as "Show red flag warnings".

## Related Issues
Closes PYR-603

## Screenshots
![Screenshot from 2021-09-30 18-07-39](https://user-images.githubusercontent.com/40574170/135537147-498c7617-1175-4a92-8800-3add29fab7ff.png)


