### PR TITLE
PYR-678 Fix the red square bug on the active fires tab.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -503,7 +503,8 @@
   {:id       layer-name
    :type     "symbol"
    :source   source-name
-   :layout   {:icon-image         ["step" ["get" "containper"]
+   :layout   {:icon-allow-overlap true
+              :icon-image         ["step" ["get" "containper"]
                                    "fire-icon-0"
                                    50  "fire-icon-50"
                                    90  "fire-icon-90"
@@ -516,7 +517,7 @@
               :text-allow-overlap true
               :text-field         ["to-string" ["get" "prettyname"]]
               :text-font          ["Open Sans Semibold" "Arial Unicode MS Regular"]
-              :text-offset        [0 0.9]
+              :text-offset        [0 0.8]
               :text-size          16
               :visibility         "visible"}
    :metadata {:type (get-layer-type layer-name)}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -265,10 +265,10 @@
         lnglat     (-> properties (select-keys ["longitude" "latitude"]) (vals))
         {:strs [name prettyname containper acres]} properties
         body       (fire-popup prettyname
-                                  containper
-                                  acres
-                                  #(select-param! (keyword name) :fire-name)
-                                  (forecast-exists? name))]
+                               containper
+                               acres
+                               #(select-param! (keyword name) :fire-name)
+                               (forecast-exists? name))]
     (mb/init-popup! "fire" lnglat body {:width "200px"})
     (mb/set-center! lnglat 0)))
 
@@ -306,7 +306,7 @@
   (reset! !/last-clicked-info nil)
   (let [main-key (first keys)]
     (when (= main-key :fire-name)
-      (select-layer! 0)
+      (reset! !/*layer-idx 0)
       (swap! !/*params assoc-in (cons @!/*forecast [:burn-pct]) :50)
       (reset! !/animate? false))
     (change-type! (not (#{:burn-pct :model-init} main-key)) ;; TODO: Make this a config
@@ -514,9 +514,9 @@
 (defn map-layer []
   (r/with-let [mouse-down? (r/atom false)
                cursor-fn   #(cond
-                              @mouse-down?                       "grabbing"
+                              @mouse-down?                           "grabbing"
                               (or @!/show-info? @!/show-match-drop?) "crosshair" ; TODO get custom cursor image from Ryan
-                              :else                              "grab")]
+                              :else                                  "grab")]
     [:div#map {:class (<class $p-mb-cursor)
                :style {:height "100%" :position "absolute" :width "100%" :cursor (cursor-fn)}
                :on-mouse-down #(reset! mouse-down? true)


### PR DESCRIPTION
## Purpose
Fixes the following bug:
1. Click on an active forecast that has a fire pop up.
2. Click “Click to View Forecast”.
3. A red square should show up and doesn’t go away.

I figured out that the issue was my use of the `select-layer!` function. Using this—instead of just manually resetting the `*layer-idx` atom—meant that the `fire-detections_active-fires:active-fires_20220421_204700` layer is added on top of the spread forecast you wish to view. This meant that once you added the layer, it would never go away. Just `reset`ing the `*layer-idx` fixes the issue. 

Also, this PR fixes an issue I noticed where overlapping icons would trump one another and certain fires would appear hidden at different zoom levels. It turns out there's a `:icon-allow-overlap` key to address just this issue, so I used that.

Lastly, I fixed up some alignment issues that I noticed in `near_term_forecast.cljs`.

## Related Issues
Closes PYR-678

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Click on an active forecast that has a fire pop up.
2. Click “Click to View Forecast”.
3. There should be no red squares that show up.
---
1. Select a fire using the Fire Name input box.
2. Click the play button, change the Predicted Fire Size to anything other than "Median (50th percentile)", and wait for a second until a few hours have passed by on the time slider.
3. Using the Fire Name input box, select a different fire.
4. The time slider should go back to the very first time step, the time slider should now be paused, and "Median (50th percentile)" should now be selected in the Predicted Fire Size input box.
---
1. Go to the Active Fires tab.
2. Zoom in and out. 
3. You should always be able to see all of the fire icons, even if they overlap slightly:
![Screenshot from 2022-04-21 17-21-30](https://user-images.githubusercontent.com/40574170/164571259-54f65824-cc3c-4967-8ba5-18690947a4ae.png)
