### PR TITLE
PYR-735 Add an input box to filter a statistic by model.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -429,26 +429,38 @@
                                                                   [:strong "Fire Volume"]
                                                                   " - Modeled fire volume (fire area in acres multiplied by flame length in feet) by ignition location and time of ignition."]
                                                      :options    (array-map
-                                                                  :h-ws   {:opt-label "Sustained wind speed (mph)"
-                                                                           :filter    "deenergization-zones"
-                                                                           :units     "mph"}
-                                                                  :h-wg   {:opt-label "Wind gust (mph)"
-                                                                           :filter    "deenergization-zones"
-                                                                           :units     "mph"}
-                                                                  :l-area {:opt-label "Fire area (acres)"
-                                                                           :filter    "deenergization-zones"
-                                                                           :units     "Acres"}
-                                                                  :l-str  {:opt-label "Impacted structures"
-                                                                           :filter    "deenergization-zones"
-                                                                           :units     "Structures"}
-                                                                  :l-vol  {:opt-label "Fire volume (acre-ft)"
-                                                                           :filter    "deenergization-zones"
-                                                                           :units     "Acre-ft"})}
+                                                                  :ws   {:opt-label "Sustained wind speed (mph)"
+                                                                         :filter    "deenergization-zones"
+                                                                         :units     "mph"}
+                                                                  :wg   {:opt-label "Wind gust (mph)"
+                                                                         :filter    "deenergization-zones"
+                                                                         :units     "mph"}
+                                                                  :area {:opt-label "Fire area (acres)"
+                                                                         :filter    "deenergization-zones"
+                                                                         :units     "Acres"}
+                                                                  :str  {:opt-label "Impacted structures"
+                                                                         :filter    "deenergization-zones"
+                                                                         :units     "Structures"}
+                                                                  :vol  {:opt-label "Fire volume (acre-ft)"
+                                                                         :filter    "deenergization-zones"
+                                                                         :units     "Acre-ft"})}
                                         :statistic  {:opt-label  "Statistic"
                                                      :hover-text "Options are minimum, mean, or maximum."
                                                      :options    {:l {:opt-label "Minimum"}
                                                                   :a {:opt-label "Mean"}
                                                                   :h {:opt-label "Maximum"}}}
+                                        :model      {:opt-label  "Model"
+                                                     :hover-text [:p {:style {:margin-bottom "0"}}
+                                                                  [:strong "ELMFIRE"]
+                                                                  " (Eulerian Level Set Model of FIRE spread) is a cloud-based deterministic fire model developed by Chris Lautenberger at Reax Engineering. Details on its mathematical implementation have been published in Fire Safety Journal ("
+                                                                  [:a {:href   "https://doi.org/10.1016/j.firesaf.2013.08.014"
+                                                                       :target "_blank"}
+                                                                   "https://doi.org/10.1016/j.firesaf.2013.08.014"]
+                                                                  ")."]
+                                                     :options   {:h {:opt-label    "HRRR"
+                                                                     :disabled-for #{:area :str :vol}}
+                                                                 :l {:opt-label    "ELMFIRE"
+                                                                     :disabled-for #{:wg :ws}}}}
                                         :model-init {:opt-label  "Forecast Start Time"
                                                      :hover-text "Start time for forecast cycle, new data comes every 6 hours."
                                                      :options    {:loading {:opt-label "Loading..."}}}}}})

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -91,7 +91,9 @@
   "Returns the name of the CSS style for a PSPS layer."
   []
   (when (= @!/*forecast :psps-zonal)
-      (str (name (get-in @!/*params [:psps-zonal :quantity]))
+      (str (name (get-in @!/*params [:psps-zonal :model]))
+           "-"
+           (name (get-in @!/*params [:psps-zonal :quantity]))
            "-"
            (name (get-in @!/*params [:psps-zonal :statistic]))
            "-poly-css")))
@@ -100,8 +102,9 @@
   "Returns the name of the point info column for a PSPS layer."
   []
   (when (= @!/*forecast :psps-zonal)
-      (str (str/replace
-            (name (get-in @!/*params [:psps-zonal :quantity])) #"-" "_")
+      (str (name (get-in @!/*params [:psps-zonal :model]))
+           "_"
+           (name (get-in @!/*params [:psps-zonal :quantity]))
            "_"
            (name (get-in @!/*params [:psps-zonal :statistic])))))
 


### PR DESCRIPTION
## Purpose
Adds a box to filter out a statistic based on the model. In the future, we will add more models. All of the models, according to the data dictionary are as follows:
```
MODEL values-
   l    ELMFIRE
   h    HRRR
   n1   NAM 3 km
   n2   NAM 12 km
   g1   GFS 0.125 deg
   g2   GFS 0.250 deg
   b    NBM
```
Note that the columns are named MODEL_QUANTITY_STATISTIC. 

## Related Issues
Closes PYR-735

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The PSPS tab should work as before, but now with the model input box.

## Screenshots

![Screenshot from 2022-03-16 17-37-58](https://user-images.githubusercontent.com/40574170/158717032-7229e43d-86fb-44fa-a866-b63de103c48f.png)
![Screenshot from 2022-03-16 17-38-15](https://user-images.githubusercontent.com/40574170/158717035-54e15dd1-3b86-4074-bbfb-9ebbf799e7ed.png)
![Screenshot from 2022-03-16 17-38-23](https://user-images.githubusercontent.com/40574170/158717038-4bf4362e-fbbd-4914-8049-2b4201cdb949.png)
![Screenshot from 2022-03-16 17-38-27](https://user-images.githubusercontent.com/40574170/158717040-6d649506-9fa3-484c-8b1f-9c57fe9e6517.png)

