### PR TITLE
PYR-620: Fix the way the legend refreshes.

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -199,7 +199,6 @@
 
 ;; Use <! for synchronous behavior or leave it off for asynchronous behavior.
 (defn get-legend! [layer]
-  (reset! legend-list [])
   (when (u/has-data? layer)
     (get-data #(wrap-wms-errors "legend" % process-legend!)
               (c/legend-url (str/replace layer #"tlines|liberty|pacificorp" "all"))))) ; TODO make a more generic way to do this.
@@ -316,9 +315,10 @@
 
 (defn select-param! [val & keys]
   (swap! *params assoc-in (cons @*forecast keys) val)
+  (reset! legend-list [])
   (when-not ((set keys) :underlays)
     (let [main-key (first keys)]
-      (when (and (= main-key :fire-name))
+      (when (= main-key :fire-name)
         (select-layer! 0)
         (swap! *params assoc-in (cons @*forecast [:burn-pct]) :50)
         (reset! animate? false))
@@ -332,6 +332,7 @@
     (doseq [[_ {:keys [name]}] (get-in @*params [@*forecast :underlays])]
       (when (some? name)
         (mb/set-visible-by-title! name false)))
+    (reset! legend-list [])
     (reset! *forecast key)
     (reset! processed-params (get-forecast-opt :params))
     (reset-underlays!)


### PR DESCRIPTION
## Purpose
Fixes the way the legend refreshes by initially resetting it to `[]` every time the forecast or a parameter changes. Gets rid of an extraneous use of `and` in `select-param!`

## Related Issues
Closes PYR-620 

## Testing
**As** a Visitor, **When** I switch between layers with different legends, **Then** there should not be an intermediate legend that shows up for a split second (the new legend shouldn't load until the layer does). 
 

