### PR TITLE
PYR-777 Read in isochrones in capabilities.clj

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -154,8 +154,9 @@
                           (re-matches #"([a-z|-]+_)\d{8}_\d{2}:([a-z|-]+\d*_)+\d{8}_\d{6}" full-name)
                           (merge-fn (split-risk-weather-psps-layer-name full-name))
 
-                          (and (re-matches #"([a-z|-]+_)[a-z|-]+[a-z|\d|-]*_\d{8}_\d{6}:([a-z|-]+_){2}\d{2}_([a-z|-]+_)\d{8}_\d{6}" full-name)
-                               (or (get-config :features :match-drop) (not (str/includes? full-name "match-drop"))))
+                          (or (str/includes? full-name "isochrones")
+                              (and (re-matches #"([a-z|-]+_)[a-z|-]+[a-z|\d|-]*_\d{8}_\d{6}:([a-z|-]+_){2}\d{2}_([a-z|-]+_)\d{8}_\d{6}" full-name)
+                                   (or (get-config :features :match-drop) (not (str/includes? full-name "match-drop")))))
                           (merge-fn (split-active-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)


### PR DESCRIPTION
## Purpose
Adds a check for isochrones layers to `capabilties.clj` so that the `layers` atom will be updated properly. An example of an isochrone layer in the `layers` atom is the following:

```clojure
{:hour 0,
  :workspace "fire-spread-forecast_nm-bear-trap_20220527_203800",
  :layer-group "",
  :forecast "fire-spread-forecast",
  :model-init "20220527_203800",
  :sim-time "20220527_203800_90",
  :layer "fire-spread-forecast_nm-bear-trap_20220527_203800:elmfire_landfire_90_isochrones_nm-bear-trap_20220527_203800_90",
  :extent ["-107.594818699476"
           "33.66942727117919"
           "-107.43988257004366"
           "33.760966431942386"],
  :filter-set #{"90"
                "isochrones"
                "nm-bear-trap"
                "landfire"
                "fire-spread-forecast"
                "elmfire"
                "20220527_203800"},
  :fire-name "nm-bear-trap"}
```

## Related Issues
Closes PYR-777

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

