### PR TITLE
Red flag fix for main

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -728,7 +728,7 @@
 (defn create-red-flag-layer!
   "Adds red flag warning layer to the map."
   [id data]
-  (let [color      ["concat" "#" ["get" "color"]]
+  (let [color      ["get" "color"]
         new-source {id {:type "geojson" :data data :generateId true}}
         new-layers [{:id       id
                      :source   id


### PR DESCRIPTION
## Purpose
The `COLOR` field in the red flag https://www.wrh.noaa.gov/map/json/WR_All_Hazards.json API request now includes the `#` in the color (before it did not). This means that we need to update the way we draw the color in the red flag Mapbox layer to fix the broken red flag layer.

> This is a duplicate to #751 in order to get the fix into `main`.

## Related Issues
Closes PYR1-720

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
The red flag layer should show/hide normally.
