### PR TITLE
PYR-800 Update the Fire History layer with the new columns

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -735,9 +735,9 @@
                                     :z-index 1003}
                      :layout       {:text-allow-overlap false
                                     :text-anchor        "top"
-                                    :text-field         ["concat" ["to-string" ["get" "INCIDENT"]]
+                                    :text-field         ["concat" ["to-string" ["get" "incidentna"]]
                                                                   " ("
-                                                                  ["to-string" ["get" "FIRE_YEAR"]]
+                                                                  ["to-string" ["get" "fireyear"]]
                                                                   ")"]
                                     :text-font          ["Open Sans Semibold" "Arial Unicode MS Regular"]
                                     :text-size          12

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -400,8 +400,8 @@
 
 (defn- init-fire-history-popup! [feature lnglat]
   (let [properties (-> feature (aget "properties") (js->clj))
-        {:strs [INCIDENT FIRE_YEAR GIS_ACRES]} properties
-        body       (fire-history-popup INCIDENT FIRE_YEAR GIS_ACRES)]
+        {:strs [incidentna fireyear gisacres]} properties
+        body       (fire-history-popup incidentna fireyear gisacres)]
     (mb/init-popup! "fire-history" lnglat body {:width "200px"})))
 
 (defn- change-type!


### PR DESCRIPTION
## Purpose
Updates the Fire History layer with the new column names. Before doing this, I updated the relevant layers on the `data` GeoServer. The new Fire History layer now has burned acres data for 2021 fires.

## Related Issues
Closes PYR-800

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Screenshots
![Screenshot from 2022-05-31 18-23-14](https://user-images.githubusercontent.com/40574170/171294105-f45197c1-28d0-4475-8d14-4a3a74823bf2.png)

