### PR TITLE
PYR-752 Fix the domain on the point info graph.

### DIFF
--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -29,9 +29,9 @@
      (rest processed-legend))))
 
 (defn- create-data-scale []
-  (let [all-hours (mapv #(:hour %) @!/last-clicked-info)]
+  (let [all-hours (mapv :hour @!/last-clicked-info)]
     {:type   "linear"
-     :domain [(apply min all-hours) (apply max all-hours)]
+     :domain [(reduce min all-hours) (reduce max all-hours)]
      :nice   false}))
 
 (defn- create-color-scale [processed-legend]
@@ -71,14 +71,14 @@
                                                     :empty "none"}}}
                          {:transform [{:filter {:or [{:field "hour" :lt current-hour}
                                                      {:field "hour" :gt current-hour}]}}]
-                          :mark     {:type   "point"
-                                     :filled true}
-                          :encoding {:size  {:condition {:selection :point-hover :value 150}
-                                             :value     75}
-                                     :color {:field  "band"
-                                             :type   "quantitative"
-                                             :scale  (create-color-scale processed-legend)
-                                             :legend false}}}
+                          :mark      {:type   "point"
+                                      :filled true}
+                          :encoding  {:size  {:condition {:selection :point-hover :value 150}
+                                              :value     75}
+                                      :color {:field  "band"
+                                              :type   "quantitative"
+                                              :scale  (create-color-scale processed-legend)
+                                              :legend false}}}
                          {:transform [{:filter {:field "hour" :equal current-hour}}]
                           :mark      {:type   "point"
                                       :filled false


### PR DESCRIPTION
## Purpose
This fixes a bug where the domain on the Vega point info graphs was not correct. See the screenshots below:

#### The Weather tab
![Screenshot from 2022-03-29 15-48-07](https://user-images.githubusercontent.com/40574170/163250333-56fcb4df-5cc7-48f4-89b1-fd5e15343e09.png)
Note that the domain extends to hour 200 on the Weather graph above even though the max hour is 192. Thus, the domain should be `[0 192]` and not `[0 200]`

#### The Risk tab
![Screenshot from 2022-03-29 15-42-50](https://user-images.githubusercontent.com/40574170/163250322-99ae57f3-b679-4945-9940-9a3e9e5fb0d6.png)
Note that the domain starts at 0 and goes up until 120. This is incorrect because the minimum hour for any of the Risk layers is 7 due to the outputs that ELMFIRE produces (it doesn't have any layers for hours 0-6). The maximum hour is 114. Thus, the domain should be `[7 114]` and not `[0 120]`.


#### The fix
It turns out that Vega will automatically select a domain for you if you don't specify it yourself. In addition to this, you must set the `:nice` key to `false` if you want to ignore the automatic rounding that Vega applies. 

In this PR I fix this issue as well as fix some column alignment in `vega.cljs` and add the Hour field to the tooltip.

## Related Issues
Closes PYR-752

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The point info should still work properly on all tabs. The Vega graph's domain should now go from the minimum forecast hour available to the maximum forecast hour available (see screenshots below). There should now be an "Hour" field in the Vega tooltip and it should display the correct hour.

## Screenshots
The domain is now `[0 192]`:
![Screenshot from 2022-04-13 11-34-13](https://user-images.githubusercontent.com/40574170/163250367-ec10b3f3-356e-496c-ab3e-265f31a134c5.png)
The domain is now `[7 114]`:
![Screenshot from 2022-04-13 11-47-35](https://user-images.githubusercontent.com/40574170/163250376-f7032211-4c78-4ec2-ae22-d0d1c119c5cb.png)

