### PR TITLE
PYR-703 Fix point information for transmission line layers.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -246,10 +246,9 @@
                                                               [:br]
                                                               [:strong "Fire Volume"]
                                                               " - Modeled fire volume (fire area in acres multiplied by flame length in feet) by ignition location and time of ignition."]
-                                                 :options    {:times-burned {:opt-label     "Relative burn probability"
-                                                                             :filter        "times-burned"
-                                                                             :units         "Times"
-                                                                             :raster-layer? true}
+                                                 :options    {:times-burned {:opt-label "Relative burn probability"
+                                                                             :filter    "times-burned"
+                                                                             :units     "Times"}
                                                               :impacted     {:opt-label "Impacted structures"
                                                                              :filter    "impacted-structures"
                                                                              :units     "Structures"}
@@ -274,8 +273,7 @@
                                                                            :filter       "all"}
                                                               :tlines     {:opt-label    "Transmission lines"
                                                                            :filter       "tlines"
-                                                                           :clear-point? true
-                                                                           :line-layer?  true}}}
+                                                                           :clear-point? true}}}
                                     :fuel       {:opt-label  "Fuel"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Source of surface and canopy fuel inputs:"
@@ -398,7 +396,6 @@
                   :allowed-org     5
                   :reverse-legend? true
                   :time-slider?    true
-                  :polygon-layer?  true
                   :hover-text      "Public Safety Power Shutoffs (PSPS) zonal statistics."
                   :params          {:quantity   {:opt-label  "Zonal Quantity"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}


### PR DESCRIPTION
## Purpose
The point information tool was not working for any of the transmission line layers. To fix this, I abstracted the function that I wrote to process a legend from a polygon layer to also work for a line layer. This also meant that I had to update the `line-fire-volume-css`, `line-fire-area-css`, and `line-impacted-structures-css` styles on the data.pyregence GeoServer (see [here](https://data.pyregence.org/geoserver/web/wicket/bookmarkable/org.geoserver.wms.web.data.StyleEditPage?33&name=line-fire-volume-css)). This fixes the hacky way in which the legend for these transmission lines layers used to be generated: `(c/legend-url (str/replace layer #"tlines|liberty|pacificorp" "all") ; TODO make a more generic way to do this.` This hack isn't currently working (check out any of the transmission lines layers with point info on pyrecast.org to verify).

I also had to add a `:raster-layer?` key to `config.cljs` because the Relative burn probability output for the Transmission lines ignition pattern is a raster layer, even though the other three outputs aren't (they're line layers).

Using this abstraction, I was also able to fix the point info tool for the NVE Energy layers by doing:
```sql
INSERT INTO organization_layers
    (organization_rid, layer_path, layer_config)
VALUES
    (5, '[:fire-risk :params :pattern :options :nve]', '{:opt-label "NV Energy overhead lines", :filter "nve", :geoserver-key :psps}');
```

Also updates the names of the PSPS styles: 
Previous standard: h-wg-a-poly-css 
New standard: poly-h-wg-a-css

## Related Issues
Closes PYR-703 PYR-745
## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
All of the layers on the risk tab should work with the point information tool. You can test this locally without needing to have/test the NVE layers.

## Screenshots
![Screenshot from 2022-03-22 18-05-40](https://user-images.githubusercontent.com/40574170/159610377-9fb4bb60-8cde-45b2-9a33-95aabe5635bc.png)

