### PR TITLE
PYR-761 Update the order of the inputs on the Fuels tab.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -122,47 +122,47 @@
                                                                 :reverse-legend? true
                                                                 :disabled-for    #{:cec}})}
                                   :model {:opt-label  "Source"
-                                                          :hover-text [:p {:style {:margin-bottom "0"}}
-                                                                       "Stock "
-                                                                       [:strong "LANDFIRE 2.0.0"]
-                                                                       " data ("
-                                                                       [:a {:href   "https://landfire.gov"
-                                                                            :target "_blank"}
-                                                                        "https://landfire.gov"]
-                                                                       ") at 30 m resolution."
-                                                                       [:br]
-                                                                       [:br]
-                                                                       [:strong "California Forest Observatory"]
-                                                                       " – Summer 2020 at 10 m resolution. Courtesy of the California Forest Observatory ("
-                                                                       [:a {:href   "https://forestobservatory.com"
-                                                                            :target "_blank"}
-                                                                        "https://forestobservatory.com"]
-                                                                       "), © Salo Sciences, Inc. 2020."
-                                                                       [:br]
-                                                                       [:br]
-                                                                       [:strong "2021 California fuelscape"]
-                                                                       " prepared by Pyrologix, LLC ("
-                                                                       [:a {:href   "https://pyrologix.com"
-                                                                            :target "_blank"}
-                                                                        "https://pyrologix.com"]
-                                                                       "), 2021."
-                                                                       [:br]
-                                                                       [:br]
-                                                                       [:strong "California Ecosystem Climate Solutions"]
-                                                                       " - Data provided by the "
-                                                                       [:a {:href   "https://california-ecosystem-climate.solutions/"
-                                                                            :target "_blank"}
-                                                                        "California Ecosystem Climate Solutions"]
-                                                                       ", Wang et al. (2021)."]
-                                                          :options    {:landfire      {:opt-label "LANDFIRE 2.0.0"
-                                                                                       :filter    "landfire-2.0.0"}
-                                                                       :cfo           {:opt-label "California Forest Obs."
-                                                                                       :filter    "cfo-2020"}
-                                                                       :ca-fuelscapes {:opt-label "2021 CA fuelscape"
-                                                                                       :filter    "ca-fuelscapes"}
-                                                                       :cec           {:opt-label    "CA Ecosystem Climate Solutions"
-                                                                                       :filter       "cec"
-                                                                                       :disabled-for #{:asp :slp :dem :cc :ch :cbh :cbd}}}}
+                                          :hover-text [:p {:style {:margin-bottom "0"}}
+                                                       "Stock "
+                                                       [:strong "LANDFIRE 2.0.0"]
+                                                       " data ("
+                                                       [:a {:href   "https://landfire.gov"
+                                                            :target "_blank"}
+                                                        "https://landfire.gov"]
+                                                       ") at 30 m resolution."
+                                                       [:br]
+                                                       [:br]
+                                                       [:strong "California Forest Observatory"]
+                                                       " – Summer 2020 at 10 m resolution. Courtesy of the California Forest Observatory ("
+                                                       [:a {:href   "https://forestobservatory.com"
+                                                            :target "_blank"}
+                                                        "https://forestobservatory.com"]
+                                                       "), © Salo Sciences, Inc. 2020."
+                                                       [:br]
+                                                       [:br]
+                                                       [:strong "2021 California fuelscape"]
+                                                       " prepared by Pyrologix, LLC ("
+                                                       [:a {:href   "https://pyrologix.com"
+                                                            :target "_blank"}
+                                                        "https://pyrologix.com"]
+                                                       "), 2021."
+                                                       [:br]
+                                                       [:br]
+                                                       [:strong "California Ecosystem Climate Solutions"]
+                                                       " - Data provided by the "
+                                                       [:a {:href   "https://california-ecosystem-climate.solutions/"
+                                                            :target "_blank"}
+                                                        "California Ecosystem Climate Solutions"]
+                                                       ", Wang et al. (2021)."]
+                                          :options    {:landfire      {:opt-label "LANDFIRE 2.0.0"
+                                                                       :filter    "landfire-2.0.0"}
+                                                       :cfo           {:opt-label "California Forest Obs."
+                                                                       :filter    "cfo-2020"}
+                                                       :ca-fuelscapes {:opt-label "2021 CA fuelscape"
+                                                                       :filter    "ca-fuelscapes"}
+                                                       :cec           {:opt-label    "CA Ecosystem Climate Solutions"
+                                                                       :filter       "cec"
+                                                                       :disabled-for #{:asp :slp :dem :cc :ch :cbh :cbd}}}}
                                   :model-init {:opt-label  "Model Creation Time"
                                                :hover-text "Time the data was created."
                                                :options    {:loading {:opt-label "Loading..."}}}}}


### PR DESCRIPTION
## Purpose
Moved the Layer input box above the Source input box on the Fuels tab to better match the other tabs. Every other tab has the layer/parameter/output as the first input box. This PR matches that functionality on the Fuels tab. 

## Related Issues
Closes PYR-761

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
The Fuels tab should work as expected.

## Screenshots
![Screenshot from 2022-04-21 10-55-03](https://user-images.githubusercontent.com/40574170/164521727-cf0dbb8e-d6b1-4586-a4cf-f231de98898f.png)


