### PR TITLE
PYR-722: Frosting messed up the tooltips. Revert change.

### DIFF
--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -21,9 +21,9 @@
 
 (defn- $radio [checked?]
   (merge
-   (when checked? {:background-color ($/color-picker :black 0.6)})
+   (when checked? {:background-color ($/color-picker :border-color 0.6)})
    {:border        "2px solid"
-    :border-color  ($/color-picker :black)
+    :border-color  ($/color-picker :border-color)
     :border-radius "100%"
     :height        "1rem"
     :margin-right  ".4rem"

--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -280,7 +280,8 @@
               underlays))]])}))
 
 (defn- $collapsible-button []
-  {:border-bottom-right-radius "5px"
+  {:background-color           ($/color-picker :bg-color)
+   :border-bottom-right-radius "5px"
    :border-color               ($/color-picker :transparent)
    :border-style               "solid"
    :border-top-right-radius    "5px"
@@ -294,7 +295,7 @@
 
 (defn- collapsible-button []
   [:button
-   {:style    ($/combine $/tool-background $collapsible-button)
+   {:style    ($collapsible-button)
     :on-click #(swap! show-panel? not)}
    [:div {:style {:align-items     "center"
                   :display         "flex"
@@ -1064,8 +1065,8 @@
 (defn- $mouse-lng-lat []
   {:background-color ($/color-picker :bg-color)
    :bottom           "84px"
-   :padding         ".2rem"
    :left             "auto"
+   :padding          ".2rem"
    :right            "70px"})
 
 (defn- $mouse-lng-lat-inner []

--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -25,7 +25,7 @@
    (color-picker color 1))
   ([color alpha]
    (case color
-     :bg-color         (color-picker :dark-gray alpha)
+     :bg-color         (color-picker :dark-gray 0.9)
      :bg-hover-color   (color-picker :white)
      :border-color     (color-picker :white alpha)
      :font-color       "rgb(235, 235, 235)"


### PR DESCRIPTION
## Closes [PYR-722](https://sig-gis.atlassian.net/browse/PYR-722)

## Purpose
While `background-filter: blur(5px)` specifically added exactly the frosted background that we were going for, it messes up the positioning of children elements: in this case the tooltips.  The fix, for the moment, is to revert the change.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Tooltips

## Testing
Navigate to the Pyrecast landing page. Trigger the tooltips on the collapsible panel and observe that they display as expected.

## Screenshots 
  _Please disregard the heavy yellow tinting_
#### before:
![image](https://user-images.githubusercontent.com/1130619/156487789-04f07245-b5a0-49e3-a155-c6cf6ec3d6dd.png)

#### after:
![image](https://user-images.githubusercontent.com/1130619/156487547-eb85dbc3-ca51-4f3f-b86a-e890256bb228.png)
