### PR TITLE
Cleaning up some point info rounding errors.

### DIFF
--- a/src/cljs/pyregence/components/map_controls/information_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/information_tool.cljs
@@ -39,7 +39,9 @@
         [:div {:style {:bottom "0" :position "absolute" :width "100%"}}
          [:label {:style {:margin-top ".5rem" :text-align "center" :width "100%"}}
           (if-let [value (:band current-point)]
-            (str (if (fn? convert) (convert value) value)
+            (str (if (fn? convert)
+                   (u/round-last-clicked-info (convert value))
+                   (u/round-last-clicked-info value))
                  (u/clean-units units))
             "No info available for this timestep.")]]))}))
 
@@ -134,8 +136,8 @@
     [:div#info-tool
      [resizable-window
       parent-box
-      200
-      400
+      290
+      460
       "Point Information"
       close-fn!
       (fn [box-height box-width]

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -43,7 +43,9 @@
   (let [processed-legend     (cond->> (u/filter-no-data @!/legend-list)
                                (fn? convert) (mapv #(update % "quantity" (comp str convert))))
         processed-point-info (cond->> (u/replace-no-data-nil @!/last-clicked-info @!/no-data-quantities)
-                               (fn? convert) (mapv #(update % :band convert)))]
+                               (fn? convert) (mapv (fn [entry]
+                                                     (update entry :band #(u/round-last-clicked-info (convert %)))))
+                               :else         (mapv #(update % :band u/round-last-clicked-info)))]
     {:width    "container"
      :height   "container"
      :autosize {:type "fit" :resize true}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -267,7 +267,7 @@
                                                                              :units     "Acre-ft"}
                                                               :plignrate    {:opt-label    "Power line ignition rate"
                                                                              :filter       "plignrate"
-                                                                             :units        "Ignitions / line-mi / hr"
+                                                                             :units        "Ignitions/line-mi/hr"
                                                                              :disabled-for #{:all :tlines}}}}
                                     :pattern    {:opt-label  "Ignition Pattern"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -8,7 +8,6 @@
             [clojure.string     :as str]
             [clojure.core.async :refer [go <!]]
             [cljs.core.async.interop :refer-macros [<p!]]
-            [decimal.core     :as dc]
             [pyregence.state  :as !]
             [pyregence.styles :as $]
             [pyregence.utils  :as u]
@@ -289,18 +288,12 @@
                                        (.-length)
                                        (> 1))
             band-extraction-fn (fn [pi-layer]
-                                 (let [v (if multi-column-info?
-                                           (some->> (get-psps-column-name)
-                                                    (u/try-js-aget pi-layer "properties"))
-                                           (some->> (u/try-js-aget  pi-layer "properties")
-                                                    (js/Object.values)
-                                                    (first)))]
-                                   (if (or (>= v 1) (= v -9999)) ; FIXME the -9999 check is due to -9999 being hard coded above in process-vector-layer-legend for the PSPS layers
-                                     (u/to-precision 1 v)
-                                     (-> v
-                                         (dc/decimal)
-                                         (dc/to-significant-digits 1)
-                                         (dc/to-number)))))
+                                 (if multi-column-info?
+                                   (some->> (get-psps-column-name)
+                                            (u/try-js-aget pi-layer "properties"))
+                                   (some->> (u/try-js-aget  pi-layer "properties")
+                                            (js/Object.values)
+                                            (first))))
             feature-info       (map (fn [pi-layer]
                                       {:band   (band-extraction-fn pi-layer)
                                        :vec-id (some-> pi-layer

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -1,5 +1,6 @@
 (ns pyregence.utils
-  (:require [cljs.reader        :as edn]
+  (:require [decimal.core       :as dc]
+            [cljs.reader        :as edn]
             [clojure.string     :as str]
             [clojure.set        :as sets]
             [clojure.core.async :refer [alts! go <! timeout go-loop chan put!]]
@@ -596,3 +597,14 @@
                                 nil
                                 band-val))))
         last-clicked-info))
+
+(defn round-last-clicked-info
+  "Rounds a point info value to the proper number of digits for rendering."
+  [last-clicked-info-val]
+  (when (some? last-clicked-info-val)
+    (if (>= last-clicked-info-val 1)
+      (to-precision 1 last-clicked-info-val)
+      (-> last-clicked-info-val
+          (dc/decimal)
+          (dc/to-significant-digits 2)
+          (dc/to-number)))))


### PR DESCRIPTION
## Purpose
A fix for `nodata` values for a bug introduced in #672 . `-9999`, which is a common `nodata` value, was getting rounded to `-10000` which is causing issues. 

This PR introduces a more robust fix than rounding the point info value when it's initially processed. Instead, we only round the last-clicked-info right before it's rendered to the user. This occurs in the information-div as well as the Vega graph.

This PR also makes the point info tool the same dimensions as the camera tool. This is good for consistency as well as to fix some strange bugs that occur with the Vega graph when the x-axis title goes beyond the edge of the div.

## Testing
The point info on the Weather, Risk, and PSPS tabs should work as expected.
The point info on the Power line ignition layers should work like so:
![Screenshot from 2022-05-17 13-29-32](https://user-images.githubusercontent.com/40574170/168875365-55044c28-bf06-472a-8b12-4eb089518f62.png)
You can see above that the value in both the component text and the tooltip are rounded properly.

