### PR TITLE
PYR-807: The admin page forgets your selected organization after updating settings.

### DIFF
--- a/src/cljs/pyregence/pages/admin.cljs
+++ b/src/cljs/pyregence/pages/admin.cljs
@@ -39,7 +39,7 @@
 ;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- get-selected-org [id]
+(defn- get-org-by-id [id]
   (->> @orgs
        (filter #(= id (:opt-id %)))
        first))
@@ -52,7 +52,7 @@
   (reset! *org-auto-add?     (:auto-add?     org)))
 
 (defn- set-selected-org-by-id! [id]
-  (set-selected-org! (get-selected-org id)))
+  (set-selected-org! (get-org-by-id id)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; API Calls
@@ -67,8 +67,7 @@
   (go
     (reset! orgs (edn/read-string (:body (<! (u/call-clj-async! "get-org-list" @_user-id))))) ; TODO get from session on the back end
     ;; find the current org, by id, in the updated @orgs vector or fallback to the org on the first index
-    (let [selected-org (or (get-selected-org @*org-id) (first @orgs))]
-    (set-selected-org! selected-org))
+    (set-selected-org! (or (get-org-by-id @*org-id) (first @orgs)))
     (get-org-users-list @*org-id)))
 
 (defn- update-org-info! [opt-id org-name email-domains auto-add? auto-accept?]


### PR DESCRIPTION
## Purpose
The purpose of this ticket is to fix a bug in the admin page that looses track of the currently selected organization after settings updates are made.

The bug existed because of the way state was used to drive the `org-settings` component.
For the sake of simplicity, an atom was created for each of the values in an org object.
Helper functions were additionally added to facilitate and maintain consistency with the "currently selected organization"


## Related Issues
Closes [PYR-807](https://sig-gis.atlassian.net/browse/PYR-807)

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)
- [X] No new reflection warnings (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. Underlays > Structures Layer) -->
<!-- The current list of all Modules is: -->
<!-- Fuels Tab, Weather Tab, Risk Tab, Active Fires Tab, PSPS Tab, -->
<!-- Underlays, Point Info, Toolbars, and Mobile. -->
<!-- e.g. Toolbars -->
Admin Page

## Testing
#### Role
<!-- Visitor, User, Admin -->
Admin

#### Steps
1. Navigate to the Pyrecast landing page
2. Click the `Log In` link at the top right of the page.
3. Log in as an user with the "Admin" role.
4. Visit the **Admin Page**
   On Production: https://pyrecast.org/admin
   For Local Dev: https://pyregence-dev.sig-gis.com
5. Select an organization, other than the selected default.
   By default, the "Organization List" sets the first item as the current selection. The selected item is highlighted with a distinct background color. 

#### Desired Outcome
The highlighted selection toggles from the default selected item to the item that was clicked.

<!-- Visitor, User, Admin -->
Admin

#### Steps
1. Navigate to the Pyrecast landing page
2. Click the `Log In` link at the top right of the page.
3. Log in as an user with the "Admin" role.
4. Visit the **Admin Page**
   On Production: https://pyrecast.org/admin
   For Local Dev: https://pyregence-dev.sig-gis.com
5. Select an organization, other than the selected default.
   By default, the "Organization List" sets the first item as the current selection. The selected item is highlighted with a distinct background color.
6. Make changes to the fields in the "Org Settings" form.
7. Click Update and confirm "Yes, Continue"

#### Desired Outcome
The active organization remains selected, and the update, on its associated settings values, is reflected in the updated fields of the "Settings" form.

## Screenshots, Etc
![bugfix-proof](https://user-images.githubusercontent.com/1130619/174236024-987dc2e4-0ef2-4823-a5b1-53e7089a441d.gif)
