### PR TITLE
PYR-625: Fix inconsistencies with the Point Information tool.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -909,9 +909,8 @@
             (nil? last-clicked-info)
             [loading-cover box-height box-width "Loading..."]
 
-            (neg? last-clicked-info) no-info
-
-            (number? last-clicked-info)
+            (and (number? last-clicked-info)
+                 (>= last-clicked-info -50))
             [single-point-info
              box-height
              box-width
@@ -920,7 +919,9 @@
              units
              convert]
 
-            (-> last-clicked-info (first) (:band) (neg?)) no-info
+            (or (< last-clicked-info -50)
+                (-> last-clicked-info (first) (:band) (< -50)))
+            no-info
 
             (not-empty last-clicked-info)
             [vega-information


### PR DESCRIPTION
## Purpose
Fixes some UI inconsistencies with the Point Information tool for both single point information and the Vega graphs. Issues would arise when clicking just over the "end" of a layer. Instead of displaying the message "This point does not have any information." the Point Information tool would display the `nodata` band number (such as -9999). This specifically affected all layers in the Fuels tab and the Smoke and HDWI layers in the Weather tab. This may have affected more layers, but I was not able to tell.

## Related Issues
Closes PYR-625 

## Testing
Clicking on a spot with no information just outside the border of the Fuels layer should yield the message "This point does not have any information." Clicking on a spot with no information on the FBFM40 layer (for all sources) should yield the same message.

## Screenshots
### The Fuels tab bug:
![Screenshot from 2021-10-14 15-40-00](https://user-images.githubusercontent.com/40574170/137411746-bea21bb7-14f4-40c9-9a9f-8d7af48d1e1c.png)
![Screenshot from 2021-10-14 15-52-31](https://user-images.githubusercontent.com/40574170/137411759-b42e1524-1b3a-4ce1-a6a2-ed494768f68f.png)


### The Weather tab bug:

![Screenshot from 2021-10-14 16-28-30](https://user-images.githubusercontent.com/40574170/137411779-5df605a0-90fd-4ef8-a38a-ae2912be5636.png)

### The fix:
![Screenshot from 2021-10-14 17-09-05](https://user-images.githubusercontent.com/40574170/137411959-822681ca-5596-410d-a104-a518ad8f8f6d.png)

![Screenshot from 2021-10-14 17-00-23](https://user-images.githubusercontent.com/40574170/137411825-e42eeb2e-d556-4d1b-b47b-78fa9d15507c.png)


