### PR TITLE
PYR1-718 Add conus-buildings layer to Pyrecast

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -160,7 +160,7 @@
                           (merge-fn (split-active-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)
-                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|us-buildings|us-transmission-lines).*" full-name))
+                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|conus-buildings|us-transmission-lines).*" full-name))
                           (merge-fn (split-fire-detections full-name))
 
                           (str/starts-with? full-name "fuels")

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -23,11 +23,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def common-underlays
-  {:us-buildings    {:enabled?      #(feature-enabled? :structures)
-                     :opt-label     "Structures"
-                     :z-index       104
-                     :filter-set    #{"fire-detections" "us-buildings"}
-                     :geoserver-key :shasta}})
+  {:conus-buildings    {:enabled?      #(feature-enabled? :structures)
+                        :opt-label     "Structures"
+                        :z-index       104
+                        :filter-set    #{"fire-detections" "conus-buildings"}
+                        :geoserver-key :shasta}})
 
 (def near-term-forecast-underlays
   (array-map


### PR DESCRIPTION
## Purpose
Adds the new `conus-buildings` layer in place of the `us-buildings` layer.

## Related Issues
Closes PYR1-718 

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
The "Structures" optional layer should load properly and display all of the continental United States.
 

## Screenshots
![Screenshot from 2022-08-10 12-29-04](https://user-images.githubusercontent.com/40574170/184003937-d0966490-be67-4b89-96f5-ea0307313cbb.png)

