### PR TITLE
PYR-610: Fix mobile legend location bugs.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -944,10 +944,10 @@
    :min-width        "1rem"})
 
 (defn $legend-location [show? mobile? time-slider?]
-  {:left          (if show? "19rem" "1rem")
+  {:left          (if (and show? (not mobile?)) "20rem" "2rem")
    :max-height    (if (and mobile? time-slider?)
-                    "calc(100% - 100px)"
-                    "calc(100% - 32px)")
+                    "calc(100% - 106px)"
+                    "calc(100% - 52px)")
    :overflow-x    "hidden"
    :overflow-y    "auto"
    :padding-left  ".5rem"


### PR DESCRIPTION
## Purpose
Fixes a number of small UI bugs with the legend. The screenshots below best describe the fixes.

## Related Issues
Closes PYR-610
 
## Screenshots
### Issue 1 
The legend didn't line up with the zoom-bar on the other side of the screen both with and without the time slider activated.
#### Before: 
![Screenshot from 2021-10-15 11-44-30](https://user-images.githubusercontent.com/40574170/137538239-e4cd5c3f-1058-4c70-b374-c35714e3769f.png)
![Screenshot from 2021-10-15 11-44-22](https://user-images.githubusercontent.com/40574170/137538250-4d8e7ad9-cc1e-4416-a123-7b51909a17c5.png)
#### After:
![Screenshot from 2021-10-15 11-43-06](https://user-images.githubusercontent.com/40574170/137538332-93a0ad07-ad9e-443d-8694-26651be21756.png)
![Screenshot from 2021-10-15 11-43-16](https://user-images.githubusercontent.com/40574170/137538335-5cc7f1ae-3d3b-41b3-9124-91c14eda8fb5.png)

### Issue 2
When the legend and collapsible side panel are both activated on mobile, the legend gets pushed all the way to the right and looks strange.
#### Before (notice the legend all the way on the right):
![Screenshot from 2021-10-15 11-45-13](https://user-images.githubusercontent.com/40574170/137538508-230d1b4f-6771-4ba8-9331-c509041c49d8.png)
#### After (the legend stays on the left side of the screen):
![Screenshot from 2021-10-15 11-45-42](https://user-images.githubusercontent.com/40574170/137538510-8b71504d-7056-4524-b3b5-ca13ef9f95b8.png)

### Issue 3
The collapsible button overlaps with longer legends. I'm not sure if it's better before or after on mobile since the solution I propose makes the mobile web app seem cramped IMO. I think this fix is fine on desktop. See images below:
#### Before (on mobile):

![Screenshot from 2021-10-15 11-49-50](https://user-images.githubusercontent.com/40574170/137538687-003dab86-9649-4d90-8e93-4d427e9d1652.png)

#### After (on mobile):
![Screenshot from 2021-10-15 11-49-33](https://user-images.githubusercontent.com/40574170/137538685-69b18b1f-f77d-4637-8108-bb80388219ae.png)

#### Before (on desktop):
![Screenshot from 2021-10-15 11-49-58](https://user-images.githubusercontent.com/40574170/137538828-9ad7963c-edfa-42cc-8553-94e29cf95b3f.png)
#### After (on desktop):
![Screenshot from 2021-10-15 11-50-21](https://user-images.githubusercontent.com/40574170/137538832-7ff3939c-d238-4957-8f84-dd44bdf7129d.png)

