### PR TITLE
PYR-725 PYR-717 Add ignition pattern data locally and hook it up to the risk tab

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -272,11 +272,14 @@
                                                               [:br]
                                                               [:strong "Transmission Lines"]
                                                               " - Fires ignited in close proximity to overhead electrical transmission lines."]
-                                                 :options    {:all        {:opt-label    "Human-caused ignitions"
-                                                                           :filter       "all"}
-                                                              :tlines     {:opt-label    "Transmission lines"
-                                                                           :filter       "tlines"
-                                                                           :clear-point? true}}}
+                                                 :options    {:all    {:opt-label "Human-caused ignitions"
+                                                                       :filter    "all"}
+                                                              :tlines {:opt-label "Transmission lines"
+                                                                       :filter    "tlines"
+                                                                       :clear-point? true}
+                                                              :nve    {:opt-label     "NV Energy overhead lines"
+                                                                       :filter        "nve"
+                                                                       :geoserver-key :psps}}}
                                     :fuel       {:opt-label  "Fuel"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Source of surface and canopy fuel inputs:"


### PR DESCRIPTION


## Purpose
Adds the NVE ignition pattern layers locally and hooks them up to the Risk tab. Note that I was also able to restrict these layers to only NVE accounts using the SQL attached below, but I am waiting to make a PR with a changefile for this SQL update until the point info is working for these layers. This is because I may have to add additional arguments to the `:nve` key to parse the legend differently for these layers since they are SHP files. 

The changefile will simply be something like:
```sql
INSERT INTO organization_layers
    (organization_rid, layer_path, layer_config)
VALUES
    (5, '[:fire-risk :params :pattern :options :nve]', '{:opt-label "NV Energy overhead lines", :filter "nve", :geoserver-key :psps}');
```

## Related Issues
Closes PYR-726 PYR-717

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
There should be a NVE ignition pattern on the risk tab and the layers should load properly. Note that the point info has not been fixed for these layers and is coming in a future ticket.

## Screenshots
![Screenshot from 2022-03-15 09-03-39](https://user-images.githubusercontent.com/40574170/158504137-0a5ee3f3-39b4-4ea4-988c-2dbea11e9cb9.png)

