### PR TITLE
PYR-751 Fixing another issue with the point info for vector line layers.

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -304,7 +304,7 @@
                      (mapv (fn [{:keys [sim-time hour]} pi-layer]
                              (let [js-time (u/js-date-from-string sim-time)]
                                  (assoc pi-layer
-                                      :js-time js-time
+                                        :js-time js-time
                                         :date    (u/get-date-from-js js-time @!/show-utc?)
                                         :time    (u/get-time-from-js js-time @!/show-utc?)
                                         :hour    hour)))


### PR DESCRIPTION
## Purpose
### The Issue
Using the point info tool leverages the `GetFeatureInfo` WMS request to GeoServer. However, when you request the feature info from a point that contains multiple overlapping lines (such as in the screenshot below), you receive the point info from all of the overlapping lines. In theory, this should not be an issue (and we have code to address this). This is because as a part of the `GetFeatureInfo` response, there is an `id` field that tells you which line the info is coming from (e.g. `"id": "elmfire_tlines_landfire_fire-area_20220407_130000.30342"`). The second part of this `id` string — which GeoServer calls the `fid` and is in this case `30342` — tells us which specific line the point info is coming from. Our code simply filters out any layers that don’t match the first `id` that we see in the `GetFeatureInfo` response. The choice to look at the first id is arbitrary but reasonable. In theory, this should give us all 108 hours’ worth of point info to visualize on the graph. Instead, we only get a few points (as seen in the screenshot below). 
![Screenshot from 2022-04-06 18-52-09](https://user-images.githubusercontent.com/40574170/162303652-19a3785e-4116-4807-a38f-46658e09fd15.png)

### First Thoughts
I realized that a potential issue might be the `FEATURE_COUNT` parameter for `GetFeatureInfo`, which we hard code as 1000. I realized that many points might be getting cut off, leading to us only seeing 4 points on the graph. I tried increasing this value and even when all possible features are returned (around 35000 in the worst case), all 108 expected hours are still not present when clicking on overlapping spots. 

My initial idea was to add a message on the point info tool that won’t let the user see a graph if they click on an overlapping point. However, for some reason, when you zoom in all of the way and click on a point the `GetFeatureInfo` response always returns two separate `fids` (such as 10117 and 10128). This means that it was virtually impossible not to get this message when using the point info tool since points are always overlapping with one another. I tried changing the styling on GeoServer to address this, but no dice. 

### The Solution
Because, as mentioned above, each `fid` doesn't have all 108 points in the response it doesn't make sense to arbitrarily filter by the first `fid` that's returned. Instead I decided to map over all of the returned `fid`s, count how many times they occurred, and filter over the `fid` that has the maximum number of points. In most cases, this works well and we get the full, desired point info graph. See below for a screenshot of this along with my debugging messages. The first print message is the raw JSON response from `GetFeatureInfo`, the second message is the map that I use to count how many points each `fid` is associated with, and the third and fourth message tells you the `fid` that I will eventually filter over as well as the number of points associated with it. The last message simply tells you how many `fid`s (and thus how many overlapping points) were returned in the `GetFeatureInfo` response.

![Screenshot from 2022-04-07 13-50-14](https://user-images.githubusercontent.com/40574170/162309273-57adf226-f3ee-4db4-ae9f-2dee4c832235.png)

### A Strange Edge Case
It’s interesting to note that in the scenario where you're all the way zoomed in the `GetFeatureInfo` response seems to always return two `fid`s: the first `fid` always has 28 points associated with it and the second `fid` always has 79 points, giving us a total of 107 points (one fewer than we expect). Based on the filtering decision I described above, this means that we only get 79 points on our point info graph. See the screenshot (and my debugging messages) below for this:

![Screenshot from 2022-04-07 13-52-26](https://user-images.githubusercontent.com/40574170/162305649-f130c763-c596-4cee-bfac-d87c5e46a243.png)

---

Let me know if you have any suggestions here and if my new filtering decision seems reasonable. In short, vector line layers don't play very nicely and take a while to load. Also, if you have suggestions for better names for my `let` bindings, feel free to let me know.

## Related Issues
Closes PYR-751

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The point info should work on all layers on all tabs. Clicking on overlapping points on vector line layers (such as fire area w/ transmission lines on the Risk tab) should give you all 108 forecast points except in the edge case mentioned above.

## Screenshots
See the screenshots in the Purpose section above.
