### PR TITLE
PYR-574: Fix bug with using time slider without an active fire selected.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -285,10 +285,11 @@
                                                                                     :z-index    0
                                                                                     :filter-set #{"fire-detections" "goes16-rgb"}}}
                                                  :default-option :active-fires
-                                                 :options        {:active-fires    {:opt-label  "*All Active Fires"
-                                                                                    :style-fn   :default
-                                                                                    :filter-set #{"fire-detections" "active-fires"}
-                                                                                    :auto-zoom? false}}}
+                                                 :options        {:active-fires    {:opt-label    "*All Active Fires"
+                                                                                    :style-fn     :default
+                                                                                    :filter-set   #{"fire-detections" "active-fires"}
+                                                                                    :auto-zoom?   false
+                                                                                    :time-slider? false}}}
                                     :output     {:opt-label  "Output"
                                                  :hover-text "This shows the areas where our models forecast the fire to spread over 3 days. Time can be advanced with the slider below, and the different colors on the map provide information about when an area is forecast to burn."
                                                  :options    {:burned {:opt-label       "Forecasted fire location"

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -137,10 +137,15 @@
         (vals (get-forecast-opt :params))))
 
 ;; TODO, can we make this the default everywhere?
-(defn get-any-level-key [key-name]
-  (or (get-current-layer-key key-name)
-      (get-options-key key-name)
-      (get-forecast-opt key-name)))
+(defn get-any-level-key
+  "Gets the first non-nil value of a given key starting from the bottom level in
+   a forecast in `config.cljs` and going to the top. Allows for bottom level keys
+   to override a default top level key (such as for `:time-slider?`)."
+  [key-name]
+  (first (filter some?
+                 [(get-current-layer-key key-name)
+                  (get-options-key       key-name)
+                  (get-forecast-opt      key-name)])))
 
 (defn create-share-link
   "Generates a link with forecast and parameters encoded in a URL"
@@ -517,7 +522,7 @@
          [mc/scale-bar @mobile?]
          (when-not @mobile? [mc/mouse-lng-lat])
          [mc/zoom-bar (get-current-layer-extent) (current-layer) @mobile? create-share-link terrain?]
-         (when (get-forecast-opt :time-slider?)
+         (when (get-any-level-key :time-slider?)
            [mc/time-slider
             param-layers
             *layer-idx


### PR DESCRIPTION
## Purpose
Disabled the time slider on the Active Fires tab whenever an active fire isn't actually selected. Fixes a bug where clicking the play, back, or forwards button would create a strange UI bug (see screenshot below).

## Related Issues
Closes PYR-574

## Screenshots
Before:
![Screenshot from 2021-10-01 14-11-38](https://user-images.githubusercontent.com/40574170/135667831-48bb6fa7-a374-4bbc-8b87-22670fdc37c4.png)


After:
![Screenshot from 2021-10-01 14-12-09](https://user-images.githubusercontent.com/40574170/135667825-5da084bd-87b5-4ad6-9ae7-dc772ac09a77.png)