### PR TITLE
PYR-693 Redirect from the Match Drop page when not logged in.

### DIFF
--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -89,22 +89,27 @@
   "The root comopnent for the match drop /dashboard page.
    Displays a header, refresh button, and a table of a user's match drops "
   [{:keys [user-id]}]
-  (when (nil? user-id) (u/redirect-to-login! "/dashboard"))
   (reset! _user-id user-id)
   (user-match-drops user-id)
   (fn [_]
-    [:div {:style ($/combine $/root {:height   "100%"
-                                     :padding  0
-                                     :position "relative"})}
-     [message-box-modal]
-     [:div {:style ($/combine $/flex-col {:padding "2rem 8rem"})}
-      [:div {:style {:display "flex"}}
-       [:h3 {:style {:margin-bottom "0"
-                     :margin-right  "1rem"}}
-        "Match Drop Dashboard"]
-       [:button {:class    (<class $/p-form-button)
-                 :on-click #(user-match-drops user-id)}
-        "Refresh"]]
-      [:div {:style {:padding "1rem"
-                     :width   "100%"}}
-       [match-drop-table]]]]))
+    (cond
+      (nil? user-id) ; User is not logged in
+      (do (u/redirect-to-login! "/dashboard")
+          nil)
+
+      :else  ; User is logged in
+      [:div {:style ($/combine $/root {:height   "100%"
+                                       :padding  0
+                                       :position "relative"})}
+       [message-box-modal]
+       [:div {:style ($/combine $/flex-col {:padding "2rem 8rem"})}
+        [:div {:style {:display "flex"}}
+         [:h3 {:style {:margin-bottom "0"
+                       :margin-right  "1rem"}}
+          "Match Drop Dashboard"]
+         [:button {:class    (<class $/p-form-button)
+                   :on-click #(user-match-drops user-id)}
+          "Refresh"]]
+        [:div {:style {:padding "1rem"
+                       :width   "100%"}}
+         [match-drop-table]]]])))


### PR DESCRIPTION
## Purpose
Immediately redirect to the log in page when trying to access the `/dashboard` page without being logged in.

## Related Issues
Closes PYR-693
This PR was opened in place of #694 

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Module(s) Impacted
Match Drop > Dashboard

## Testing
#### Role
Visitor

#### Steps
1. Visit Pyrecast without being logged in.
2. Try to visit the https://pyrecast.org/dashboard page.

#### Desired Outcome
You are redirected immediately to the `/login` page without seeing any of the `/dashboard` page.

---

#### Role
User

#### Steps
1. Visit Pyrecast.
2. Log in.
4. Try to visit the https://pyrecast.org/dashboard page.

#### Desired Outcome
You should successfully see the Match Drop dashboard page.
