### PR TITLE
PYR-790 Auto zoom to extent on the active fires tab.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -132,8 +132,8 @@
   (.fitBounds @the-map
               (LngLatBounds. (clj->js [[minx miny] [maxx maxy]]))
               (-> {:linear  true
-                   :padding (if (#{"fire-risk-forecast" "fire-detections"} (get-layer-type (:layer current-layer)))
-                              {:top 30 :bottom 150 :left 0 :right 0}
+                   :padding (if (#{"fire-active" "fire-risk-forecast" "fire-detections"} (get-layer-type (:layer current-layer)))
+                              {:top 150 :bottom 150 :left 150 :right 150}
                               0)}
                   (merge (when max-zoom {:maxZoom max-zoom}))
                   (clj->js))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -398,7 +398,7 @@
         body       (red-flag-popup url prod_type onset ends)]
     (mb/init-popup! "red-flag" lnglat body {:width "200px"})))
 
-(defn change-type!
+(defn- change-type!
   "Changes the type of data that is being shown on the map."
   [get-model-times? clear? zoom? max-zoom]
   (go
@@ -418,10 +418,13 @@
     (if clear?
       (clear-info!)
       (get-point-info! (mb/get-overlay-bbox)))
-    (when zoom?
+    (when (or zoom? (= @!/*forecast :active-fire))
       (mb/zoom-to-extent! (get-current-layer-extent) (current-layer) max-zoom))))
 
-(defn select-param! [val & keys]
+(defn- select-param!
+  "The function called whenever an input dropdown is changed on the collapsible panel.
+   Resets the proper state atoms with the new, selected inputs from the UI."
+  [val & keys]
   (swap! !/*params assoc-in (cons @!/*forecast keys) val)
   (!/set-state-legend-list! [])
   (reset! !/last-clicked-info nil)
@@ -435,7 +438,9 @@
                   (get-current-option-key main-key val :auto-zoom?)
                   (get-any-level-key     :max-zoom))))
 
-(defn select-forecast! [key]
+(defn- select-forecast!
+  "The function called whenever you select a new forecast/tab."
+  [key]
   (go
     (!/set-state-legend-list! [])
     (reset! !/last-clicked-info nil)


### PR DESCRIPTION
## Purpose
Adds auto zoom to extent on the Active Fires tab so that the first time you load the website you see all of the current active fires. Before, the website was centered on California which would sometimes hide active fires from other states from view.

Also adds some docstrings to `near-term-forecast.cljs` functions.

## Related Issues
Closes PYR-790

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Module(s) Impacted
Active Fires Tab > Zoom

## Testing
#### Role
Visitor

#### Steps
1. Visit Pyrecast (you should be taken by default to the Active Fires tab.

#### Desired Outcome
You should see all of the active fires on your screen.

#### Steps
1. Visit Pyrecast.
2. Go to the Weather tab.
3. Zoom in and scroll around a bit so that you're looking at a random part of the map.
4. Go back to the Active Fires tab.

#### Desired Outcome
Your map should be automatically moved such that you can see all of the active fires on your screen.

## Screenshots
When first loading Pyrecast:
### Before
![Screenshot from 2022-05-26 10-33-37](https://user-images.githubusercontent.com/40574170/170509964-7608b195-2a50-4f16-b24d-88803f1d69c4.png)

### After
![Screenshot from 2022-05-26 10-31-23](https://user-images.githubusercontent.com/40574170/170509753-fea2533d-70fc-4b73-be47-a2187204ce60.png)


