### PR TITLE
Some small changes so that remove-workspace and set-capabilities can be called properly via the remote API.

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -147,7 +147,7 @@
 
 (defn remove-workspace! [{:strs [geoserver-key workspace-name]}]
   (swap! layers
-         update [(keyword geoserver-key)]
+         update (keyword geoserver-key)
                 #(filterv (fn [{:keys [workspace]}]
                             (not= workspace workspace-name)) %))
   (data-response (str workspace-name " removed.")))
@@ -156,8 +156,7 @@
   (data-response (mapcat #(map :filter-set (val %)) @layers)))
 
 (defn set-capabilities! [{:strs [geoserver-key workspace-name]}]
-  (let [geoserver-key  (keyword geoserver-key)
-        workspace-name (keyword workspace-name)]
+  (let [geoserver-key  (keyword geoserver-key)]
     (if (contains? (get-config :geoserver) geoserver-key)
       (try
         (let [stdout?    (= 0 (count @layers))
@@ -165,9 +164,9 @@
               message    (str (count new-layers) " layers added to capabilities.")]
           (if workspace-name
             (do
-              (remove-workspace! {"geoserver-key"  geoserver-key
+              (remove-workspace! {"geoserver-key"  (name geoserver-key)
                                   "workspace-name" workspace-name})
-              (swap! layers update [geoserver-key] concat new-layers))
+              (swap! layers update geoserver-key concat new-layers))
             (swap! layers assoc geoserver-key new-layers))
           (log message :force-stdout? stdout?)
           (data-response message))


### PR DESCRIPTION
## Purpose
`set-capabilities!` and `remove-workspace!` were unable to be called via the remote API since they were assuming the use of a Clojure keyword for the keys and values of the map passed in. Instead, the map needs to have a type of strings for both the keys and values.  

## Submission Checklist
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The following calls should work properly (note that you'll need to replace "xxxxx" with the proper auth-token).
`set-capabilities!`:
```bash
curl 'http://local.pyrecast.org:8080/clj/set-capabilities?auth-token=xxxxx' -d clj-args="[{\"geoserver-key\":\"pyrecast\"}]"
```
`remove-workspace!`:
```bash
curl 'http://local.pyrecast.org:8080/clj/remove-workspace?auth-token=xxxxx' -d clj-args="[{\"geoserver-key\":\"pyrecast\",\"workspace-name\":\"fire-detections_active-fires\"}]"
```
`set-all-capabilities!`:
```bash
curl 'http://local.pyrecast.org:8080/clj/set-all-capabilities?auth-token=xxxxx'
```


