### PR TITLE
PYR-652: Fix styling between sections on collapsible panel.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -317,7 +317,7 @@
   "A section component to differentiate content in the collapsible panel."
   [id body]
   [:section {:id    (str "section-" id)
-             :style {:padding "0.75rem 0.6rem"}}
+             :style {:padding "0.75rem 0.6rem 0 0.6rem"}}
    [:div {:style {:background-color ($/color-picker :header-color 0.6)
                   :border-radius "8px"
                   :box-shadow    "0px 0px 3px #bbbbbb"
@@ -347,6 +347,16 @@
             :on-change #(do (reset! active-opacity (u/input-int-value %))
                             (mb/set-opacity-by-title! "active" (/ @active-opacity 100.0)))}]])
 
+(defn- $collapsible-panel-body
+  []
+  (with-meta
+    {:display         "flex"
+     :flex-direction  "column"
+     :height          "calc(100% - 3.25rem)"
+     :justify-content "space-between"
+     :overflow-y      "auto"}
+    {:pseudo {:last-child {:padding-bottom "0.75rem"}}}))
+
 (defn collapsible-panel [*params select-param! active-opacity param-options mobile?]
   (let [*base-map        (r/atom c/base-map-default)
         select-base-map! (fn [id]
@@ -358,12 +368,7 @@
         [:div#collapsible-panel {:style ($collapsible-panel @show-panel? mobile?)}
          [collapsible-panel-toggle mobile?]
          [collapsible-panel-header]
-         [:div#collapsible-panel-body
-          {:style {:display         "flex"
-                   :flex-direction  "column"
-                   :height          "calc(100% - 3.25rem)"
-                   :justify-content "space-between"
-                   :overflow-y      "auto"}}
+         [:div#collapsible-panel-body {:class (<class $collapsible-panel-body)}
           [:div#section-wrapper
            [collapsible-panel-section
             "layer-selection"


### PR DESCRIPTION
## Purpose
Fixes extra padding between different sections on the collapsible panel by using a last-child pseudo tag.

## Related Issues
Closes PYR-652

## Screenshots
### Before

![Screenshot from 2021-11-09 10-21-54](https://user-images.githubusercontent.com/40574170/140982262-0a7ae0f0-960b-483d-adc2-899a4806077b.png)
![Screenshot from 2021-11-09 10-21-37](https://user-images.githubusercontent.com/40574170/140982260-c1884478-f4f2-43d8-8d2b-a4be06414935.png)

### After

![Screenshot from 2021-11-09 10-20-05](https://user-images.githubusercontent.com/40574170/140982231-74c5e635-0a2a-4d52-862a-4cb71b0f9a7a.png)
![Screenshot from 2021-11-09 10-20-18](https://user-images.githubusercontent.com/40574170/140982235-a800526b-272c-4fee-9910-061d7a619db3.png)

