### PR TITLE
PYR-719: Add conditional PSPS tab visibility

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -396,7 +396,7 @@
                   :filter              "psps-zonal"
                   :geoserver-key       :psps
                   :underlays           (merge common-underlays near-term-forecast-underlays)
-                  :allowed-orgs        5
+                  :allowed-org         5
                   :reverse-legend?     true
                   :time-slider?        true
                   :multi-param-layers? true

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -32,6 +32,7 @@
                              (s/cat :forecast #{:fire-risk :active-fire :fire-weather}
                                     :params   #(= % :params)
                                     :etc      (s/+ keyword?))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -490,9 +491,8 @@
       (process-capabilities! (edn/read-string (:body (<! fire-names-chan)))
                              (edn/read-string (:body (<! user-layers-chan)))
                              (params->selected-options @!/options @!/*forecast params))
-
       (<! (select-forecast! @!/*forecast))
-      (reset! !/*user-org-list (edn/read-string (:body (<! (u/call-clj-async! "get-org-list" user-id)))))
+      (reset! !/user-org-list (edn/read-string (:body (<! (u/call-clj-async! "get-org-list" user-id)))))
       (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras))))
       (reset! !/loading? false))))
 
@@ -695,12 +695,11 @@
          [message-modal]
          [:div {:style ($/combine $app-header {:background ($/color-picker :yellow)})}
           [:span {:style {:display "flex" :padding ".25rem 0"}}
-           (doall (map (fn [[key {:keys [opt-label hover-text allowed-orgs]}]]
-                         (when (or (nil? allowed-orgs)
-                                   (and (some? allowed-orgs)
-                                        (some (fn [{org-id :opt-id}]
-                                                (= org-id allowed-orgs))
-                                              @!/*user-org-list)))
+           (doall (map (fn [[key {:keys [opt-label hover-text allowed-org]}]]
+                         (when (or (nil? allowed-org)
+                                   (some (fn [{org-id :opt-id}]
+                                           (= org-id allowed-org))
+                                         @!/user-org-list))
                            ^{:key key}
                            [tool-tip-wrapper
                             hover-text

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -42,7 +42,7 @@
 ;; Miscellaneous State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defonce *user-org-list
+(defonce user-org-list
   ^{:doc "For the currently logged in user, stores a list of all of the
           organizations that they belong to."}
   (r/atom []))


### PR DESCRIPTION
## Closes [PYR-719](https://sig-gis.atlassian.net/browse/PYR-719)

## Purpose
The purpose of this ticket is to restrict the visibility of the PSPS tab to registered users of the NV Energy organization.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Near Term Forecast Tabs

## Testing
#### Test that the PSPS tab is hidden when the PSPS tab restriction exists and the user has not logged in.
Clear your cache and restart Pyrecast.
When not logged in, the PSPS tab is hidden.
![image](https://user-images.githubusercontent.com/1130619/157747991-e1d6620c-02e7-4507-a5e4-391457ae7efd.png)

#### Test that the PSPS tab is hidden to logged-in users that are not members of the NV Energy organization
To test this feature, add two test users to your local database.
Add a user that is "registerd" with the NV organization and another that is not.
Open up your local Pyrecast and verity that the PSPS tab is visible when logged in as NV Energy member
and hidden when logged in as the user that is not a member
![image](https://user-images.githubusercontent.com/1130619/157748480-292213c3-69a6-4924-8a68-cc9412149b72.png)
