### PR TITLE
Change toast message width on mobile for near term forecast.

### DIFF
--- a/src/cljs/pyregence/components/messaging.cljs
+++ b/src/cljs/pyregence/components/messaging.cljs
@@ -54,7 +54,7 @@
 ;; UI Styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- $alert-box []
+(defn- $alert-box [& [mobile?]]
   {:align-items     "center"
    :background      "white"
    :border          "1.5px solid #009"
@@ -68,7 +68,7 @@
    :left            "1rem"
    :padding         ".5rem"
    :position        "fixed"
-   :width           "50%"
+   :width           (if mobile? "90%" "50%")
    :z-index         "10000"})
 
 (defn- $alert-transition [show-full?]
@@ -115,12 +115,12 @@
                                           "See console for complete list."))]))))
 (defn toast-message
   "Creates a toast message component."
-  []
+  [mobile?]
   (let [message (r/atom "")]
-    (fn []
+    (fn [mobile?]
       (let [message? (not (nil? @toast-message-text))]
         (when message? (reset! message @toast-message-text))
-        [:div#toast-message {:style ($/combine $alert-box [$alert-transition message?])}
+        [:div#toast-message {:style ($/combine ($alert-box mobile?) [$alert-transition message?])}
          [:span {:style ($/padding ".5rem")}
           (show-line-break @message)]
          [:span {:class    (<class $p-alert-close)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -647,7 +647,7 @@
       :reagent-render
       (fn [_]
         [:div {:style ($/combine $/root {:height @height :padding 0 :position "relative"})}
-         [toast-message]
+         [toast-message @mobile?]
          [message-box-modal]
          (when @loading? [loading-modal])
          [message-modal]


### PR DESCRIPTION
## Purpose
Changed the width of the toast message on mobile for the near term forecast. Note that this doesn't change toast messages on other pages because currently only the near-term-forecast keeps track of the `mobile?` atom (which is updated through its `root-component`). 

## Screenshots
Before:
![Screenshot from 2021-10-21 16-27-26](https://user-images.githubusercontent.com/40574170/138373310-ebfb3c0f-d7c6-4712-8367-1e9270135e7c.png)

After:
![Screenshot from 2021-10-21 16-33-32](https://user-images.githubusercontent.com/40574170/138373313-6c19c142-85fb-40c4-b805-dbb846222f8d.png)

