### PR TITLE
PYR-640: Modify page_layout to have one wrap-page function.

### DIFF
--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -13,8 +13,7 @@
             [pyregence.pages.reset-password     :as reset-password]
             [pyregence.pages.terms-of-use       :as terms]
             [pyregence.pages.verify-email       :as verify-email]
-            [pyregence.components.page-layout   :refer [wrap-page-ha
-                                                        wrap-page-hf]]))
+            [pyregence.components.page-layout   :refer [wrap-page]]))
 
 (defonce ^:private original-params (atom {}))
 
@@ -43,13 +42,13 @@
   (let [uri (-> js/window .-location .-pathname)]
     (render (cond
               (uri->root-component-ha uri)
-              (wrap-page-ha #((uri->root-component-ha uri) params))
+              (wrap-page #((uri->root-component-ha uri) params))
 
               (uri->root-component-hf uri)
-              (wrap-page-hf #((uri->root-component-hf uri) params))
+              (wrap-page #((uri->root-component-hf uri) params) true)
 
               :else
-              (wrap-page-hf not-found/root-component))
+              (wrap-page not-found/root-component true))
             (dom/getElement "app"))))
 
 (defn- ^:export init

--- a/src/cljs/pyregence/components/page_layout.cljs
+++ b/src/cljs/pyregence/components/page_layout.cljs
@@ -52,18 +52,13 @@
 ;; Page Layouts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn wrap-page-ha
-  "Specifies the content to go inside of the [:body [:div#app]] for a page with a header and announcement banner."
-  [root-component]
+(defn wrap-page
+  "Specifies the content to go inside of the [:body [:div#app]] for a page.
+   By default, a page does not include a footer unless specified."
+  [root-component & [footer?]]
   [:<>
    [header]
    ;[announcement-banner] ; TODO: move announcement-banner from views.clj to here.
-   [root-component]])
-
-(defn wrap-page-hf
-  "Specifies the content to go inside of the [:body [:div#app]] for a page with a header and footer."
-  [root-component]
-  [:<>
-   [header]
    [root-component]
-   [footer]])
+   (when footer?
+     [footer])])


### PR DESCRIPTION
## Purpose
Gets rid of the two wrap-page functions in page_layout.cljs in place of one function that optionally takes a footer.

## Related Issues
Closes PYR-640

## Testing
All pages should work as normal (and only the "static" pages should have a footer).


