### PR TITLE
PYR-711 PYR-723 Read in PSPS layers in config.cljs and query the style in the GetTile request.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -445,7 +445,7 @@
 (defn- wms-source [layer-name geoserver-key style]
   {:type     "raster"
    :tileSize 256
-   :tiles    [(c/wms-layer-url layer-name geoserver-key (or style ""))]})
+   :tiles    [(c/wms-layer-url layer-name geoserver-key style)]})
 
 (defn- wms-layer [layer-name source-name opacity visible? & [z-index]]
   {:id       layer-name

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -747,7 +747,7 @@
         "&SERVICE=WMTS"
         "&VERSION=1.0.0"
         "&LAYER=" layer
-        "&STYLE=" style
+        "&STYLE=" (or style "")
         "&FORMAT=image/png"
         "&TILEMATRIX=EPSG:900913:{z}"
         "&TILEMATRIXSET=EPSG:900913"
@@ -760,7 +760,7 @@
           "&SERVICE=WMTS"
           "&VERSION=1.0.0"
           "&LAYER=" layer
-          "&STYLE=" style
+          "&STYLE=" (or style "")
           "&FORMAT=image/png"
           "&TILEMATRIX=EPSG:900913:{z}"
           "&TILEMATRIXSET=EPSG:900913"
@@ -775,7 +775,7 @@
           "&WIDTH=256"
           "&HEIGHT=256"
           "&CRS=EPSG%3A3857"
-          "&STYLES=" style
+          "&STYLES=" (or style "")
           "&FORMAT_OPTIONS=dpi%3A113"
           "&BBOX={bbox-epsg-3857}"
           "&LAYERS=" layer

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -125,9 +125,8 @@
 (defn- get-psps-layer-style
   "Returns the name of the CSS style for a PSPS layer and an empty string."
   []
-  (if (= @!/*forecast :psps-zonal)
-      (str (name (get-in @!/*params [:psps-zonal :stat])) "-css")
-      ""))
+  (when (= @!/*forecast :psps-zonal)
+      (str (name (get-in @!/*params [:psps-zonal :stat])) "-poly-css")))
 
 (defn create-share-link
   "Generates a link with forecast and parameters encoded in a URL"


### PR DESCRIPTION
## Purpose
Configures the `:psps-zonal` entry in `config.cljs` properly for the four statistics included with the test data.  Allows the style portion of the GetTile request for PSPS layers to be changed when the Zonal Statistic dropdown changes.

## Related Issues
Closes PYR-711 PYR-723

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
All layers should work normally when the `:pyrecast` portion of the `:geoserver` `config.edn` points to "https://data.pyregence.org/geoserver". For me (and Joel) when pointing `:pyrecast` to  "http://localhost:8090/geoserver", the PSPS zonal layers should load and the styling on them should change when changing the Zonal Statistic dropdown.

## Screenshots
![Screenshot from 2022-02-23 17-56-06](https://user-images.githubusercontent.com/40574170/155432695-6d55aca7-0866-4537-8929-becd33b9fb29.png)
![Screenshot from 2022-02-23 17-56-17](https://user-images.githubusercontent.com/40574170/155432697-8ade247d-30f7-4078-8086-52083c8f5818.png)

