### PR TITLE
Update tooltip for Active Fires tab

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -340,7 +340,7 @@
                   :block-info?     true
                   :reverse-legend? false
                   :time-slider?    true
-                  :hover-text      "3-day forecasts of active fires with burning areas established from satellite-based heat detection."
+                  :hover-text      "5-day forecasts of active fires with burning areas established from satellite-based heat detection."
                   :params          {:fire-name  {:opt-label      "Fire Name"
                                                  :sort?          true
                                                  :hover-text     "Provides a list of active fires for which forecasts are available. To zoom to a specific fire, select it from the dropdown menu."


### PR DESCRIPTION
## Purpose
Changing the tooltip on the Active Fires tab to say "5-day" instead of "3-day" at the suggestion of Shane

## Screenshots
![Screenshot from 2022-07-05 09-56-46](https://user-images.githubusercontent.com/40574170/177378953-20beed2d-60db-4f32-9472-dca7d7995332.png)

