### PR TITLE
PYR-728 Add remaining statistics and their associated styles.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -402,40 +402,66 @@
                                                                   [:strong "Fire Volume"]
                                                                   " - Modeled fire volume (fire area in acres multiplied by flame length in feet) by ignition location and time of ignition."]
                                                      :options    (array-map
-                                                                  :ws-max       {:opt-label "Max sustained wind speed"
-                                                                                 :filter    "nve"
+                                                                  :h-ws-l       {:opt-label "Min sustained wind speed"
+                                                                                 :filter    "deenergization-zones"
                                                                                  :units     "mph"
-                                                                                 :info-key  "WS_MAX"}
-                                                                  :ws-avg       {:opt-label "Avg sustained wind speed"
-                                                                                 :filter    "nve"
+                                                                                 :info-key  "h_ws_l"}
+                                                                  :h-ws-a       {:opt-label "Avg sustained wind speed"
+                                                                                 :filter    "deenergization-zones"
                                                                                  :units     "mph"
-                                                                                 :info-key  "WS_AVG"}
-                                                                  :wg-max       {:opt-label "Max wind gust"
-                                                                                 :filter    "nve"
+                                                                                 :info-key  "h_ws_a"}
+                                                                  :h-ws-h       {:opt-label "Max sustained wind speed"
+                                                                                 :filter    "deenergization-zones"
                                                                                  :units     "mph"
-                                                                                 :info-key  "WG_MAX"}
-                                                                  :wg-avg       {:opt-label "Avg wind gust"
-                                                                                 :filter    "nve"
+                                                                                 :info-key  "h_ws_h"}
+                                                                  :h-wg-l       {:opt-label "Min wind gust"
+                                                                                 :filter    "deenergization-zones"
                                                                                  :units     "mph"
-                                                                                 :info-key  "WG_AVG"})}
-                                                                  ; :hdw          {:opt-label "Hot-Dry-Windy Index (hPa*m/s)"
-                                                                  ;                :filter    "nve"
-                                                                  ;                :units     "hPa*m/s"}
-                                                                  ; :ffwi         {:opt-label "Fosberg Fire Weather Index"
-                                                                  ;                :filter    "nve"
-                                                                  ;                :units     ""}
-                                                                  ; :times-burned {:opt-label "Relative burn probability"
-                                                                  ;                :filter    "nve"
-                                                                  ;                :units     "Times"}
-                                                                  ; :impacted     {:opt-label "Impacted structures"
-                                                                  ;                :filter    "nve"
-                                                                  ;                :units     "Structures"}
-                                                                  ; :fire-area    {:opt-label "Fire area"
-                                                                  ;                :filter    "nve"
-                                                                  ;                :units     "Acres"}
-                                                                  ; :fire-volume  {:opt-label "Fire volume"
-                                                                  ;                :filter    "nve"
-                                                                  ;                :units     "Acre-ft"})}
+                                                                                 :info-key  "h_wg_l"}
+                                                                  :h-wg-a       {:opt-label "Avg wind gust"
+                                                                                 :filter    "deenergization-zones"
+                                                                                 :units     "mph"
+                                                                                 :info-key  "h_wg_a"}
+                                                                  :h-wg-h       {:opt-label "Max wind gust"
+                                                                                 :filter    "deenergization-zones"
+                                                                                 :units     "mph"
+                                                                                 :info-key  "h_wg_h"}
+                                                                  :l-area-l     {:opt-label "Min fire area"
+                                                                                 :filter    "deenergization-zones"
+                                                                                 :units     "Acres"
+                                                                                 :info-key  "l_area_l"}
+                                                                  :l-area-a     {:opt-label "Avg firea area"
+                                                                                 :filter    "deenergization-zones"
+                                                                                 :units     "Acres"
+                                                                                 :info-key  "l_area_a"}
+                                                                  :l-area-h     {:opt-label "Max fire area"
+                                                                                 :filter    "deenergization-zones"
+                                                                                 :units     "Acres"
+                                                                                 :info-key  "l_area_h"}
+                                                                  :l-str-l     {:opt-label "Min impacted structures"
+                                                                                :filter    "deenergization-zones"
+                                                                                :units     "Structures"
+                                                                                :info-key  "l_str_l"}
+                                                                  :l-str-a     {:opt-label "Avg impacted structures"
+                                                                                :filter    "deenergization-zones"
+                                                                                :units     "Structures"
+                                                                                :info-key  "l_str_a"}
+                                                                  :l-str-h     {:opt-label "Max impacted structures"
+                                                                                :filter    "deenergization-zones"
+                                                                                :units     "Structures"
+                                                                                :info-key  "l_str_h"}
+                                                                  :l-vol-l     {:opt-label "Min fire volume"
+                                                                                :filter    "deenergization-zones"
+                                                                                :units     "Acre-ft"
+                                                                                :info-key  "l_vol_l"}
+                                                                  :l-vol-a     {:opt-label "Avg fire volume"
+                                                                                :filter    "deenergization-zones"
+                                                                                :units     "Acre-ft"
+                                                                                :info-key  "l_vol_a"}
+                                                                  :l-vol-h     {:opt-label "Max fire volume"
+                                                                                :filter    "deenergization-zones"
+                                                                                :units     "Acre-ft"
+                                                                                :info-key  "l_vol_h"})}
                                         :model-init {:opt-label  "Forecast Start Time"
                                                      :hover-text "Start time for forecast cycle, new data comes every 6 hours."
                                                      :options    {:loading {:opt-label "Loading..."}}}}}})
@@ -712,14 +738,15 @@
 
 (defn legend-url
   "Generates a URL for the legend given a layer."
-  [layer geoserver-key]
+  [layer geoserver-key style]
   (str (wms-url geoserver-key)
        "?SERVICE=WMS"
        "&EXCEPTIONS=application/json"
        "&VERSION=1.3.0"
        "&REQUEST=GetLegendGraphic"
        "&FORMAT=application/json"
-       "&LAYER=" layer))
+       "&LAYER=" layer
+       "&STYLE=" (or style "")))
 
 (defn point-info-url
   "Generates a URL for the point information."

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -214,7 +214,8 @@
   (when (u/has-data? layer)
     (get-data #(wrap-wms-errors "legend" % process-legend!)
               (c/legend-url (str/replace layer #"tlines|liberty|pacificorp" "all") ; TODO make a more generic way to do this.
-                            @!/geoserver-key))))
+                            @!/geoserver-key
+                            (get-psps-layer-style)))))
 
 (defn- process-timeline-point-info!
   "Resets the !/last-clicked-info atom according the the JSON resulting from a


### PR DESCRIPTION
## Purpose
Before working on this PR, I added a number of layers from the new test data from Chris to my local GeoServer. I also locally added a number of different GeoServer CSS styles for the new columns. 

This PR fixes an issue where the legend didn't query the selected style and adds in the new statistics/styles to `config.cljs`. 

The next step is to split out the `min`, `avg`, and `max` statistics into a new input box. 

## Related Issues
Closes PYR-728

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The layers should load properly and the point info and legend should work for each layer.

## Screenshots
![Screenshot from 2022-03-04 14-29-39](https://user-images.githubusercontent.com/40574170/156842795-78b41671-92bd-4a59-8c09-ab79f85be5b2.png)

![Screenshot from 2022-03-04 14-29-36](https://user-images.githubusercontent.com/40574170/156842766-9b4b40cb-6760-420f-a566-4e5e4c1387bc.png)

Note that this specific layer didn't have any point info for the ELMFIRE statistics since ELMFIRE doesn't produce any statistics for forecast hours 0-6. This is to show that my `nodata` `fill-opacity: 0` styling is working. 
![Screenshot from 2022-03-04 14-29-45](https://user-images.githubusercontent.com/40574170/156842840-b7b0d2bf-21b6-4f90-8a15-b4a76bc699df.png)

