### PR TITLE
PYR-647: Fixing addColorStop bug.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -952,7 +952,7 @@
                 (-> last-clicked-info (first) (:band) (< -50)))
             no-info
 
-            (not-empty last-clicked-info)
+            (and (not-empty last-clicked-info) (not-empty legend-list))
             [vega-information
              box-height
              box-width


### PR DESCRIPTION
## Purpose
Fixes the following bug: 
```
vega.inc.js:132 ERROR DOMException: Failed to execute 'addColorStop' on 'CanvasGradient': The value provided ('null') could not be parsed as a color.
    at gradient (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13314:22)
    at color (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13326:7)
    at stroke (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13351:29)
    at drawPath (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13456:24)
    at CanvasRenderer.<anonymous> (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13441:9)
    at CanvasRenderer.prototype$M.draw (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:15444:15)
    at http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13807:18
    at visit (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13402:7)
    at http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13806:7
    at visit (http://local.pyrecast.org:8080/cljs/cljsjs/development/vega.inc.js:13402:7)
```
This occurred because the legend-list atom is reset to `[]` every time the forecast changes, which meant that `(first legend-list)` inside of vega/create-stops returns `nil` and thus an error. To fix this, only render the `vega-information` when `last-clicked-info` and `legend-list` aren't empty.

## Related Issues
Closes PYR-647 

## Testing
With the console open, use the Point Information tool to select a point. Then, change to another Forecast Tab. The error message above should not show up in the console.

