### PR TITLE
PYR-653 Fix some issues with WFS feature highlights

### DIFF
--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -68,9 +68,9 @@
                                    (reset! image-src nil)
                                    (let [image-chan  (get-camera-image-chan @active-camera)]
                                      (reset! camera-age (-> (:update-time @active-camera)
-          					                                        (u/camera-time->js-date)
-          					                                        (u/get-time-difference)
-          					                                        (u/ms->hr)))
+                                                            (u/camera-time->js-date)
+                                                            (u/get-time-difference)
+                                                            (u/ms->hr)))
                                      (when (> 4 @camera-age)
                                        (reset! image-src (<! image-chan))
                                        (reset! exit-chan

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -13,7 +13,7 @@
             [pyregence.utils  :as u]
             [pyregence.config :as c]
             [pyregence.components.mapbox    :as mb]
-            [pyregence.components.popups    :refer [fire-popup red-flag-popup fire-history-popup]]
+            [pyregence.components.popups    :refer [fire-popup]]
             [pyregence.components.common    :refer [tool-tip-wrapper]]
             [pyregence.components.messaging :refer [message-box-modal toast-message!]]
             [pyregence.components.svg-icons :as svg]
@@ -392,18 +392,6 @@
     (mb/init-popup! "fire" lnglat body {:width "200px"})
     (mb/set-center! lnglat 0)))
 
-(defn- init-red-flag-popup! [feature lnglat]
-  (let [properties (-> feature (aget "properties") (js->clj))
-        {:strs [url prod_type onset ends]} properties
-        body       (red-flag-popup url prod_type onset ends)]
-    (mb/init-popup! "red-flag" lnglat body {:width "200px"})))
-
-(defn- init-fire-history-popup! [feature lnglat]
-  (let [properties (-> feature (aget "properties") (js->clj))
-        {:strs [incidentna fireyear gisacres]} properties
-        body       (fire-history-popup incidentna fireyear gisacres)]
-    (mb/init-popup! "fire-history" lnglat body {:width "200px"})))
-
 (defn- change-type!
   "Changes the type of data that is being shown on the map."
   [get-model-times? clear? zoom? max-zoom]
@@ -417,15 +405,10 @@
                               (/ @!/active-opacity 100)
                               (get-psps-layer-style))
       (mb/clear-popup!)
+      ; When we have a style-fn (which indicates a WFS layer) add the feature highlight.
+      ; For now, the only dropdown layer that is WFS is the *Active Fires layer.
       (when (some? style-fn)
-        (mb/add-feature-highlight! "fire-active" "fire-active" :click-fn init-fire-popup!)
-        (mb/add-feature-highlight! "red-flag" "red-flag" :click-fn init-red-flag-popup!)
-        (mb/add-feature-highlight! "fire-history" "fire-history"
-                                   :click-fn init-fire-history-popup!
-                                   :source-layer "fire-history")
-        (mb/add-feature-highlight! "fire-history-centroid" "fire-history-centroid"
-                                   :click-fn init-fire-history-popup!
-                                   :source-layer "fire-history-centroid"))
+        (mb/add-feature-highlight! "fire-active" "fire-active" :click-fn init-fire-popup!))
       (get-legend! source))
     (if clear?
       (clear-info!)


### PR DESCRIPTION
## Purpose
There was an issue with the Mapbox feature highlights where they were not always created in all scenarios. This fixes that by moving the `add-feature-highlight!` functions to the proper component instead of in `near-term-forecast!`.

## Related Issues
Closes PYR-653

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
The red flag, fire history, camera, and active fire layers/popups should all work normally. 
