### PR TITLE
PYR-563: Fix disabled styling on mobile, Firefox, and Safari.

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -282,10 +282,16 @@ button,
 }
 
 button:not(:disabled),
+select:not(:disabled),
+input:not(:disabled),
 [type="button"]:not(:disabled),
 [type="reset"]:not(:disabled),
 [type="submit"]:not(:disabled) {
   cursor: pointer;
+}
+
+select:disabled {
+  opacity: 0.5;
 }
 
 button::-moz-focus-inner,


### PR DESCRIPTION
## Purpose
Fixed an issue where disabled elements weren't being "greyed out" on mobile, Firefox, and Safari. Additionally, added a pointer cursor styling to any non-disabled select/input elements.

## Related Issues
Closes PYR-563

## Testing
Running this branch locally on mobile, Firefox, and Safari should grey out all disabled elements and should display a pointer cursor for any non-disabled elements.

## Screenshots
### Firefox
#### Before (ignore the outdated collapsible panel UI)
![Screenshot from 2021-10-28 12-39-58](https://user-images.githubusercontent.com/40574170/139324809-0bd87b87-fb45-4948-895a-22321c7d4b57.png)

#### After
![Screenshot from 2021-10-28 12-38-18](https://user-images.githubusercontent.com/40574170/139324817-190f57cf-9631-47b3-8ca1-81ada359ab2c.png)


### Mobile
#### Before (ignore the outdated collapsible panel UI)
![247113702_1227493467751170_5189327177447458092_n](https://user-images.githubusercontent.com/40574170/139324794-8fed1e00-a989-4f13-b615-9b94d1e62b7a.jpg)

#### After
![248046765_246308334197971_193247027614797109_n](https://user-images.githubusercontent.com/40574170/139324798-d9cd2ab8-5552-4cb6-9020-bb3fb0da974c.jpg)


