### PR TITLE
PYR1-705: Refactor utility functions, add `string-utils` namespace

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -1,13 +1,14 @@
 (ns pyregence.capabilities
-  (:require [clojure.edn        :as edn]
-            [clojure.string     :as str]
-            [clojure.set        :as set]
-            [clj-http.client    :as client]
-            [triangulum.utils    :as u]
-            [triangulum.config   :refer [get-config]]
-            [triangulum.database :refer [call-sql]]
-            [triangulum.logging  :refer [log log-str]]
-            [pyregence.views     :refer [data-response]]))
+  (:require [clj-http.client              :as client]
+            [clojure.edn                  :as edn]
+            [clojure.set                  :as set]
+            [clojure.string               :as str]
+            [pyregence.utils.string-utils :as u-str]
+            [pyregence.views              :refer [data-response]]
+            [triangulum.config            :refer [get-config]]
+            [triangulum.database          :refer [call-sql]]
+            [triangulum.logging           :refer [log log-str]]
+            [triangulum.utils             :as u]))
 
 ;;; State
 
@@ -113,7 +114,7 @@
    functions above."
   [geoserver-key workspace-name]
   (let [xml-response (-> (get-config :geoserver geoserver-key)
-                         (u/end-with "/")
+                         (u-str/end-with "/")
                          (str "wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities"
                               (when workspace-name
                                 (str "&NAMESPACE=" workspace-name)))

--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -1,12 +1,13 @@
 (ns pyregence.components.common
   (:require-macros [pyregence.herb-patch :refer [style->class]])
-  (:require [clojure.core.async         :refer [go <! timeout]]
-            [herb.core                  :refer [<class]]
-            [pyregence.styles           :as $]
-            [pyregence.utils            :as u]
-            [pyregence.utils.time-utils :as u-time]
-            [reagent.core               :as r]
-            [reagent.dom                :as rd]))
+  (:require [clojure.core.async           :refer [go <! timeout]]
+            [herb.core                    :refer [<class]]
+            [pyregence.styles             :as $]
+            [pyregence.utils              :as u]
+            [pyregence.utils.string-utils :as u-str]
+            [pyregence.utils.time-utils   :as u-time]
+            [reagent.core                 :as r]
+            [reagent.dom                  :as rd]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
@@ -144,14 +145,14 @@
   (let [{:keys [type autocomplete disabled? call-back autofocus? required? placeholder]
          :or {type "text" disabled? false call-back #(reset! state (u/input-value %))} required? false} opts]
     [:section {:style ($labeled-input)}
-     [:label {:for (u/sentence->kebab label)} label]
+     [:label {:for (u-str/sentence->kebab label)} label]
      [:input {:class         (style->class $/p-bordered-input)
               :auto-complete autocomplete
               :auto-focus    autofocus?
               :disabled      disabled?
               :required      required?
               :placeholder   placeholder
-              :id            (u/sentence->kebab label)
+              :id            (u-str/sentence->kebab label)
               :type          type
               :value         @state
               :on-change     call-back}]]))

--- a/src/cljs/pyregence/components/map_controls/information_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/information_tool.cljs
@@ -10,6 +10,7 @@
             [pyregence.utils                               :as u]
             [pyregence.utils.data-utils                    :as u-data]
             [pyregence.utils.number-utils                  :as u-num]
+            [pyregence.utils.string-utils                  :as u-str]
             [reagent.core                                  :as r]
             [reagent.dom                                   :as rd]))
 
@@ -91,7 +92,7 @@
                          (@!/*forecast)
                          (vals)
                          (into #{}))
-        add-units   #(u/end-with % (u-num/clean-units units))
+        add-units   #(u-str/end-with % (u-num/clean-units units))
         fbfm40?     (contains? *inputs :fbfm40)
         display-val (cond
                       fbfm40? ; for all fbfm40 layers we just need a simple lookup

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -2,7 +2,8 @@
   (:require [clojure.string               :as str]
             [pyregence.state              :as !]
             [pyregence.utils              :as u]
-            [pyregence.utils.number-utils :as u-num]))
+            [pyregence.utils.number-utils :as u-num]
+            [pyregence.utils.string-utils :as u-str]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Feature Flags
@@ -831,13 +832,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- wms-url [geoserver-key]
-  (str (u/end-with (geoserver-key @!/geoserver-urls) "/") "wms"))
+  (str (u-str/end-with (geoserver-key @!/geoserver-urls) "/") "wms"))
 
 (defn- wfs-url [geoserver-key]
-  (str (u/end-with (geoserver-key @!/geoserver-urls) "/") "wfs"))
+  (str (u-str/end-with (geoserver-key @!/geoserver-urls) "/") "wfs"))
 
 (defn- mvt-url [geoserver-key]
-  (str (u/end-with ((keyword geoserver-key) @!/geoserver-urls) "/") "gwc/service/wmts"))
+  (str (u-str/end-with ((keyword geoserver-key) @!/geoserver-urls) "/") "gwc/service/wmts"))
 
 (defn legend-url
   "Generates a URL for the legend given a layer."

--- a/src/cljs/pyregence/utils.cljs
+++ b/src/cljs/pyregence/utils.cljs
@@ -32,22 +32,6 @@
   [event]
   (-> event .-target .-files (aget 0)))
 
-;; Text
-
-(defn sentence->kebab
-  "Converts a string to a kebab-case string."
-  [string]
-  (-> string
-      (str/lower-case)
-      (str/replace #"[\s-\.\,]+" "-")))
-
-(defn end-with
-  "Appends `end` to `s` as long as `s` doesn't already end with `end`."
-  [s end]
-  (str s
-       (when-not (str/ends-with? s end)
-         end)))
-
 ;; Session
 
 (def session-key "pyregence")

--- a/src/cljs/pyregence/utils/string_utils.cljs
+++ b/src/cljs/pyregence/utils/string_utils.cljs
@@ -1,0 +1,21 @@
+(ns pyregence.utils.string-utils
+  (:require [clojure.string :as str]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Utility Functions - String Utils
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;p;;;;;;;;;;;;;;;;;;
+
+(defn sentence->kebab
+  "Converts a string to a kebab-case string."
+  [string]
+  (-> string
+      (str/lower-case)
+      (str/replace #"[\s-\.\,]+" "-")))
+
+(defn end-with
+  "Appends `end` to `s` as long as `s` doesn't already end with `end`."
+  [s end]
+  (str s
+       (when-not (str/ends-with? s end)
+         end)))
+


### PR DESCRIPTION
## Purpose
Refactor utility functions into cohesive namespaces: Add `string-utils`
namespace, migrate string related functions into it, and update references
