### PR TITLE
PYR-781 Use the specified GeoServer opacity when displaying legend colors.

### DIFF
--- a/src/cljs/pyregence/components/map_controls/legend_box.cljs
+++ b/src/cljs/pyregence/components/map_controls/legend_box.cljs
@@ -7,11 +7,12 @@
 ;; Styles
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- $legend-color [color]
+(defn- $legend-color [color opacity]
   {:background-color color
    :height           "1rem"
    :margin-right     ".5rem"
-   :min-width        "1rem"})
+   :min-width        "1rem"
+   :opacity          opacity})
 
 (defn- $legend-box [show? time-slider?]
   {:left          (if (and show? (not @!/mobile?)) "20rem" "2rem")
@@ -45,7 +46,7 @@
           (map-indexed (fn [i leg]
                          ^{:key i}
                          [:div {:style ($/combine {:display "flex" :justify-content "flex-start"})}
-                          [:div {:style ($legend-color (get leg "color"))}]
+                          [:div {:style ($legend-color (get leg "color") (get leg "opacity"))}]
                           [:label (str (get leg "label") (u/clean-units units))]])
                        (if reverse?
                          (reverse processed-legend)


### PR DESCRIPTION
## Purpose
The legend box component on Pyrecast previously did not take into account the opacity of a color (as specified in the GeoServer style) before rendering it to the front end. This PR fixes that.

## Related Issues
Closes PYR-781

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Module(s) Impacted
Point Info > Legend Box

## Testing
#### Role
Visitor

#### Steps
1. Navigate to the Active Fires tab.
2. Select an active fire.
3. Look at the legend box in the top left corner of the screen.

#### Desired Outcome
The colors on the legend should match the colors you see on the active fire layer. Note that this is a pretty subtle change, so the legend may not look much different than it did before. 

## Screenshots
### Before
![Screenshot from 2022-05-26 11-13-09](https://user-images.githubusercontent.com/40574170/170518925-5fbf612c-5748-43d8-a96f-90869a80e9f5.png)

### After
![Screenshot from 2022-05-26 11-13-04](https://user-images.githubusercontent.com/40574170/170518942-8f1c018c-512d-4ee9-8708-bb162e60e1e9.png)

Notice how the bottom three colors on the legend are at 50% opacity in the "After" photo. All other colors have 100% opacity so they are unchanged.
