### PR TITLE
PYR-637: Put global state in state.cljs.

### DIFF
--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -117,7 +117,7 @@
   ([label state condition on-click themed?]
    [:div {:style    ($/flex-row)
           :on-click #(on-click condition)}
-    [:div {:style ($radio (= @state condition) themed?)}]
+    [:div {:style ($radio (= state condition) themed?)}]
     [:label {:style {:font-size ".8rem" :margin "4px .5rem 0 0"}} label]]))
 
 (defn check-box

--- a/src/cljs/pyregence/components/help.cljs
+++ b/src/cljs/pyregence/components/help.cljs
@@ -1,12 +1,13 @@
 (ns pyregence.components.help
-  (:require [pyregence.utils :as u]
+  (:require [pyregence.state :as !]
+            [pyregence.utils :as u]
             [pyregence.components.messaging :refer [set-message-box-content!]]))
 
 ;;; Help Dialogs
 
-(defn- get-help-dialog [dialog mobile?]
+(defn- get-help-dialog [dialog]
   (-> {:terrain {:title "3D Terrain Enabled"
-                 :body  (if mobile?
+                 :body  (if @!/mobile?
                           "You have enabled 3D Terrain. Use two fingers to tilt or rotate the map."
                           "You have enabled 3D Terrain. Click and drag using your right mouse button to tilt or rotate the map.")}}
       (get dialog)))
@@ -25,9 +26,9 @@
 
 (defn show-help!
   "Shows the help modal popup for the given dialog and device."
-  [dialog & [mobile? always-show]]
-  {:pre [(get-help-dialog dialog mobile?)]}
+  [dialog & [always-show]]
+  {:pre [(get-help-dialog dialog)]}
   (when (or always-show (not (seen-help? dialog)))
     (set-help-seen! dialog)
-    (set-message-box-content! (-> (get-help-dialog dialog mobile?)
+    (set-message-box-content! (-> (get-help-dialog dialog)
                                   (assoc :mode :close)))))

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -4,6 +4,7 @@
             [reagent.dom         :refer [render]]
             [clojure.core.async  :refer [go <!]]
             [clojure.string      :as str]
+            [pyregence.state     :as !]
             [pyregence.config    :as c]
             [pyregence.utils     :as u]
             [pyregence.geo-utils :as g]))
@@ -350,11 +351,11 @@
 (defn add-feature-highlight!
   "Adds events to highlight WFS features. Optionally can provide a function `click-fn`,
    which will be called on click as `(click-fn <feature-js-object> [lng lat])`"
-  [layer source mobile? & [click-fn]]
+  [layer source & [click-fn]]
   (remove-events! "mousemove" layer)
   (remove-events! "mouseleave" layer)
   (remove-events! "click" layer)
-  (when-not mobile?
+  (when-not @!/mobile?
     (add-event! "mouseenter"
                 (fn [e]
                   (when-let [feature (-> e (aget "features") (first))]
@@ -665,9 +666,11 @@
 
 (defn create-camera-layer!
   "Adds wildfire camera layer to the map."
-  [id data]
+  [id]
   (add-icon! "video-icon" "./images/video.png")
-  (let [new-source {id {:type "geojson" :data data :generateId true}}
+  (let [new-source {id {:type       "geojson" 
+                        :data       (clj->js @!/the-cameras)
+                        :generateId true}}
         new-layers [{:id       id
                      :source   id
                      :type     "symbol"

--- a/src/cljs/pyregence/components/messaging.cljs
+++ b/src/cljs/pyregence/components/messaging.cljs
@@ -3,6 +3,7 @@
             [reagent.core       :as r]
             [clojure.core.async :refer [chan go >! <! timeout]]
             [clojure.string     :as str]
+            [pyregence.state    :as !]
             [pyregence.styles   :as $]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -69,7 +70,7 @@
      :left            "1rem"
      :padding         ".5rem"
      :position        "fixed"
-     :width           "50%"
+     :width           (if @!/mobile? "90%" "50%")
      :z-index         "10000"}
     {:media {{:max-width "800px"}
              {:width "90%"}}}))
@@ -118,9 +119,9 @@
                                           "See console for complete list."))]))))
 (defn toast-message
   "Creates a toast message component."
-  [mobile?]
+  []
   (let [message (r/atom "")]
-    (fn [mobile?]
+    (fn []
       (let [message? (not (nil? @toast-message-text))]
         (when message? (reset! message @toast-message-text))
         [:div#toast-message {:class (<class $alert-box)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -1,13 +1,14 @@
 (ns pyregence.pages.near-term-forecast
   (:require [reagent.core :as r]
-            [reagent.dom :as rd]
-            [herb.core :refer [<class]]
+            [reagent.dom  :as rd]
+            [herb.core    :refer [<class]]
             [cognitect.transit :as t]
             [clojure.edn        :as edn]
             [clojure.spec.alpha :as s]
             [clojure.string     :as str]
             [clojure.core.async :refer [go <!]]
             [cljs.core.async.interop :refer-macros [<p!]]
+            [pyregence.state  :as !]
             [pyregence.styles :as $]
             [pyregence.utils  :as u]
             [pyregence.config :as c]
@@ -33,60 +34,34 @@
                                     :etc      (s/+ keyword?))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; State
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defonce animate?           (r/atom false))
-(defonce options            (r/atom {}))
-(defonce mobile?            (r/atom false))
-(defonce legend-list        (r/atom []))
-(defonce last-clicked-info  (r/atom []))
-(defonce show-utc?          (r/atom true))
-(defonce show-info?         (r/atom false))
-(defonce show-match-drop?   (r/atom false))
-(defonce show-camera?       (r/atom false))
-(defonce show-red-flag?     (r/atom false))
-(defonce show-fire-history? (r/atom false))
-(defonce active-opacity     (r/atom 100.0))
-(defonce capabilities       (r/atom []))
-(defonce *forecast          (r/atom nil))
-(defonce processed-params   (r/atom []))
-(defonce *params            (r/atom {}))
-(defonce param-layers       (r/atom []))
-(defonce *layer-idx         (r/atom 0))
-(defonce the-cameras        (r/atom nil))
-(defonce loading?           (r/atom true))
-(defonce terrain?           (r/atom false))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Data Processing Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn get-forecast-opt [key-name]
-  (get-in @capabilities [@*forecast key-name]))
+  (get-in @!/capabilities [@!/*forecast key-name]))
 
 (defn process-model-times! [model-times]
   (let [processed-times (into (u/reverse-sorted-map)
                               (map (fn [utc-time]
                                      [(keyword utc-time)
-                                      {:opt-label (u/time-zone-iso-date utc-time @show-utc?)
+                                      {:opt-label (u/time-zone-iso-date utc-time @!/show-utc?)
                                        :utc-time  utc-time ; TODO is utc-time redundant?
                                        :filter    utc-time}])
                                    model-times))]
-    (reset! processed-params
+    (reset! !/processed-params
             (assoc-in (get-forecast-opt :params)
                       [:model-init :options]
                       processed-times))
-    (swap! *params assoc-in [@*forecast :model-init] (ffirst processed-times))))
+    (swap! !/*params assoc-in [@!/*forecast :model-init] (ffirst processed-times))))
 
 (defn get-layers! [get-model-times?]
   (go
-    (let [params       (dissoc (get @*params @*forecast) (when get-model-times? :model-init))
+    (let [params       (dissoc (get @!/*params @!/*forecast) (when get-model-times? :model-init))
           selected-set (or (some (fn [[key {:keys [options]}]]
                                    (get-in options [(params key) :filter-set]))
-                                 @processed-params)
+                                 @!/processed-params)
                            (into #{(get-forecast-opt :filter)}
-                                 (->> @processed-params
+                                 (->> @!/processed-params
                                       (map (fn [[key {:keys [options]}]]
                                              (get-in options [(params key) :filter])))
                                       (remove nil?))))
@@ -94,13 +69,13 @@
                                                (:body (<! (u/call-clj-async! "get-layers"
                                                                              (pr-str selected-set)))))]
       (when model-times (process-model-times! model-times))
-      (reset! param-layers layers)
-      (swap! *layer-idx #(max 0 (min % (- (count @param-layers) 1))))
-      (when-not (seq @param-layers)
+      (reset! !/param-layers layers)
+      (swap! !/*layer-idx #(max 0 (min % (- (count @!/param-layers) 1))))
+      (when-not (seq @!/param-layers)
         (toast-message! "There are no layers available for the selected parameters. Please try another combination.")))))
 
 (defn current-layer []
-  (get @param-layers @*layer-idx))
+  (get @!/param-layers @!/*layer-idx))
 
 (defn get-current-layer-name []
   (:layer (current-layer) ""))
@@ -110,7 +85,7 @@
 
 (defn get-current-layer-full-time []
   (if-let [sim-time (:sim-time (current-layer))]
-    (u/time-zone-iso-date sim-time @show-utc?)
+    (u/time-zone-iso-date sim-time @!/show-utc?)
     ""))
 
 (defn get-current-layer-extent []
@@ -122,7 +97,7 @@
 (defn get-current-layer-key [key-name]
   (->> (get-forecast-opt :params)
        (map (fn [[key {:keys [options]}]]
-              (get-in options [(get-in @*params [@*forecast key]) key-name])))
+              (get-in options [(get-in @!/*params [@!/*forecast key]) key-name])))
        (remove nil?)
        (first)))
 
@@ -151,11 +126,11 @@
   []
   (let [center          (mb/get-center)
         zoom            (get (mb/get-zoom-info) 0)
-        selected-params (get @*params @*forecast)
+        selected-params (get @!/*params @!/*forecast)
         page-params     (merge selected-params
                                center
-                               {:forecast  @*forecast
-                                :layer-idx @*layer-idx
+                               {:forecast  @!/*forecast
+                                :layer-idx @!/*layer-idx
                                 :zoom      zoom})]
     (->> page-params
          (map (fn [[k v]] (cond
@@ -188,7 +163,7 @@
         (success-fn json-res)))))
 
 (defn process-legend! [json-res]
-  (reset! legend-list
+  (reset! !/legend-list
           (as-> json-res data
             (u/try-js-aget data "Legend" 0 "rules" 0 "symbolizers" 0 "Raster" "colormap" "entries")
             (js->clj data)
@@ -202,8 +177,8 @@
               (c/legend-url (str/replace layer #"tlines|liberty|pacificorp" "all"))))) ; TODO make a more generic way to do this.
 
 (defn- process-timeline-point-info! [json-res]
-  (reset! last-clicked-info [])
-  (reset! last-clicked-info
+  (reset! !/last-clicked-info [])
+  (reset! !/last-clicked-info
           (as-> json-res pi
             (u/try-js-aget pi "features")
             (map (fn [pi-layer]
@@ -215,16 +190,16 @@
             (mapv (fn [pi-layer {:keys [sim-time hour]}]
                     (let [js-time (u/js-date-from-string sim-time)]
                       (merge {:js-time js-time
-                              :date    (u/get-date-from-js js-time @show-utc?)
-                              :time    (u/get-time-from-js js-time @show-utc?)
+                              :date    (u/get-date-from-js js-time @!/show-utc?)
+                              :time    (u/get-time-from-js js-time @!/show-utc?)
                               :hour    hour}
                              pi-layer)))
                   pi
-                  @param-layers))))
+                  @!/param-layers))))
 
 (defn- process-single-point-info! [json-res]
-  (reset! last-clicked-info [])
-  (reset! last-clicked-info
+  (reset! !/last-clicked-info [])
+  (reset! !/last-clicked-info
           (-> json-res
               (u/try-js-aget "features")
               (first)
@@ -234,7 +209,7 @@
 
 ;; Use <! for synchronous behavior or leave it off for asynchronous behavior.
 (defn get-point-info! [point-info]
-  (reset! last-clicked-info nil)
+  (reset! !/last-clicked-info nil)
   (let [layer-name          (get-current-layer-name)
         layer-group         (get-current-layer-group)
         single?             (str/blank? layer-group)
@@ -247,24 +222,24 @@
                                   (if single? 1 1000))))))
 
 (defn select-layer! [new-layer]
-  (reset! *layer-idx new-layer)
-  (mb/swap-active-layer! (get-current-layer-name) (/ @active-opacity 100)))
+  (reset! !/*layer-idx new-layer)
+  (mb/swap-active-layer! (get-current-layer-name) (/ @!/active-opacity 100)))
 
 (defn select-layer-by-hour! [hour]
   (select-layer! (first (keep-indexed (fn [idx layer]
                                         (when (= hour (:hour layer)) idx))
-                                      @param-layers))))
+                                      @!/param-layers))))
 
 (defn clear-info! []
   (mb/clear-point!)
-  (reset! last-clicked-info [])
+  (reset! !/last-clicked-info [])
   (when (get-forecast-opt :block-info?)
-    (reset! show-info? false)))
+    (reset! !/show-info? false)))
 
 (declare select-param!) ;; FIXME: Look at ways to decouple callbacks
 
 (defn- forecast-exists? [fire-name]
-  (contains? (get-in @capabilities [:active-fire :params :fire-name :options])
+  (contains? (get-in @!/capabilities [:active-fire :params :fire-name :options])
              (keyword fire-name)))
 
 (defn- init-fire-popup! [feature _]
@@ -292,11 +267,11 @@
     (<! (get-layers! get-model-times?))
     (let [source   (get-current-layer-name)
           style-fn (get-current-layer-key :style-fn)]
-      (mb/reset-active-layer! source style-fn (/ @active-opacity 100))
+      (mb/reset-active-layer! source style-fn (/ @!/active-opacity 100))
       (mb/clear-popup!)
       (when (some? style-fn)
-        (mb/add-feature-highlight! "fire-active" "fire-active" @mobile? init-fire-popup!)
-        (mb/add-feature-highlight! "red-flag" "red-flag" @mobile? init-red-flag-popup!))
+        (mb/add-feature-highlight! "fire-active" "fire-active" init-fire-popup!)
+        (mb/add-feature-highlight! "red-flag" "red-flag" init-red-flag-popup!))
       (get-legend! source))
     (if clear?
       (clear-info!)
@@ -305,13 +280,13 @@
       (mb/zoom-to-extent! (get-current-layer-extent) (current-layer) max-zoom))))
 
 (defn select-param! [val & keys]
-  (swap! *params assoc-in (cons @*forecast keys) val)
-  (reset! legend-list [])
+  (swap! !/*params assoc-in (cons @!/*forecast keys) val)
+  (reset! !/legend-list [])
   (let [main-key (first keys)]
     (when (= main-key :fire-name)
       (select-layer! 0)
-      (swap! *params assoc-in (cons @*forecast [:burn-pct]) :50)
-      (reset! animate? false))
+      (swap! !/*params assoc-in (cons @!/*forecast [:burn-pct]) :50)
+      (reset! !/animate? false))
     (change-type! (not (#{:burn-pct :model-init} main-key)) ;; TODO: Make this a config
                   (get-current-layer-key :clear-point?)
                   (get-current-option-key main-key val :auto-zoom?)
@@ -319,9 +294,9 @@
 
 (defn select-forecast! [key]
   (go
-    (reset! legend-list [])
-    (reset! *forecast key)
-    (reset! processed-params (get-forecast-opt :params))
+    (reset! !/legend-list [])
+    (reset! !/*forecast key)
+    (reset! !/processed-params (get-forecast-opt :params))
     (<! (change-type! true
                       true
                       (get-any-level-key :auto-zoom?)
@@ -330,29 +305,29 @@
 (defn set-show-info! [show?]
   (if (and show? (get-forecast-opt :block-info?))
     (toast-message! "There is currently no point information available for this layer.")
-    (do (reset! show-info? show?)
+    (do (reset! !/show-info? show?)
         (clear-info!))))
 
 (defn select-time-zone! [utc?]
-  (reset! show-utc? utc?)
-  (swap! last-clicked-info #(mapv (fn [{:keys [js-time] :as layer}]
-                                    (assoc layer
-                                           :date (u/get-date-from-js js-time @show-utc?)
-                                           :time (u/get-time-from-js js-time @show-utc?)))
-                                  @last-clicked-info))
-  (swap! processed-params  #(update-in %
+  (reset! !/show-utc? utc?)
+  (swap! !/last-clicked-info #(mapv (fn [{:keys [js-time] :as layer}]
+                                      (assoc layer
+                                             :date (u/get-date-from-js js-time @!/show-utc?)
+                                             :time (u/get-time-from-js js-time @!/show-utc?)))
+                                    @!/last-clicked-info))
+  (swap! !/processed-params  #(update-in %
                                        [:model-init :options]
                                        (fn [options]
                                          (u/mapm (fn [[k {:keys [utc-time] :as v}]]
                                                    [k (assoc v
                                                              :opt-label
-                                                             (u/time-zone-iso-date utc-time @show-utc?))])
+                                                             (u/time-zone-iso-date utc-time @!/show-utc?))])
                                                  options)))))
 
 ;;; Capabilities
 
 (defn process-capabilities! [fire-names user-layers & [selected-options]]
-  (reset! capabilities
+  (reset! !/capabilities
           (-> (reduce (fn [acc {:keys [layer_path layer_config]}]
                         (let [layer-path   (edn/read-string layer_path)
                               layer-config (edn/read-string layer_config)]
@@ -360,20 +335,20 @@
                                    (s/valid? ::layer-config layer-config))
                             (assoc-in acc layer-path layer-config)
                             acc)))
-                      @options
+                      @!/options
                       user-layers)
               (update-in [:active-fire :params :fire-name :options]
                          merge
                          fire-names)))
-  (reset! *params (u/mapm
-                   (fn [[forecast _]]
-                     (let [params (get-in @capabilities [forecast :params])]
-                       [forecast (merge (u/mapm (fn [[k v]]
-                                                  [k (or (get-in selected-options [forecast k])
-                                                         (:default-option v)
-                                                         (ffirst (:options v)))])
-                                                params))]))
-                   @options)))
+  (reset! !/*params (u/mapm
+                     (fn [[forecast _]]
+                       (let [params (get-in @!/capabilities [forecast :params])]
+                         [forecast (merge (u/mapm (fn [[k v]]
+                                                    [k (or (get-in selected-options [forecast k])
+                                                           (:default-option v)
+                                                           (ffirst (:options v)))])
+                                                  params))]))
+                     @!/options)))
 
 (defn refresh-fire-names! [user-id]
   (go
@@ -381,7 +356,7 @@
       (<! fire-names)
       (:body fire-names)
       (edn/read-string fire-names)
-      (swap! capabilities update-in [:active-fire :params :fire-name :options] merge fire-names))))
+      (swap! !/capabilities update-in [:active-fire :params :fire-name :options] merge fire-names))))
 
 (defn- params->selected-options
   "Parses url query parameters to into the selected options"
@@ -398,17 +373,17 @@
           user-layers-chan (u/call-clj-async! "get-user-layers" user-id)
           fire-names-chan  (u/call-clj-async! "get-fire-names" user-id)
           fire-cameras     (u/call-clj-async! "get-cameras")]
-      (reset! options options-config)
-      (reset! *forecast (or (keyword forecast)
+      (reset! !/options options-config)
+      (reset! !/*forecast (or (keyword forecast)
                             (keyword (forecast-type @c/default-forecasts))))
-      (reset! *layer-idx (if layer-idx (js/parseInt layer-idx) 0))
+      (reset! !/*layer-idx (if layer-idx (js/parseInt layer-idx) 0))
       (mb/init-map! "map" layers (if (every? nil? [lng lat zoom]) {} {:center [lng lat] :zoom zoom}))
       (process-capabilities! (edn/read-string (:body (<! fire-names-chan)))
                              (edn/read-string (:body (<! user-layers-chan)))
-                             (params->selected-options @options @*forecast params))
-      (<! (select-forecast! @*forecast))
-      (reset! the-cameras (edn/read-string (:body (<! fire-cameras))))
-      (reset! loading? false))))
+                             (params->selected-options @!/options @!/*forecast params))
+      (<! (select-forecast! @!/*forecast))
+      (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras))))
+      (reset! !/loading? false))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; UI Styles
@@ -432,18 +407,18 @@
    :position "absolute"
    :width    "100%"})
 
-(defn $message-modal [mobile? loading?]
+(defn $message-modal [loading-message?]
   {:background-color "white"
    :border-radius    "3px"
    :display          "flex"
    :flex-direction   "column"
    :margin           (cond
-                       (and mobile? loading?) "10rem 4rem .5rem 4rem"
-                       mobile?                ".25rem"
+                       (and @!/mobile? loading-message?) "10rem 4rem .5rem 4rem"
+                       @!/mobile?                ".25rem"
                        :else                  "8rem auto")
    :overflow         "hidden"
-   :max-height       (if mobile? "calc(100% - .5rem)" "50%")
-   :width            (if mobile? "unset" "25rem")})
+   :max-height       (if @!/mobile? "calc(100% - .5rem)" "50%")
+   :width            (if @!/mobile? "unset" "25rem")})
 
 (defn $p-mb-cursor []
   (with-meta
@@ -471,63 +446,42 @@
       (fn []
         [:div {:style ($control-layer)}
          [mc/collapsible-panel
-          (get @*params @*forecast)
-          select-param!
-          active-opacity
-          @processed-params
-          @mobile?]
+          (get @!/*params @!/*forecast)
+          select-param!]
          (when (aget @my-box "height")
            [:<>
-            (when @show-info?
+            (when @!/show-info?
               [mc/information-tool
                get-point-info!
                @my-box
-               *layer-idx
                select-layer-by-hour!
                (get-current-layer-key :units)
                (get-current-layer-key :convert)
                (get-current-layer-hour)
-               @legend-list
-               @last-clicked-info
                #(set-show-info! false)])
-            (when @show-match-drop?
-              [mc/match-drop-tool @my-box #(reset! show-match-drop? false) refresh-fire-names! user-id])
-            (when @show-camera?
-              [mc/camera-tool @the-cameras @my-box @mobile? terrain? #(reset! show-camera? false)])])
+            (when @!/show-match-drop?
+              [mc/match-drop-tool @my-box #(reset! !/show-match-drop? false) refresh-fire-names! user-id])
+            (when @!/show-camera?
+              [mc/camera-tool @my-box #(reset! !/show-camera? false)])])
          [mc/legend-box
-          @legend-list
           (get-any-level-key :reverse-legend?)
-          @mobile?
           (get-any-level-key :time-slider?)
           (get-current-layer-key :units)]
          [mc/tool-bar
-          show-info?
-          show-match-drop?
-          show-camera?
-          show-red-flag?
-          show-fire-history?
           set-show-info!
-          @mobile?
           user-id]
-         [mc/scale-bar @mobile? (get-any-level-key :time-slider?)]
-         (when-not @mobile? [mc/mouse-lng-lat])
+         [mc/scale-bar (get-any-level-key :time-slider?)]
+         (when-not @!/mobile? [mc/mouse-lng-lat])
          [mc/zoom-bar
           (get-current-layer-extent)
           (current-layer)
-          @mobile?
           create-share-link
-          terrain?
           (get-any-level-key :time-slider?)]
          (when (get-any-level-key :time-slider?)
            [mc/time-slider
-            param-layers
-            *layer-idx
             (get-current-layer-full-time)
             select-layer!
-            show-utc?
-            select-time-zone!
-            animate?
-            @mobile?])])})))
+            select-time-zone!])])})))
 
 (defn pop-up []
   [:div#pin {:style ($/fixed-size "2rem")}
@@ -537,7 +491,7 @@
   (r/with-let [mouse-down? (r/atom false)
                cursor-fn   #(cond
                               @mouse-down?                       "grabbing"
-                              (or @show-info? @show-match-drop?) "crosshair" ; TODO get custom cursor image from Ryan
+                              (or @!/show-info? @!/show-match-drop?) "crosshair" ; TODO get custom cursor image from Ryan
                               :else                              "grab")]
     [:div#map {:class (<class $p-mb-cursor)
                :style {:height "100%" :position "absolute" :width "100%" :cursor (cursor-fn)}
@@ -547,14 +501,14 @@
 (defn theme-select []
   [:div {:style {:position "absolute" :left "3rem" :display "flex"}}
    [:label {:style {:margin "4px .5rem 0"}} "Theme:"]
-   [radio "Light" $/light? true  #(reset! $/light? %)]
-   [radio "Dark"  $/light? false #(reset! $/light? %)]])
+   [radio "Light" @$/light? true  #(reset! $/light? %)]
+   [radio "Dark"  @$/light? false #(reset! $/light? %)]])
 
 (defn message-modal []
   (r/with-let [show-me? (r/atom (not @c/dev-mode?))]
     (when @show-me?
       [:div#message-modal {:style ($/modal)}
-       [:div {:style ($message-modal @mobile? false)}
+       [:div {:style ($message-modal false)}
         [:div {:style {:background ($/color-picker :yellow)
                        :width      "100%"}}
          [:label {:style {:padding ".5rem 0 0 .5rem" :font-size "1.5rem"}}
@@ -600,7 +554,7 @@
 
 (defn loading-modal []
   [:div#message-modal {:style ($/modal)}
-   [:div {:style ($message-modal @mobile? true)}
+   [:div {:style ($message-modal true)}
     [:h3 {:style {:margin-bottom "0"
                   :padding       "1rem"
                   :text-align    "center"}}
@@ -613,7 +567,7 @@
       (fn [_]
         (let [update-fn (fn [& _]
                           (-> js/window (.scrollTo 0 0))
-                          (reset! mobile? (> 800.0 (.-innerWidth js/window)))
+                          (reset! !/mobile? (> 800.0 (.-innerWidth js/window)))
                           (reset! height  (str (- (.-innerHeight js/window)
                                                   (-> js/document
                                                       (.getElementById "header")
@@ -631,21 +585,21 @@
         [:div#near-term-forecast
          {:style ($/combine $/root {:height @height :padding 0 :position "relative"})}
          [message-box-modal]
-         (when @loading? [loading-modal])
+         (when @!/loading? [loading-modal])
          [message-modal]
          [:div {:style ($/combine $app-header {:background ($/color-picker :yellow)})}
-          (when-not @mobile? [theme-select])
+          (when-not @!/mobile? [theme-select])
           [:span {:style {:display "flex" :padding ".25rem 0"}}
            (doall (map (fn [[key {:keys [opt-label hover-text]}]]
                          ^{:key key}
                          [tool-tip-wrapper
                           hover-text
                           :top
-                          [:label {:style ($forecast-label (= @*forecast key))
+                          [:label {:style ($forecast-label (= @!/*forecast key))
                                    :on-click #(select-forecast! key)}
                            opt-label]])
-                       @capabilities))]
-          (when-not @mobile?
+                       @!/capabilities))]
+          (when-not @!/mobile?
             (if user-id
               [:span {:style {:position "absolute" :right "3rem" :display "flex"}}
                [:label {:style {:margin-right "1rem" :cursor "pointer"}

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -1,0 +1,51 @@
+(ns pyregence.state
+  (:require [reagent.core :as r]))
+
+; TODO: Add detailed docstrings to each of the state atoms.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Forecast/Layer State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce *forecast        (r/atom nil))
+(defonce *layer-idx       (r/atom 0))
+(defonce *params          (r/atom {}))
+(defonce active-opacity   (r/atom 100.0))
+(defonce capabilities     (r/atom []))
+(defonce options          (r/atom {}))
+(defonce param-layers     (r/atom []))
+(defonce processed-params (r/atom []))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Show/Hide State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce show-camera?       (r/atom false))
+(defonce show-fire-history? (r/atom false))
+(defonce show-info?         (r/atom false))
+(defonce show-match-drop?   (r/atom false))
+(defonce show-red-flag?     (r/atom false))
+(defonce show-utc?          (r/atom true))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Point Information State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce last-clicked-info (r/atom []))
+(defonce legend-list       (r/atom []))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Miscellaneous State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce animate?    (r/atom false))
+(defonce loading?    (r/atom true))
+(defonce mobile?     (r/atom false))
+(defonce terrain?    (r/atom false))
+(defonce the-cameras (r/atom nil))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; State Setters
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; TODO: Add in state setters here.


### PR DESCRIPTION
## Purpose
Moving global state into `state.cljs`. A WIP until all global state is moved over. Note that the one issue that seems to have been created by these changes so far is the following point information tool error: 
```
vega.inc.js:132 ERROR DOMException: Failed to execute 'addColorStop' on 'CanvasGradient': The value provided ('null') could not be parsed as a color.
    at gradient (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13314:22)
    at color (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13326:7)
    at stroke (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13351:29)
    at drawPath (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13456:24)
    at CanvasRenderer.<anonymous> (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13441:9)
    at CanvasRenderer.prototype$M.draw (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:15444:15)
    at http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13807:18
    at visit (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13402:7)
    at http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13806:7
    at visit (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13402:7)
```

## Related Issues
Closes PYR-637 

