### PR TITLE
PYR-741 Figure out file naming conventions for the NVE GeoServer and update config.cljs accordingly.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -391,6 +391,7 @@
                                                  :options    {:loading {:opt-label "Loading..."}}}}}
    :psps-zonal   {:opt-label       "PSPS"
                   :geoserver-key   :psps
+                  :filter          "psps-zonal"
                   :underlays       (merge common-underlays near-term-forecast-underlays)
                   :allowed-org     5
                   :reverse-legend? true
@@ -424,26 +425,29 @@
                                                               [:strong "Fire Volume"]
                                                               " - Modeled fire volume (fire area in acres multiplied by flame length in feet) by ignition location and time of ignition."]
                                                  :options    (array-map
-                                                              :ws   {:opt-label  "Sustained wind speed (mph)"
-                                                                     :filter-set #{"psps-zonal" "nve" "deenergization-zones"}
-                                                                     :units      "mph"}
-                                                              :wg   {:opt-label  "Wind gust (mph)"
-                                                                     :filter-set #{"psps-zonal" "nve" "deenergization-zones"}
-                                                                     :units      "mph"}
-                                                              :area {:opt-label  "Fire area (acres)"
-                                                                     :filter-set #{"psps-zonal" "nve" "deenergization-zones"}
-                                                                     :units      "Acres"}
-                                                              :str  {:opt-label  "Impacted structures"
-                                                                     :filter-set #{"psps-zonal" "nve" "deenergization-zones"}
-                                                                     :units      "Structures"}
-                                                              :vol  {:opt-label  "Fire volume (acre-ft)"
-                                                                     :filter-set #{"psps-zonal" "nve" "deenergization-zones"}
-                                                                     :units      "Acre-ft"})}
+                                                              :ws   {:opt-label "Sustained wind speed (mph)"
+                                                                     :filter    "nve"
+                                                                     :units     "mph"}
+                                                              :wg   {:opt-label "Wind gust (mph)"
+                                                                     :filter    "nve"
+                                                                     :units     "mph"}
+                                                              :area {:opt-label "Fire area (acres)"
+                                                                     :filter    "nve"
+                                                                     :units     "Acres"}
+                                                              :str  {:opt-label "Impacted structures"
+                                                                     :filter    "nve"
+                                                                     :units     "Structures"}
+                                                              :vol  {:opt-label "Fire volume (acre-ft)"
+                                                                     :filter    "nve"
+                                                                     :units     "Acre-ft"})}
                                     :statistic  {:opt-label  "Statistic"
                                                  :hover-text "Options are minimum, mean, or maximum."
-                                                 :options    {:l {:opt-label "Minimum"}
-                                                              :a {:opt-label "Mean"}
-                                                              :h {:opt-label "Maximum"}}}
+                                                 :options    {:l {:opt-label "Minimum"
+                                                                  :filter    "deenergization-zones"}
+                                                              :a {:opt-label "Mean"
+                                                                  :filter    "deenergization-zones"}
+                                                              :h {:opt-label "Maximum"
+                                                                  :filter    "deenergization-zones"}}}
                                     :model      {:opt-label  "Model"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               [:strong "ELMFIRE"]


### PR DESCRIPTION
## Purpose
I verified the file naming conventions for the NVE GeoServer with Chris. It looks like we are going with `psps_zonal/YYYYMMDD_HH/nve/deenergization-zones.shp` for the PSPS layers, so I added `nve` to the `filter-set` instead of just `filter`ing. This also meant that I had to add `psps-zonal` to the `filter-set` since the `filter-set` overrides any above `filter`s. This is okay for the PSPS layers since all of the stats are coming from the same file, the only thing that changes is the style. 

## Related Issues
Closes PYR-741

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
All PSPS layers should work as normal.

