### PR TITLE
PYR-634: Move the opacity to the bottom of the first section in the collapsible panel.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -363,24 +363,22 @@
            [collapsible-panel-section
             "layer-selection"
             [:<>
-             (doall (map-indexed (fn [idx
-                                      [key {:keys [opt-label hover-text options underlays sort?]}]]
-                                   (let [sorted-options (if sort? (sort-by (comp :opt-label second) options) options)]
-                                     ^{:key hover-text}
-                                     [:<>
-                                      [panel-dropdown
-                                       opt-label
-                                       hover-text
-                                       (get *params key)
-                                       sorted-options
-                                       (= 1 (count sorted-options))
-                                       #(select-param! % key)
-                                       selected-param-set]
-                                      (when (zero? idx)
-                                       [opacity-input active-opacity])
-                                      (when underlays
-                                        [optional-layers underlays *params select-param!])]))
-                         param-options))]]
+             (map (fn [[key {:keys [opt-label hover-text options underlays sort?]}]]
+                    (let [sorted-options (if sort? (sort-by (comp :opt-label second) options) options)]
+                      ^{:key hover-text}
+                      [:<>
+                       [panel-dropdown
+                        opt-label
+                        hover-text
+                        (get *params key)
+                        sorted-options
+                        (= 1 (count sorted-options))
+                        #(select-param! % key)
+                        selected-param-set]
+                       (when underlays
+                         [optional-layers underlays *params select-param!])]))
+                  param-options)
+             [opacity-input active-opacity]]]
            [collapsible-panel-section
             "base-map"
             [panel-dropdown


### PR DESCRIPTION
## Purpose
Moves the opacity to below the first option in each Tab per Andrea's suggestion. From a UI standpoint, this seems to imply that the opacity is being applied to that option, which makes sense for most tabs besides the Fuels tab. We might want to switch the order of the Source and Layer inputs for the Fuels tab for consistency. 

## Related Issues
Closes PYR-634

## Screenshots
### Before
![Screenshot from 2021-10-25 18-51-41](https://user-images.githubusercontent.com/40574170/138795414-f032d294-c9e8-455e-b5d5-2a344c6be355.png)
![Screenshot from 2021-10-25 18-52-05](https://user-images.githubusercontent.com/40574170/138795416-fd381942-a943-434e-8f2f-5276288a12d5.png)
### After

![Screenshot from 2021-10-25 18-50-08](https://user-images.githubusercontent.com/40574170/138795413-9e7a7467-cb4c-406e-a0b4-b03ea4e1cbf0.png)
![Screenshot from 2021-10-25 18-50-00](https://user-images.githubusercontent.com/40574170/138795411-b9d38da2-7a32-43d8-a75c-4ac8a2d4f680.png)


