### PR TITLE
PYR-814 Disable CFO Risk layers in the UI.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -313,8 +313,9 @@
                                                               "), © Salo Sciences, Inc. 2020."]
                                                  :options    {:landfire {:opt-label "2022 CA fuelscape"
                                                                          :filter    "landfire"}
-                                                              :cfo      {:opt-label "2020 CA Forest Obs."
-                                                                         :filter    "cfo"}}}
+                                                              :cfo      {:opt-label    "2020 CA Forest Obs."
+                                                                         :filter       "cfo"
+                                                                         :disabled-for #{:times-burned :impacted :fire-area :fire-volume :plignrate}}}}
                                     :model      {:opt-label  "Model"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Computer fire spread model used to generate active fire and risk forecasts."


### PR DESCRIPTION
## Purpose
Temporarily disabling the CFO fuel option on the Risk tab because those layers are not being pushed anymore.

## Related Issues
Closes PYR-814

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
The CFO option on the Risk tab should not be clickable.
 
## Screenshots
![Screenshot from 2022-06-17 09-32-08](https://user-images.githubusercontent.com/40574170/174339866-e9e5cc26-ffda-4147-aced-7382e3d96e2e.png)

