### PR TITLE
PYR-659 Update WG4 layers.

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -91,7 +91,7 @@
         [_ parameters]    (str/split layer #"_geoTiff_")
         [_ model prob measure year] (re-matches #"([^_]+)_([^_]+)_AA_all_([^_]+)_mean_(\d+)" parameters)]
     {:workspace   workspace
-     :layer-group ""
+     :layer-group (str workspace ":" model "_" prob "_AA_all_" measure "_mean")
      :forecast    model
      :filter-set  #{workspace model prob measure "20210407_000000"}
      :model-init  "20210407_000000"
@@ -103,7 +103,7 @@
                                              "wms?SERVICE=WMS"
                                              "&VERSION=1.3.0"
                                              "&REQUEST=GetCapabilities"
-                                             (when (pos? (count workspace-name))
+                                             (when (some? workspace-name)
                                                (str "&NAMESPACE=" workspace-name)))))]
     (as-> xml-response xml
       (str/replace xml "\n" "")
@@ -135,7 +135,7 @@
                           (str/starts-with? full-name "fuels")
                           (merge-fn (split-fuels full-name))
 
-                          (str/starts-with? full-name "wg4_FireSim")
+                          (re-matches #"climate_FireSim.*_\d{4}" full-name)
                           (merge-fn (split-wg4-scenarios full-name))))))
                    (vec)))
             xml)

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -391,10 +391,11 @@
 
 (def long-term-forecast-options
   {:fire-scenarios {:opt-label       "Fire Scenarios"
-                    :filter          "wg4_FireSim"
+                    :filter          "climate_FireSim"
                     :hover-text      "Wildfire scenario projections for area burned with varied emissions and population scenarios."
                     :reverse-legend? true
-                    :block-info?     true
+                    :block-info?     false
+                    :time-slider?    true
                     :params          {:model      {:opt-label  "Global Climate Model"
                                                    :hover-text "Four climate models selected by the California's Climate Action Team as priority models for research contributing to California's Fourth Climate Change Assessment.\n
                                                                 Projected future climate from these four models can be described as producing:
@@ -446,7 +447,7 @@
    associated metadata for the loading term forecast.
 
    forecast-layer? - Layers corresponding to a forecast. Excludes layers such as fire-cameras."
-  {:wg4          {:forecast-layer? true}
+  {:climate      {:forecast-layer? true}
    :fire-cameras {:forecast-layer? false}
    :red-flag     {:forecast-layer? false}})
 


### PR DESCRIPTION
## Purpose
Updates the logic needed to parse the WG4 layers now that they exist on their own GeoServer.

## Related Issues
Closes PYR-659

## Testing
Changing `config.edn` to 
```clojure
 :geoserver         {:base-url "https://climate.pyregence.org/geoserver"}
```
and going to `/long-term-forecast` should display all of the long term forecast layers. Note that the underlays will not work.

## Screenshots
![Screenshot from 2021-12-03 14-15-45](https://user-images.githubusercontent.com/40574170/144680224-4abbb361-121d-4876-ae8e-ee1053aaeade.png)

