### PR TITLE
PYR-743: Add .25x speed option

### DIFF
--- a/src/cljs/pyregence/components/map_controls/time_slider.cljs
+++ b/src/cljs/pyregence/components/map_controls/time_slider.cljs
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn time-slider [layer-full-time select-layer! select-time-zone!]
-  (r/with-let [*speed          (r/atom 1)
+  (r/with-let [*speed          (r/atom 2)
                cycle-layer!    (fn [change]
                                  (select-layer! (mod (+ change @!/*layer-idx) (count @!/param-layers))))
                loop-animation! (fn la []

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -751,10 +751,11 @@
 ;; Scroll speeds for time slider
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def speeds [{:opt-label ".5x" :delay 2000}
-             {:opt-label "1x"  :delay 1000}
-             {:opt-label "2x"  :delay 500}
-             {:opt-label "5x"  :delay 200}])
+(def speeds [{:opt-label ".25x" :delay 4000}
+             {:opt-label ".5x"  :delay 2000}
+             {:opt-label "1x"   :delay 1000}
+             {:opt-label "2x"   :delay 500}
+             {:opt-label "5x"   :delay 200}])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Match Drop Configuration


### PR DESCRIPTION
## Closes [PYR-743](https://sig-gis.atlassian.net/browse/PYR-743)

## Purpose
To extend the range of speed options with an additional .25x option.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Time Slider

## Testing
#### Observe that the 1x continues to be the default speed on the "Time Slider"
1. Visit the Pyrecast landing page and select the "Weather tab".
2. Observe and verify that the default time-slider speed options is still "1x"

#### Observe that .25x is a new option available for selection from the "Time Slider" speed dropdown.
1. Visit the Pyrecast landing page and select the "Weather tab".
2. Navigate to the "Time Slider" control and speed dropdown.
3. Observe the presence of an additional ".25x" speed option.
4. Select ".25x" and observe that it is 4 times as slow as "1x" and twice as slow as ".5x"

## Screenshots, Etc.
![image](https://user-images.githubusercontent.com/1130619/159563615-2d184997-3de0-48e8-8b14-ce56ac1c1e69.png)


