### PR TITLE
PYR-824 Revert small CSS change.

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -235,7 +235,6 @@ th {
 label {
   display: inline-block;
   margin-bottom: 0.5rem;
-  cursor: pointer;
 }
 
 button {
@@ -299,9 +298,14 @@ input:disabled {
   cursor: not-allowed;
 }
 
-#optional-layer-checkbox input[disabled] + label {
+#optional-layer-checkbox input:disabled + label {
   opacity: 0.3;
   cursor: not-allowed;
+}
+
+#optional-layer-checkbox input:enabled,
+#optional-layer-checkbox label {
+  cursor: pointer;
 }
 
 button::-moz-focus-inner,


### PR DESCRIPTION
## Purpose
Reverting a small style change where a cursor of type pointer was being applied to all labels instead of just labels within the optional layers component.

## Related Issues
Closes PYR-824

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Side Panel > Optional Layers

#### Role
Visitor

#### Steps
1. Do a hard refresh on your browser to apply the new style changes (Command + Shift + R)
2. On the side panel, navigate down to the optional layers box.
3. Hover over both the checkboxes and labels in the optional layers box.

#### Desired Outcome
You should get a cursor of type pointer when hovering over an enabled checkbox and its associated label. 

---

#### Module Impacted
Side Panel > Optional Layers

#### Role
Visitor

#### Steps
1. Do a hard refresh on your browser to apply the new style changes (Command + Shift + R)
2. On the side panel, navigate down to any one of the input labels besides any of the Optional Layers labels (e.g. Fire Name on the Active Fires tab).
3. Hover over that label.

#### Desired Outcome
You should **not** get a cursor of type pointer when hovering over the label.
