### PR TITLE
PYR-455: Rewind time slider, load median percentile, and pause animation on fire change.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -108,9 +108,8 @@
    :right        "0"
    :width        (if mobile? "20rem" "min-content")})
 
-(defn time-slider [layers *layer-idx layer-full-time select-layer! show-utc? select-time-zone! mobile?]
-  (r/with-let [animate?        (r/atom false)
-               *speed          (r/atom 1)
+(defn time-slider [layers *layer-idx layer-full-time select-layer! show-utc? select-time-zone! animate? mobile?]
+  (r/with-let [*speed          (r/atom 1)
                cycle-layer!    (fn [change]
                                  (select-layer! (mod (+ change @*layer-idx) (count @layers))))
                loop-animation! (fn la []

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -38,6 +38,7 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defonce animate?           (r/atom false))
 (defonce options            (r/atom {}))
 (defonce mobile?            (r/atom false))
 (defonce legend-list        (r/atom []))
@@ -312,6 +313,10 @@
   (swap! *params assoc-in (cons @*forecast keys) val)
   (when-not ((set keys) :underlays)
     (let [main-key (first keys)]
+      (when (and (= main-key :fire-name))
+        (select-layer! 0)
+        (swap! *params assoc-in (cons @*forecast [:burn-pct]) :50)
+        (reset! animate? false))
       (change-type! (not (#{:burn-pct :model-init} main-key)) ;; TODO: Make this a config
                     (get-current-layer-key :clear-point?)
                     (get-current-option-key main-key val :auto-zoom?)
@@ -525,6 +530,7 @@
             select-layer!
             show-utc?
             select-time-zone!
+            animate?
             @mobile?])])})))
 
 (defn pop-up []


### PR DESCRIPTION
## Purpose
When a fire is changed, the time slider is set back to step 0, the median burn-pct percentile is selected, and any animation is paused.

## Related Issues
Closes PYR-455 

## Testing
Select a fire, change the predicted fire size to something other than the 50th percentile, and press play on the time slider. Then, select a different fire. The time slider should stop animating and be set back to time step 0 and the percentile should be set back to the 50th percentile.

