### PR TITLE
PYR-733 Make the point info tool more robust by getting rid of nodata points from Vega graphs.

### DIFF
--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -39,13 +39,7 @@
      :height   "container"
      :autosize {:type "fit" :resize true}
      :padding  {:left "16" :top "16" :right "16" :bottom "16"}
-     :data     {:values (or (map (fn [entry]
-                                   (let [band-val (:band entry)]
-                                     (assoc entry :band (if (contains? @!/no-data-quantities (str band-val))
-                                                          nil ; this removes any nodata point from the graph
-                                                          band-val))))
-                                @!/last-clicked-info)
-                            [])}
+     :data     {:values (u/replace-no-data-nil @!/last-clicked-info @!/no-data-quantities)}
      :layer    [{:encoding {:x {:field "hour" :type "quantitative" :title "Hour"}
                             :y {:field "band" :type "quantitative" :title units}
                             :tooltip [{:field "band" :title units  :type "nominal"}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -224,18 +224,12 @@
    Also populates the no-data-quantities atom with all quantities associated
    with `nodata` points."
   [json-res]
-  (reset! !/legend-list
-          (as-> json-res %
-            (if (get-any-level-key :multi-param-layers?)
-              (process-multiparam-layer-legend %)
-              (process-raster-colormap-legend %))
-            (remove (fn [leg] (nil? (get leg "label"))) %)
-            (doall %)))
-  (reset! !/no-data-quantities
-          (into #{}
-                (for [entry @pyregence.state/legend-list
-                      :when (= (get entry "label") "nodata")]
-                  (get entry "quantity")))))
+  (!/set-state-legend-list! (as-> json-res %
+                              (if (get-any-level-key :multi-param-layers?)
+                                (process-multiparam-layer-legend %)
+                                (process-raster-colormap-legend %))
+                              (remove (fn [leg] (nil? (get leg "label"))) %)
+                              (doall %))))
 
 ;; Use <! for synchronous behavior or leave it off for asynchronous behavior.
 (defn- get-legend!
@@ -395,7 +389,7 @@
 
 (defn select-param! [val & keys]
   (swap! !/*params assoc-in (cons @!/*forecast keys) val)
-  (reset! !/legend-list [])
+  (!/set-state-legend-list! [])
   (reset! !/last-clicked-info nil)
   (let [main-key (first keys)]
     (when (= main-key :fire-name)
@@ -409,7 +403,7 @@
 
 (defn select-forecast! [key]
   (go
-    (reset! !/legend-list [])
+    (!/set-state-legend-list! [])
     (reset! !/last-clicked-info nil)
     (reset! !/*forecast key)
     (reset! !/processed-params (get-forecast-opt :params))

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -32,7 +32,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defonce last-clicked-info   (r/atom []))
-(defonce no-data-quantities 
+(defonce no-data-quantities
   ^{:doc "A set containing all of the quantities associated with `nodata` points."}
   (r/atom #{}))
 (defonce legend-list         (r/atom []))
@@ -52,4 +52,14 @@
 ;; State Setters
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; TODO: Add in state setters here.
+(defn set-state-legend-list!
+  "A function to set the state of the legend-list atom and all other dependent atoms."
+  [new-legend-list]
+  (reset! legend-list new-legend-list)
+  (reset! no-data-quantities
+          (into #{}
+                (for [entry @legend-list
+                      :when (= (get entry "label") "nodata")]
+                  (get entry "quantity")))))
+
+; TODO: Add in more state setters here.

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -585,3 +585,14 @@
   (remove (fn [leg]
             (= "nodata" (get leg "label")))
           legend-list))
+
+(defn replace-no-data-nil
+  "Replaces any nodata 'band' entries from the provided last-clicked-info list
+   with nil."
+  [last-clicked-info no-data-quantities]
+  (map (fn [entry]
+        (let [band-val (:band entry)]
+          (assoc entry :band (if (contains? no-data-quantities (str band-val))
+                               nil
+                               band-val))))
+       last-clicked-info))


### PR DESCRIPTION
## Purpose
This PR introduces a new `no-data-quantities` atom. This atom contains all of the quantities/values that are associated with `nodata` points for the current `legend-list`. Note that this is possible because of recent change where `nodata` entries in the `legend-list` are not immediately filtered out. This atom can then be used to determine if the `last-clicked-info` (at a certain timestep) is a `nodata` point.

Previously, all of the `nodata` points were being displayed as a part of the Vega graph. A good example of this is for the Relative burn probability Human-caused ignitions Risk forecasts. The `nodata` points for this forecast are 0 and 1, however, if you display the Vega graph for this forecast you can see many points at 0 or 1. For other forecasts (such as the new PSPS forecast) where the `nodata` value is `-9999`, these points' inclusion heavily skewed the graph. Recall that certain PSPS statistics are only available at certain hours of a PSPS forecast, making it necessary to be able to still view a Vega graph where some points are `nodata`. This PR adds functionality such that any `nodata` point in a forecast simply are omitted from the Vega graph but any other points are still visible (see the screenshots below). 

## Related Issues
Closes PYR-733

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The point information tool should work as expected. When clicking on a forecast that has some `nodata` points, those points should not be visible on the graph. When going to the timestep that is associated with that `nodata` point, the "No point information" message should replace the graph on the point info tool (see screenshots below).

## Screenshots
This is what happens when you're at a timestep that has a `nodata` point:
![Screenshot from 2022-03-09 22-22-12](https://user-images.githubusercontent.com/40574170/157603607-766bbf9f-fda9-4dcd-88ae-4dde5c7f3063.png)
And then what happens when you go to a timestep that does have a point:
![Screenshot from 2022-03-09 22-22-24](https://user-images.githubusercontent.com/40574170/157603613-b9a5b2ee-2290-400d-ab08-0b1aa76d420e.png)
Let me know what you think about this UI. Another option for when you're on a time step with a `nodata` point would be to still show the graph, but add some code so that the div underneath the Vega graph says "This point does not have any information." instead of the whole point info window saying "This point does not have any information." You can check out the Risk tab for places where `nodata` points are common within a forecast.

---

This is what the Relative burn probability Human-caused ignitions Risk forecast looks like when you filter out all of the `nodata` points from the graph:
![Screenshot from 2022-03-09 22-30-04](https://user-images.githubusercontent.com/40574170/157603637-bffbe553-4faf-4b75-9bd6-1e3a1d92aea3.png)

