### PR TITLE
PYR-746 Point info on the risk tab breaks in an edge case.

### DIFF
--- a/src/cljs/pyregence/components/map_controls.cljs
+++ b/src/cljs/pyregence/components/map_controls.cljs
@@ -863,7 +863,7 @@
     (fn [_]
       (let [cleaned-last-clicked-info (u/replace-no-data-nil @!/last-clicked-info
                                                              @!/no-data-quantities)
-            current-point             (nth cleaned-last-clicked-info @!/*layer-idx)]
+            current-point             (get cleaned-last-clicked-info @!/*layer-idx)]
         [:div {:style {:bottom "0" :position "absolute" :width "100%"}}
          [:label {:style {:margin-top ".5rem" :text-align "center" :width "100%"}}
           (if (some? (:band current-point))

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -590,9 +590,9 @@
   "Replaces any nodata 'band' entries from the provided last-clicked-info list
    with nil."
   [last-clicked-info no-data-quantities]
-  (map (fn [entry]
-        (let [band-val (:band entry)]
-          (assoc entry :band (if (contains? no-data-quantities (str band-val))
-                               nil
-                               band-val))))
-       last-clicked-info))
+  (mapv (fn [entry]
+         (let [band-val (:band entry)]
+           (assoc entry :band (if (contains? no-data-quantities (str band-val))
+                                nil
+                                band-val))))
+        last-clicked-info))


### PR DESCRIPTION
## Purpose
The point info on the Risk tab for vector layers still isn't being parsed properly for overlapping points. This will be fixed as a part of PYR-751, but for now I'm fixing an edge case with the risk tab that crashes the site. 

## Related Issues
Closes PYR-746

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Go to the Risk tab
2. Select Fire area and Transmission lines as your inputs
3. Using the point info, click in the middle of a lot of lines (to try and get lines that overlap)
4. Toggle around the time slider, the website should not crash

