### PR TITLE
PYR-686: Add "frosted glass" look to all map tools

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -278,8 +278,7 @@
               underlays))]])}))
 
 (defn- $collapsible-button []
-  {:background-color           ($/color-picker :bg-color)
-   :border-bottom-right-radius "5px"
+  {:border-bottom-right-radius "5px"
    :border-color               ($/color-picker :transparent)
    :border-style               "solid"
    :border-top-right-radius    "5px"
@@ -293,7 +292,7 @@
 
 (defn- collapsible-button []
   [:button
-   {:style    ($collapsible-button)
+   {:style    ($/combine $/tool-background $collapsible-button)
     :on-click #(swap! show-panel? not)}
    [:div {:style {:align-items     "center"
                   :display         "flex"

--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -29,7 +29,7 @@
    (case color
      :bg-color         (if @light?
                          (color-picker :white)
-                         (color-picker :dark-gray 0.9))
+                         (color-picker :dark-gray alpha))
      :bg-hover-color   (if @light?
                          (color-picker :brown)
                          (color-picker :white))
@@ -363,8 +363,8 @@
 (defn tool-background
   "A shortcut for applying common background attributes for tool styling."
   []
-  {:backdrop-filter "blur(3px)"
-   :background-color (color-picker :bg-color)})
+  {:backdrop-filter  "blur(3px)"
+   :background-color (color-picker :bg-color 0.85)})
 
 (defn tool
   "A shortcut for tool styling (eg. the legend or time slider)."


### PR DESCRIPTION
## Closes [PYR-686](https://sig-gis.atlassian.net/browse/PYR-686)

## Purpose
Find a styling method, `backdrop-filter`, for applying a "frosted glass" treatment to the backgrounds of all map tool controls. Isolate and move inline background properties applied to tool controls, and cull them into a new styling function `tool-background`: that can be composed into the the `tool` styling function and freely applied to the Collapsible Panel.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Toolbars

## Testing
Navigate to pyrecast and select the "Risk" tab. Run map text beneath the controls and observe the "frost".

## Screenshots, Etc.
![frosted-glass-screenshot](https://user-images.githubusercontent.com/1130619/154373061-dad92157-c47c-49b8-a83e-c72dea17a26c.png)


