### PR TITLE
PYR-742: Remove redundant close, X button

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -85,7 +85,7 @@
    [:label {:style {:font-size "1.5rem"}}
     "Layer Selection"]
    [:span {:style {:margin-right "-.5rem"
-                   :visibility (if (and @!/show-panel? @!/mobile?) "visible" "hidden")}}
+                   :visibility   (if (and @!/show-panel? @!/mobile?) "visible" "hidden")}}
     [tool-button :close #(reset! !/show-panel? false)]]])
 
 (defn- optional-layer [opt-label filter-set id]


### PR DESCRIPTION
## Closes [PYR-742](https://sig-gis.atlassian.net/browse/PYR-742)

## Purpose
The secondary close button in the side panel header, was redundant, and so this change removes it.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Side Panel

## Testing
### Observe that the redundant "X" Close button is not longer visible
- Visit the Pyrecast landing page and select the "Weather tab".
- Observe and verify that the "X" close button is no longer visible on the side panel

## Screenshots, Etc.
### Before
![image](https://user-images.githubusercontent.com/1130619/160550894-7d8b93ed-0d6f-49d2-b5bf-9ad779656c8b.png)

### After
![image](https://user-images.githubusercontent.com/1130619/162267523-337fad21-0fc1-4f02-9c06-1d46f03975da.png)

