### PR TITLE
PYR-704: Position the slider flush with the bottom

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -99,16 +99,17 @@
 ;; Time Slider
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn $time-slider []
-  {:align-items  "center"
-   :bottom       "1rem"
-   :display      "flex"
-   :left         "0"
-   :margin-left  "auto"
-   :margin-right "auto"
-   :padding      ".5rem"
-   :right        "0"
-   :width        (if @!/mobile? "20rem" "min-content")})
+(defn- $time-slider []
+  {:align-items   "center"
+   :border-radius "5px 5px 0 0"
+   :bottom        "0"
+   :display       "flex"
+   :left          "0"
+   :margin-left   "auto"
+   :margin-right  "auto"
+   :padding       ".5rem"
+   :right         "0"
+   :width         (if @!/mobile? "20rem" "min-content")})
 
 (defn time-slider [layer-full-time select-layer! select-time-zone!]
   (r/with-let [*speed          (r/atom 1)


### PR DESCRIPTION
## Closes [PYR-704](https://sig-gis.atlassian.net/browse/PYR-704)

## Purpose
To pull the time slider down so that it is flush with the bottom border, similar to how the collapsible side panel is flush with the left side of the screen.

Also, followed https://guide.clojure.style/#prefer-docstrings and added a docstring to the `$time-slider` function to remove a lint warning near the position change

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [X] Code passes linter rules (`clj-kondo --lint src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Screenshots
![Screenshot from 2022-02-12 07-19-29](https://user-images.githubusercontent.com/1130619/153717151-230524bd-2341-4c19-a22d-1c5680f964df.png)

