### PR TITLE
PYR-787 Clean up Fire History logic and add the 2021 layer.

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -159,7 +159,7 @@
                           (merge-fn (split-active-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)
-                              (re-matches #"fire-detections.*:(fire_history|us-buildings|us-transmission-lines).*" full-name))
+                              (re-matches #"fire-detections.*:(fire-history|us-buildings|us-transmission-lines).*" full-name))
                           (merge-fn (split-fire-detections full-name))
 
                           (str/starts-with? full-name "fuels")

--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -14,18 +14,6 @@
             [pyregence.components.map-controls.tool-button    :refer [tool-button]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Helper Functions
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn get-layer-name [geoserver-key filter-set update-layer!]
-  (go
-    (let [name (edn/read-string (:body (<! (u/call-clj-async! "get-layer-name"
-                                                              geoserver-key
-                                                              (pr-str filter-set)))))]
-      (update-layer! :name name)
-      name)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -98,7 +86,7 @@
                :checked   @show?
                :on-change #(go
                              (swap! show? not)
-                             (mb/set-visible-by-title! (<! (get-layer-name geoserver-key filter-set identity))
+                             (mb/set-visible-by-title! (<! (u/get-layer-name geoserver-key filter-set identity))
                                                        @show?))}]
       [:label {:for id} opt-label]]]))
 
@@ -112,7 +100,7 @@
       (fn []
         (go-loop [opt-layers sorted-underlays]
           (let [{:keys [filter-set z-index geoserver-key]} (first opt-layers)
-                layer-name                                 (<! (get-layer-name geoserver-key filter-set identity))]
+                layer-name                                 (<! (u/get-layer-name geoserver-key filter-set identity))]
             (mb/create-wms-layer! layer-name
                                   layer-name
                                   geoserver-key

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -33,12 +33,16 @@
 (defn toggle-fire-history-layer!
   "Toggles the fire history layer."
   []
-  (swap! !/show-fire-history? not)
-  (when (and @!/show-fire-history? (not (mb/layer-exists? "fire-history")))
-    (mb/create-fire-history-layer! "fire-history"
-                                   "fire-detections_fire-history%3Afire-history"
-                                   :pyrecast))
-  (mb/set-visible-by-title! "fire-history" @!/show-fire-history?))
+  (go
+    (let [layer-name (<! (u/get-layer-name :pyrecast #{"fire-detections" "fire-history"} identity))]
+      (swap! !/show-fire-history? not)
+      (when (and @!/show-fire-history? (not (mb/layer-exists? "fire-history")))
+        (mb/create-wms-layer! layer-name
+                              layer-name
+                              :pyrecast
+                              true
+                              200))
+      (mb/set-visible-by-title! layer-name @!/show-fire-history?))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Root component

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -647,7 +647,8 @@
                    :new-layers  new-layers)))
 
 (defn create-wms-layer!
-  "Adds WMS layer to the map. This is currently only used to add optional layers to the map."
+  "Adds a WMS layer to the map. This is currently used to add optional layers and
+   the fire history layer to the map."
   [id source geoserver-key visible? & [z-index]]
   (when id
     (if (layer-exists? id)
@@ -694,25 +695,6 @@
 (defn- mvt-source [layer-name geoserver-key]
   {:type  "vector"
    :tiles [(c/mvt-layer-url layer-name geoserver-key)]})
-
-(defn create-fire-history-layer!
-  "Adds red flag warning layer to the map."
-  [id layer-name geoserver-key]
-  (let [new-source {id (mvt-source layer-name geoserver-key)}
-        new-layers [{:id           id
-                     :source       id
-                     :source-layer "fire-history"
-                     :type         "fill"
-                     :metadata     {:type (get-layer-type id)}
-                     :paint        {:fill-color         ["step" ["get" "Decade"]
-                                                         "#cccccc"  ; Default
-                                                         1990 "#ffffb2"
-                                                         2000 "#fecc5c"
-                                                         2010 "#fd8d3c"
-                                                         2020 "#f03b20"]
-                                    :fill-opacity       0.3
-                                    :fill-outline-color "#ff0000"}}]]
-    (update-style! (get-style) :new-sources new-source :new-layers new-layers)))
 
 (defn remove-layer!
   "Removes layer that matches `id`"

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -608,3 +608,11 @@
           (dc/decimal)
           (dc/to-significant-digits 2)
           (dc/to-number)))))
+
+(defn get-layer-name [geoserver-key filter-set update-layer!]
+  (go
+    (let [name (edn/read-string (:body (<! (call-clj-async! "get-layer-name"
+                                                            geoserver-key
+                                                            (pr-str filter-set)))))]
+      (update-layer! :name name)
+      name)))


### PR DESCRIPTION
## Purpose
Cleans up the logic that deals with adding the Fire History layer. Note that `config.edn` will have to be updated on production and development to show the button that allows for the Fire History layer.

One question that I have here is whether or not the Fire History layer needs its own button. It seems that the Fire History layer would be better suited to be added as an optional layer/underlay. Please let me know your thoughts on this, as the code is easy enough to change either way.

## Related Issues
Closes PYR-787

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Module(s) Impacted
Underlays > Fire History Layer

## Testing
#### Role
Visitor

#### Steps
1. Navigate to the Pyrecast home page.
2. Click the "Show Fire History" button on the tool bar.

#### Desired Outcome
The Fire History layer should show and hide properly. 

## Screenshots
![Screenshot from 2022-05-25 14-11-08](https://user-images.githubusercontent.com/40574170/170337616-91433e48-7211-40f2-a987-ef3a861ae9be.png)

