### PR TITLE
PYR-577: Fix copy url button highlighting on mobile.

### DIFF
--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -520,7 +520,6 @@
   [element-id]
   {:pre [(string? element-id)]}
   (doto (js/document.getElementById element-id)
-    (.focus)
     (.select))
   (js/document.execCommand "copy"))
 


### PR DESCRIPTION
## Purpose
Fixes a bug where focused text that was hidden on mobile would be highlighted after clicking the Copy URL button.

## Related Issues
Closes PYR-577

## Screenshots
Before:
![240432891-1181149252392772-9097023906103607087-n](https://user-images.githubusercontent.com/40574170/135671072-2be15ecc-58e4-4ea4-a88b-b96d06847444.jpg)



After:
![243730271_1077676709634427_4098215801542809242_n](https://user-images.githubusercontent.com/40574170/135670987-5df78cca-cd65-46e6-af55-6ad9a0bddb23.jpg)


