### PR TITLE
PYR-642: Simplify near-term-forecast-layers.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -417,7 +417,7 @@
   [id opacity] ;TODO, this function doesn't make sense as is because it sets the opacity of all layers currently active, not just one layer by id.
   {:pre [(string? id) (number? opacity) (<= 0.0 opacity 1.0)]}
   (let [style      (get-style)
-        new-layers (map (u/call-when #(-> % (get-layer-metadata "type") (get-layer-type-metadata-property :change-opacity?))
+        new-layers (map (u/call-when #(-> % (get-layer-metadata "type") (get-layer-type-metadata-property :forecast-layer?))
                                      #(set-opacity % opacity))
                         (get style "layers"))]
     (update-style! style :layers new-layers)))

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -375,28 +375,17 @@
   "All layers added in addition to the default Mapbox layers and their
    associated metadata for the near term forecast.
 
-   forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras.
-   change-opacity? - Layers whose opacity should change. Excludes any underlays (fire-detections)."
-  {:fire-spread-forecast  {:forecast-layer? true
-                           :change-opacity? true}
-   :fire-active           {:forecast-layer? true
-                           :change-opacity? true}
-   :fire-active-labels    {:forecast-layer? true
-                           :change-opacity? true}
-   :fire-detections       {:forecast-layer? false
-                           :change-opacity? false}
-   :fire-risk-forecast    {:forecast-layer? true
-                           :change-opacity? true}
-   :fire-weather-forecast {:forecast-layer? true
-                           :change-opacity? true}
-   :fuels-and-topography  {:forecast-layer? true
-                           :change-opacity? true}
-   :fire-cameras          {:forecast-layer? false
-                           :change-opacity? false}
-   :red-flag              {:forecast-layer? false
-                           :change-opacity? false}
-   :fire-history          {:forecast-layer? false
-                           :change-opacity? false}})
+   forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras and underlays."
+  {:fire-spread-forecast  {:forecast-layer? true}
+   :fire-active           {:forecast-layer? true}
+   :fire-active-labels    {:forecast-layer? true}
+   :fire-detections       {:forecast-layer? false}
+   :fire-risk-forecast    {:forecast-layer? true}
+   :fire-weather-forecast {:forecast-layer? true}
+   :fuels-and-topography  {:forecast-layer? true}
+   :fire-cameras          {:forecast-layer? false}
+   :red-flag              {:forecast-layer? false}
+   :fire-history          {:forecast-layer? false}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; WG4 Forecast
@@ -459,14 +448,10 @@
   "All layers added in addition to the default Mapbox layers and their
    associated metadata for the loading term forecast.
 
-   forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras.
-   change-opacity? - Layers whose opacity should change."
-  {:wg4          {:forecast-layer? true
-                  :change-opacity? true}
-   :fire-cameras {:forecast-layer? false
-                  :change-opacity? false}
-   :red-flag     {:forecast-layer? false
-                  :change-opacity? false}})
+   forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras."
+  {:wg4          {:forecast-layer? true}
+   :fire-cameras {:forecast-layer? false}
+   :red-flag     {:forecast-layer? false}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Forecast Configuration


### PR DESCRIPTION
## Purpose
Simplifies the near-term-forecast-layers metadata map now that the underlays are present on each tab.

## Related Issues
Closes PYR-642 

## Testing
All layers should work normally.


