### PR TITLE
Fixing the way the single point info refreshes.

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -215,7 +215,6 @@
 
 ;; Use <! for synchronous behavior or leave it off for asynchronous behavior.
 (defn get-point-info! [point-info]
-  (reset! !/last-clicked-info nil)
   (let [layer-name          (get-current-layer-name)
         layer-group         (get-current-layer-group)
         single?             (str/blank? layer-group)
@@ -296,6 +295,7 @@
 (defn select-param! [val & keys]
   (swap! !/*params assoc-in (cons @!/*forecast keys) val)
   (reset! !/legend-list [])
+  (reset! !/last-clicked-info nil)
   (let [main-key (first keys)]
     (when (= main-key :fire-name)
       (select-layer! 0)
@@ -309,6 +309,7 @@
 (defn select-forecast! [key]
   (go
     (reset! !/legend-list [])
+    (reset! !/last-clicked-info nil)
     (reset! !/*forecast key)
     (reset! !/processed-params (get-forecast-opt :params))
     (<! (change-type! true


### PR DESCRIPTION
## Purpose
Fixes the way the point info refreshes in the same way as I did for the legend in https://github.com/pyregence/pyregence/pull/588/

## Submission Checklist
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Go to the Fuels tab.
2. Click on a point using the point info tool.
3. Change the layer to another layer.
4. You shouldn't see an intermediate number/value popup (you can look on pyrecast.org for the current bug).


