### PR TITLE
PYR-664 Update external remote api calls to take a map as a parameter.

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -176,8 +176,8 @@
 (defn set-all-capabilities!
   "Calls set-capabilities! on all GeoServer URLs provided in config.edn."
   []
-  (run! set-capabilities! (mapv #(into {:geoserver-key %})
-                                (keys (get-config :geoserver))))
+  (doseq [geoserver-key (keys (get-config :geoserver))]
+    (set-capabilities! {:geoserver-key geoserver-key}))
   (data-response (str (reduce + (map count (vals @layers)))
                       " layers added to capabilities.")))
 


### PR DESCRIPTION
## Purpose
Updates the two functions in `capabilities.clj` that are called externally to take in a map as a paramter.

`remove-workspace!` can now be called like:
```clojure
(remove-workspace! {:geoserver-key :pyrecast
                    :workspace-name "name-of-workspace"})
```

`set-capabilties!` can now be called like:
```clojure
(set-capabilties! {:geoserver-key :pyrecast
                   :workspace-name "name-of-workspace"})
```

## Related Issues
Closes PYR-664

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
All features should work as normal.

