### PR TITLE
PYR-740: Sort the underlay list by z-index in descending order

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -244,15 +244,15 @@
     (r/create-class
      {:component-did-mount
       (fn []
-        (go-loop [optlayers sorted-underlays]
-          (let [{:keys [filter-set z-index geoserver-key]} (first optlayers)
+        (go-loop [opt-layers sorted-underlays]
+          (let [{:keys [filter-set z-index geoserver-key]} (first opt-layers)
                 layer-name                                 (<! (get-layer-name geoserver-key filter-set identity))]
             (mb/create-wms-layer! layer-name
                                   layer-name
                                   geoserver-key
                                   false
                                   z-index)
-            (when-let [tail (seq (rest optlayers))]
+            (when-let [tail (seq (rest opt-layers))]
               (recur tail)))))
 
       :display-name "optional-layers"


### PR DESCRIPTION
## Closes [PYR-740](https://sig-gis.atlassian.net/browse/PYR-740)

## Purpose
Ensure that the list of underlay checkbox items are sorted in descending order, by z-index.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Collapsible Panel

## Testing
Navigate to the near term forecast page and verify that the optional layers are in the following sorted order:
- US Transmission Lines
- Structures
- NIFS Perimeters
- VIIRS Hotspots
- MODIS Hotspots
- Live satellite (GOES-16)

## Screenshots
![image](https://user-images.githubusercontent.com/1130619/161641902-4431245f-1163-4394-945d-b835e6dec185.png)
