### PR TITLE
PYR-809: Add 2022 CA fuelscape and 2022 LANDFIRE 2.20 Layers on the Fuels tab in the Source Dropdown

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -140,12 +140,12 @@
                                                        "), © Salo Sciences, Inc. 2020."
                                                        [:br]
                                                        [:br]
-                                                       [:strong "2021 California fuelscape"]
+                                                       [:strong "2022 California fuelscape"]
                                                        " prepared by Pyrologix, LLC ("
                                                        [:a {:href   "https://pyrologix.com"
                                                             :target "_blank"}
                                                         "https://pyrologix.com"]
-                                                       "), 2021."
+                                                       "), 2022."
                                                        [:br]
                                                        [:br]
                                                        [:strong "California Ecosystem Climate Solutions"]
@@ -297,12 +297,12 @@
                                                               "Source of surface and canopy fuel inputs:"
                                                               [:br]
                                                               [:br]
-                                                              [:strong "- 2021 California fuelscape"]
+                                                              [:strong "- 2022 California fuelscape"]
                                                               " prepared by Pyrologix, LLC ("
                                                               [:a {:href   "https://pyrologix.com"
                                                                    :target "_blank"}
                                                                "https://pyrologix.com"]
-                                                              "), 2021."
+                                                              "), 2022."
                                                               [:br]
                                                               [:br]
                                                               [:strong "- California Forest Observatory"]
@@ -378,12 +378,12 @@
                                                               "Source of surface and canopy fuel inputs:"
                                                               [:br]
                                                               [:br]
-                                                              [:strong  "- 2021 California fuelscape"]
+                                                              [:strong  "- 2022 California fuelscape"]
                                                               " prepared by Pyrologix, LLC ("
                                                               [:a {:href   "https://pyrologix.com"
                                                                    :target "_blank"}
                                                                "https://pyrologix.com"]
-                                                              "), 2021."
+                                                              "), 2022."
                                                               [:br]
                                                               [:br]
                                                               [:strong "- California Forest Observatory"]


### PR DESCRIPTION
## Purpose
Updates the labels and filters in `config.cljs` so that Pyrecast points to
the added 2022 fuel layers.

- CA fuelscape
- 2022 LANDFIRE 2.20

This was verified by enabling the "Source Dropdown" and verifying the copy
updates. Changing layers is reflected on the map, so the `filter` changes
reflect a valid path on the data server

## Related Issues
Closes [PYR-809](https://sig-gis.atlassian.net/browse/PYR-809)

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)
- [X] No new reflection warnings (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. Underlays > Structures Layer) -->
<!-- The current list of all Modules is: -->
<!-- Fuels Tab, Weather Tab, Risk Tab, Active Fires Tab, PSPS Tab, -->
<!-- Underlays, Point Info, Toolbars, and Mobile. -->
<!-- e.g. Toolbars -->
Fuels Tab > Side Panel

## Testing
#### Role
Visitor

#### Steps
1. Navigate to the "Pyrecast" Landing Page
2. Navigate to the "Fuels Tab" and Click.
3. Click the Source Dropdown on the Side Panel

#### Desired Outcome
The Source Dropdown will have 2022 CA fuelscape and LANDFIRE 2.2.0 as options

## Screenshots, Etc.
![image](https://user-images.githubusercontent.com/1130619/173141408-a8d5bb2f-3ad3-4fa7-8b86-fa646f3a89a3.png)
