### PR TITLE
Add pointer cursor to close button on resizable windows.

### DIFF
--- a/src/cljs/pyregence/components/resizable_window.cljs
+++ b/src/cljs/pyregence/components/resizable_window.cljs
@@ -36,7 +36,8 @@
    :z-index      "2"})
 
 (defn- $close-button [height]
-  {:fill     ($/color-picker :font-color)
+  {:cursor   "pointer"
+   :fill     ($/color-picker :font-color)
    :height   height
    :position "absolute"
    :right    ".25rem"


### PR DESCRIPTION
## Purpose
Adds a pointer cursor to the close button on resizable windows to match the styling of tool buttons.

## Testing
Hovering over the close button on resizable windows should change the cursor to a pointer.

