### PR TITLE
PYR1-717 Reverse the legend order for apcp layers

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -212,22 +212,26 @@
                                                               :wg     {:opt-label "Wind gust (mph)"
                                                                        :filter    "wg"
                                                                        :units     "mph"}
-                                                              :apcp   {:opt-label    "Accumulated precipitation (in)"
-                                                                       :filter       "apcp"
-                                                                       :units        "inches"
-                                                                       :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :rtma-ru}}
-                                                              :apcp01 {:opt-label    "1-hour precipitation (in)"
-                                                                       :filter       "apcp01"
-                                                                       :units        "inches"
-                                                                       :disabled-for #{:gfs0p25 :nam-awip12 :nbm :rtma-ru}}
-                                                              :apcp03 {:opt-label    "3-hour precipitation (in)"
-                                                                       :filter       "apcp03"
-                                                                       :units        "inches"
-                                                                       :disabled-for #{:gfs0p125 :gfs0p25 :hrrr :hybrid :nam-conusnest :nbm :rtma-ru}}
-                                                              :apcp06 {:opt-label    "6-hour precipitation (in)"
-                                                                       :filter       "apcp06"
-                                                                       :units        "inches"
-                                                                       :disabled-for #{:gfs0p125 :hrrr :hybrid :nam-awip12 :nam-conusnest :nbm :rtma-ru}}
+                                                              :apcp   {:opt-label       "Accumulated precipitation (in)"
+                                                                       :filter          "apcp"
+                                                                       :units           "inches"
+                                                                       :disabled-for    #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :rtma-ru}
+                                                                       :reverse-legend? false}
+                                                              :apcp01 {:opt-label       "1-hour precipitation (in)"
+                                                                       :filter          "apcp01"
+                                                                       :units           "inches"
+                                                                       :disabled-for    #{:gfs0p25 :nam-awip12 :nbm :rtma-ru}
+                                                                       :reverse-legend? false}
+                                                              :apcp03 {:opt-label       "3-hour precipitation (in)"
+                                                                       :filter          "apcp03"
+                                                                       :units           "inches"
+                                                                       :disabled-for    #{:gfs0p125 :gfs0p25 :hrrr :hybrid :nam-conusnest :nbm :rtma-ru}
+                                                                       :reverse-legend? false}
+                                                              :apcp06 {:opt-label       "6-hour precipitation (in)"
+                                                                       :filter          "apcp06"
+                                                                       :units           "inches"
+                                                                       :disabled-for    #{:gfs0p125 :hrrr :hybrid :nam-awip12 :nam-conusnest :nbm :rtma-ru}
+                                                                       :reverse-legend? false}
                                                               :vpd    {:opt-label    "Vapor pressure deficit (hPa)"
                                                                        :filter       "vpd"
                                                                        :units        "hPa"


### PR DESCRIPTION
## Purpose
Reverses the legends for each of the four APCP layers.

## Related Issues
Closes PYR1-717

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Point Info > Precipitation Layers Legend

#### Role
Visitor

#### Steps
1. Go to the Weather tab
2. Select each of the following layers:
  a. Accumulated precipitation
  b. 1-hour precipitation
  c. 3-hour precipitation
  d. 6-hour precipitation
3. Look at the legend for each layer.

#### Desired Outcome
For each layer's legend, the bins are sorted in order from smallest (on the top) to largest (on the bottom). That is, they start at 0 inches (at the top) and end at 20 inches (at the bottom).

