### PR TITLE
PYR-772: Add better help text to the Optional Layers Component

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -131,12 +131,12 @@
            [:label "Optional Layers"]
            [tool-tip-wrapper
             [:div "Check the boxes below to display additional layers."
-             [:div {:style { :margin-top 10 }}
-             "Note: The optional layers do not contain any data that can be queried by the "
+             [:div {:style {:margin-top 10}}
+             [:hr]
+             [:strong "Note"]
+             ": The optional layers do not contain any data that can be queried by the "
              [:strong "Point Information "]
-              "tool. Clicking on a area overlaid by an optional layer, will display point "
-              "information for the base layer, beneath the point clicked, and not for any selected optional layer(s)."]]
-
+             "tool. Clicking on an area overlaid by an optional layer will display point information for the base layer beneath the point clicked and not for any selected optional layer(s)."]]
             :left
             [:div {:style ($/combine ($/fixed-size "1rem")
                                      {:margin "0 .25rem 4px 0"


### PR DESCRIPTION
## Closes [PYR-772](https://sig-gis.atlassian.net/browse/PYR-772)

## Purpose
Add a helpful note, on the tooltip for the Optional Layers, that highlights
that underlays do not have point information that can be queried. It'll
serve as a guiding note for users that presume the Point Information
tool may provide data when clicking on a visible region of an underlay.

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Optional Layers

## Testing
1. Navigate to the Pyrecast landing page
2. Select the "Risk Tab"
3. Focus your attention on the "Optional Layers" section of the collapsible panel on the left side of the screen
4. Hover your mouse cursor over the helpful tooltip icon: depicted by an encircled question mark
5. Observe a note that highlights a point information data limitation of the "Opitonal Layers"

![Screenshot from 2022-05-17 14-18-40](https://user-images.githubusercontent.com/40574170/168883481-21086a1a-03ae-4a76-96e7-9ec93ae4644f.png)

