### PR TITLE
PYR1-702: Bug: Point info for RTMA weather layers doesnt work

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -50,7 +50,7 @@
      :sim-time    sim-timestamp
      :hour        (/ (- (.getTime (java-date-from-string sim-timestamp))
                         (.getTime (java-date-from-string (str init-timestamp "0000"))))
-                     1000 60 60)}))
+                     1000.0 60 60)}))
 
 (defn- split-active-layer-name
   "Gets information about an active fire layer based on its name."


### PR DESCRIPTION
## Purpose
#### The problem
The Vega graph is fed ratio values it is unable to handle.

In Clojure, if an integer division results in decimal, Clojure holds the value as a Ratio.
https://practical.li/clojure/reference/clojure-syntax/ratios.html

#### The fix
Change one of the conversions constants, in the conversion from milliseconds to hours, to a decimal value. 
```
(/ (- simulated-timestamp initial-timestamp) 1000 60 60)
;; becomes
(/ (- simulated-timestamp initial-timestamp) 1000.0 60 60)
```

## Related Issues
Closes [PYR1-702](https://sig-gis.atlassian.net/browse/PYR1-702)

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. Symbol’s value as variable is void: PYR1-)
- [X] Code passes linter rules (Symbol’s value as variable is void: clj-kondo)
- [X] Feature(s) work when compiled (Symbol’s value as variable is void: clojure)
- [X] No new reflection warnings (Symbol’s value as variable is void: clojure)

## Module(s) Impacted
Point Info

## Testing
#### Role
Visitor

#### Steps
 1. Navigate to the **Pyrecast** landing page
 2. Navigate to the "Weather Tab"
 3. Leave the **_Weather Parameter_** dropdown as "Temperature"
 4. Set **_Model_** to "RTMA"
 5. Open the `Point Info Tool` and click on a point on the map.

 #### Desired Outcome
 The Point Info Vega Graph now displays an Hour scale reflecting fractions of an hour.

 ## Screenshots, Etc.
* _Note that the graph in this screenshot only has two values: due to a known Geosync issue_
![image](https://user-images.githubusercontent.com/1130619/184032079-0f3b3cd0-b851-41d6-ab36-c2b055fbb1c4.png)
