### PR TITLE
Fixing the check for an empty red flag warning call.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -425,7 +425,7 @@
     (let [data (-> (<! (u/call-clj-async! "get-red-flag-layer"))
                    (:body)
                    (js/JSON.parse))]
-      (if (not (some? data))
+      (if (empty? (.-features data))
         (do
           (toast-message! "There are no red flag warnings at this time.")
           (reset! show-red-flag? false))


### PR DESCRIPTION
## Purpose
The check for an empty red flag warning API call was incorrect. This fixes it. 

## Testing
As of the time of this PR, there are no red flag warnings. Clicking the red flag button should yield the expected toast message.

