### PR TITLE
PYR-754 Fix the long term forecast point info

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -504,16 +504,16 @@
                                                    :auto-zoom? true
                                                    :options    {:can-esm2   {:opt-label "CanESM2"
                                                                              :filter    "CanESM2"
-                                                                             :units     ""}
+                                                                             :units     "ha"}
                                                                 :hadgem2-es {:opt-label "HadGEM2-ES"
                                                                              :filter    "HadGEM2-ES"
-                                                                             :units     ""}
+                                                                             :units     "ha"}
                                                                 :cnrm-cm5   {:opt-label "CNRM-CM5"
                                                                              :filter    "CNRM-CM5"
-                                                                             :units     ""}
+                                                                             :units     "ha"}
                                                                 :miroc5     {:opt-label "MIROC5"
                                                                              :filter    "MIROC5"
-                                                                             :units     ""}}}
+                                                                             :units     "ha"}}}
                                       :prob       {:opt-label  "RCP Scenario"
                                                    :hover-text "Representative Concentration Pathway (RCP) is the greenhouse gas concentration trajectory adopted by the IPCC.\n
                                                                 Options include:


### PR DESCRIPTION
## Purpose
Updates the units for the long term forecast point info. Before, the units were hard coded into the CSS style on GeoServer. I removed the units from there and added them to `config.cljs` instead so that the point info will show the proper units.

## Related Issues
Closes PYR-754

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
Go to the long term forecast page. The point info should work properly.

## Screenshots

![Screenshot from 2022-04-05 14-35-38](https://user-images.githubusercontent.com/40574170/161854211-c0482600-9378-4ed5-b552-19abdc3f1ab5.png)

