### PR TITLE
PYR-623: Add a flag to config.edn for using GeoWebCache.

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -6,11 +6,11 @@
               :user     "pyregence"
               :password "pyregence"}
  :dev-mode   <true/false>
- :use-gwc?   true
- :features   {:match-drop   true
-              :fire-history false
-              :structures   false
-              :gridfire     false}
+ :features   {:match-drop        true
+              :fire-history      false
+              :structures        false
+              :gridfire          false
+              :image-mosaic-gwc  true}
  :geoserver  {:base-url "https://data.pyregence.org/geoserver"}
  :match-drop {:app-host      "app.pyregence.org"
               :app-port      31337

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -44,7 +44,6 @@
     (c/set-feature-flags! cur-params)
     (c/set-geoserver-base-url! (get-in cur-params [:geoserver :base-url]))
     (c/set-mapbox-access-token! (get-in cur-params [:mapbox :access-token]))
-    (c/set-gwc! (get-in cur-params [:use-gwc?]))
     (render-root cur-params)))
 
 (defn- ^:after-load mount-root!


### PR DESCRIPTION
## Purpose
Adds a flag for whether or not GWC should be used. This way, the `wms-layer-url` function can be easily written to provide a URL structure that is for GWC or not. I'm not sure what the proper URL structure for a non-GWC WMS layer should be, but this can be easily added.

## Related Issues
Closes PYR-623  

