### PR TITLE
PYR-729: Disable a model if an unsupported statistic is already selected

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -92,8 +92,9 @@
                                                                        :filter    "cfo-2020"}
                                                        :ca-fuelscapes {:opt-label "2021 CA fuelscape"
                                                                        :filter    "ca-fuelscapes"}
-                                                       :cec           {:opt-label "CA Ecosystem Climate Solutions"
-                                                                       :filter    "cec"}}}
+                                                       :cec           {:opt-label    "CA Ecosystem Climate Solutions"
+                                                                       :filter       "cec"
+                                                                       :disabled-for #{:asp :slp :dem :cc :ch :cbh :cbd}}}}
                                   :layer {:opt-label  "Layer"
                                           :hover-text [:p {:style {:margin-bottom "0"}}
                                                        "Geospatial surface and canopy fuel inputs, forecasted ember ignition probability and head fire spread rate & flame length."


### PR DESCRIPTION
## Closes [PYR-729](https://sig-gis.atlassian.net/browse/PYR-729)

## Purpose
To disable models from selection, if an unsupported statistic is currently selected.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Layer Selection

## Testing
1. Select the "Fuels" tab
2. Select the "Source" dropdown and verify that
   - "LANDFIRE 2.0.0" is the default selected model
   - The CECS model is enabled and available for selection
3. Open the layer dropdown and select "Crown Bulk Density"
4. If you now open the source dropdown again, the CECS model should be disabled.

## Screenshots, Etc.
![image](https://user-images.githubusercontent.com/1130619/157985325-11c3ddac-bc43-4fc8-b8af-d73755b1f9b5.png)
