### PR TITLE
PYR-744 Add US transmission lines as an underlay.

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -159,7 +159,7 @@
                           (merge-fn (split-active-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)
-                              (re-matches #"fire-detections.*:(fire_history|us-buildings).*" full-name))
+                              (re-matches #"fire-detections.*:(fire_history|us-buildings|us-transmission-lines).*" full-name))
                           (merge-fn (split-fire-detections full-name))
 
                           (str/starts-with? full-name "fuels")

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -36,7 +36,20 @@
                      :geoserver-key :pyrecast}})
 
 (def near-term-forecast-underlays
-  {:nifs-perimeters {:opt-label     "NIFS Perimeters"
+  (array-map
+   :us-trans-lines  {:opt-label     "US Transmission Lines"
+                     :z-index       107
+                     :filter-set    #{"fire-detections" "us-transmission-lines"}
+                     :geoserver-key :pyrecast}
+   :trans-nve       {:opt-label     "Transmission Lines (NVE)"
+                     :z-index       106
+                     :filter-set    #{"nve-trans" "psps-static"}
+                     :geoserver-key :psps}
+   :dist-nve        {:opt-label     "Distribution Lines (NVE)"
+                     :z-index       105
+                     :filter-set    #{"nve-dist" "psps-static"}
+                     :geoserver-key :psps}
+   :nifs-perimeters {:opt-label     "NIFS Perimeters"
                      :z-index       103
                      :filter-set    #{"fire-detections" "nifs-perimeters"}
                      :geoserver-key :pyrecast}
@@ -51,15 +64,7 @@
    :goes-imagery    {:opt-label     "Live satellite (GOES-16)"
                      :z-index       100
                      :filter-set    #{"fire-detections" "goes16-rgb"}
-                     :geoserver-key :pyrecast}
-   :trans-nve       {:opt-label     "Transmission Lines (NVE)"
-                     :z-index       106
-                     :filter-set    #{"nve-trans" "psps-static"}
-                     :geoserver-key :psps}
-   :dist-nve        {:opt-label     "Distribution Lines (NVE)"
-                     :z-index       105
-                     :filter-set    #{"nve-dist" "psps-static"}
-                     :geoserver-key :psps}})
+                     :geoserver-key :pyrecast}))
 
 (def near-term-forecast-options
   {:fuels        {:opt-label     "Fuels"


### PR DESCRIPTION
## Purpose
Adds the publicly available US transmission line data from https://hifld-geoplatform.opendata.arcgis.com/datasets/geoplatform::electric-power-transmission-lines as an underlay on all tabs. I added the files to a new `us-transmission-lines` directory on data.pyregence.org here: https://data.pyregence.org/fire_detections/us-transmission-lines/. I created a store, layer, and workspace on the production GeoServer for this underlay as well as a [`transmission-lines-css`](https://data.pyregence.org/geoserver/web/wicket/bookmarkable/org.geoserver.wms.web.data.StyleEditPage?82&name=transmission-lines-css) style  

## Related Issues
Closes PYR-744

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The new US transmission lines underlay should load properly on all tabs. Note that if you are pointing your `:pyrecast` GeoServer key at the production GeoServer, you should be able to test this.

## Screenshots
![Screenshot from 2022-03-16 12-23-04](https://user-images.githubusercontent.com/40574170/158674415-2a75cefe-e6db-477d-960c-5a025968120d.png)

