### PR TITLE
PYR-641: Use passed in z-index

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -241,11 +241,12 @@
                                       (map (fn [[id v]] (assoc v :id id)))
                                       (sort-by :z-index)
                                       (reverse))]
-        (let [{:keys [filter-set]} (first sorted-underlays)
+        (let [{:keys [filter-set z-index]} (first sorted-underlays)
               layer-name (<! (get-layer-name filter-set identity))]
           (mb/create-wms-layer! layer-name
                                 layer-name
-                                false)
+                                false
+                                z-index)
           (when-let [tail (seq (rest sorted-underlays))]
             (recur tail)))))
 

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -220,28 +220,24 @@
                     layer))
                 layers))
 
-(defn- compare-z-index
-  "A compare function for layers with a z-index."
-  [el1 el2]
-  (let [get-z-index #(-> % (get-layer-metadata "type") (get-layer-type-metadata-property :z-index))
-        z-index-el1 (get-z-index el1)
-        z-index-el2 (get-z-index el2)]
-    (< z-index-el1 z-index-el2)))
-
 (defn- process-layer-order!
   "Takes in layers and arranges them in the proper order as
    specified by the z-index. By default, all Mapbox layers are added first."
   [layers]
-  (let [mapbox-layers  (get-mapbox-layers layers)
-        project-layers (sort compare-z-index (get-project-layers layers))]
-    (vec (concat mapbox-layers project-layers))))
+  (let [mapbox-layers (get-mapbox-layers layers)
+        proj-layers   (sort-by #(get-layer-metadata % "z-index")
+                               (get-project-layers layers))]
+    (vec (concat mapbox-layers proj-layers))))
 
-(defn- update-style! [style & {:keys [sources layers new-sources new-layers]}]
+(defn- update-style!
+  "Updates the Mapbox Style object. Takes in the current Mapbox Style object
+   and optionally updates the `sources` and `layers` keys."
+  [style & {:keys [sources layers new-sources new-layers]}]
   (let [new-style (cond-> style
                     sources     (assoc "sources" sources)
-                    layers      (assoc "layers" (process-layer-order! layers))
+                    layers      (assoc "layers" layers)
                     new-sources (update "sources" merge new-sources)
-                    new-layers  (update "layers" merge-layers new-layers)
+                    new-layers  (update "layers" merge-layers new-layers) ;TODO: For future z-index updates, we will want this update function to do something similar to `process-layer-order!`
                     :always     (clj->js))]
     (-> @the-map (.setStyle new-style))))
 
@@ -482,21 +478,22 @@
    :tileSize 256
    :tiles    [(c/wms-layer-url layer-name)]})
 
-(defn- wms-layer [layer-name source-name opacity visible?]
+(defn- wms-layer [layer-name source-name opacity visible? & [z-index]]
   {:id       layer-name
    :type     "raster"
    :source   source-name
    :layout   {:visibility (if visible? "visible" "none")}
-   :metadata {:type (get-layer-type layer-name)}
+   :metadata {:type    (get-layer-type layer-name)
+              :z-index (or z-index 5)} ; Note that the default z-index here is 5 because 4 is the largest underlay z-index
    :paint    {:raster-opacity opacity}})
 
 (defn- build-wms
   "Returns new WMS source and layer in the form `[source [layer]]`.
    `source` must be a valid WMS layer in the geoserver,
    `opacity` must be a float between 0.0 and 1.0."
-  [id source opacity visibile?]
+  [id source opacity visibile? & [z-index]]
   (let [new-source {id (wms-source source)}
-        new-layer  (wms-layer id id opacity visibile?)]
+        new-layer  (wms-layer id id opacity visibile? z-index)]
     [new-source [new-layer]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -681,20 +678,14 @@
 
 (defn create-wms-layer!
   "Adds WMS layer to the map."
-  [id source visible?]
+  [id source visible? & [z-index]]
   (when id
     (if (layer-exists? id)
       (set-visible-by-title! id visible?)
-      (let [[new-source new-layers] (build-wms id source 1.0 visible?)
+      (let [[new-source new-layer] (build-wms id source 1.0 visible? z-index)
             style                   (get-style)
-            layers                  (get style "layers")
-            zero-idx                (->> layers
-                                         (keep-indexed (fn [idx layer]
-                                                         (when (some? (get-layer-metadata layer "type"))
-                                                           idx)))
-                                         (first))
-            [before after]          (split-at (or zero-idx (count layers)) layers)
-            final-layers            (vec (concat before new-layers after))]
+            current-layers          (get style "layers")
+            final-layers            (process-layer-order! (concat current-layers new-layer))]
         (update-style! style
                        :new-sources new-source
                        :layers      final-layers)))))

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -373,28 +373,17 @@
   "All layers added in addition to the default Mapbox layers and their
    associated metadata for the near term forecast.
 
-   forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras and underlays.
-   z-index         - The z-index of a specific layer type."
-  {:fire-spread-forecast  {:forecast-layer? true
-                           :z-index         0}
-   :fire-active           {:forecast-layer? true
-                           :z-index         1}
-   :fire-active-labels    {:forecast-layer? true
-                           :z-index         2}
-   :fire-detections       {:forecast-layer? false
-                           :z-index         3}
-   :fire-risk-forecast    {:forecast-layer? true
-                           :z-index         4}
-   :fire-weather-forecast {:forecast-layer? true
-                           :z-index         5}
-   :fuels-and-topography  {:forecast-layer? true
-                           :z-index         6}
-   :fire-history          {:forecast-layer? false
-                           :z-index         7}
-   :red-flag              {:forecast-layer? false
-                           :z-index         8}
-   :fire-cameras          {:forecast-layer? false
-                           :z-index         9}})
+   forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras and underlays."
+  {:fire-spread-forecast  {:forecast-layer? true}
+   :fire-active           {:forecast-layer? true}
+   :fire-active-labels    {:forecast-layer? true}
+   :fire-detections       {:forecast-layer? false}
+   :fire-risk-forecast    {:forecast-layer? true}
+   :fire-weather-forecast {:forecast-layer? true}
+   :fuels-and-topography  {:forecast-layer? true}
+   :fire-history          {:forecast-layer? false}
+   :red-flag              {:forecast-layer? false}
+   :fire-cameras          {:forecast-layer? false}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; WG4 Forecast
@@ -458,12 +447,9 @@
    associated metadata for the loading term forecast.
 
    forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras."
-  {:climate      {:forecast-layer? true
-                  :z-index         0}
-   :fire-cameras {:forecast-layer? false
-                  :z-index         1}
-   :red-flag     {:forecast-layer? false
-                  :z-index         2}})
+  {:climate      {:forecast-layer? true}
+   :fire-cameras {:forecast-layer? false}
+   :red-flag     {:forecast-layer? false}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Forecast Configuration


### PR DESCRIPTION
## Purpose
Gets rid of the `zero-idx` code in `create-wms-layer!` and instead sorts layers in `update-style!` based on their specified z-index in `config.cljs`. Works as is (you can change around the z-index in `config.cljs` to test), but not when removing the `zero-idx` code in `create-wms-layer!`. The issue might be that passing in `:new-layers` doesn't account for the z-index.

## Related Issues
Closes PYR-641

## Testing
Layers should be arranged according to the z-index specified in `config.cljs`.

