### PR TITLE
PYR-798 Fix a bug with null values on the red flag warning layer.

### DIFF
--- a/src/cljs/pyregence/components/popups.cljs
+++ b/src/cljs/pyregence/components/popups.cljs
@@ -63,6 +63,6 @@
    [:h6 {:style ($popup-header)}
     prod-type]
    [:div
-    [fire-property "Onset" onset]
-    [fire-property "Ends" ends]
-    [red-flag-link url]]])
+    [fire-property "Onset" (if (= onset "null") "N/A" onset)]
+    [fire-property "Ends" (if (= ends "null") "N/A" ends)]
+    (when (not= url "null") [red-flag-link url])]])


### PR DESCRIPTION
## Purpose
Addresses a UI bug where the red flag warning API call returns `null` values for the fields used in the popup. 

For example, the onset, ends, and url fields (which are used in the popup) are null here:
```json
"properties": {
                "CAP_ID": null,
                "MSG_TYPE": null,
                "PROD_TYPE": "Fire Weather Watch",
                "VTEC": null,
                "PHENOM": "Fire Weather",
                "SIG": "Watch",
                "WFO": "KEPZ",
                "EVENT": null,
                "ISSUANCE": 1653840000,
                "EXPIRATION": 1653879600,
                "ONSET": null,
                "ENDS": null,
                "URL": null,
                "COLOR": "FFDEAD",
                "PRIORITY": 116,
                "WARNID": null
            },
```

## Related Issues
Closes PYR-798

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Module(s) Impacted
Red Flag layer > Popup

## Testing
#### Role
Visitor

#### Steps
1. Visit the Pyrecast homepage
2. Turn on the Red Flag warning layer
3. Click on different red flag layers

#### Desired Outcome
You should not get any popups that say `null` for any field (it should instead say `N/A`) and for any popups that say `N/A` there should not be a button that says "Click for more info" on the popup.

## Screenshots

### Before
![Screenshot from 2022-05-27 13-08-26](https://user-images.githubusercontent.com/40574170/170751134-7ced7d38-a1f5-4702-8f5a-b53ed3bdcc1e.png)

### After
![Screenshot from 2022-05-27 13-06-29](https://user-images.githubusercontent.com/40574170/170751076-93b59d6a-cfc9-4a0c-8947-30993e9dd277.png)