### PR TITLE
PYR1-16: Add icon opacity

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -418,7 +418,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- symbol-opacity [opacity]
-  {"text-opacity" ["step" ["zoom"] 0 6 opacity 22 opacity]})
+  {"text-opacity" ["step" ["zoom"] 0 6 opacity 22 opacity]
+   "icon-opacity" opacity})
 
 (defn- circle-opacity [opacity]
   {"circle-opacity"        opacity


### PR DESCRIPTION
## Purpose
Bugfix: minor change to fix the fire icon opacity updates

## Related Issues
Closes [PYR1-16](https://sig-gis.atlassian.net/browse/PYR1-16)

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [X] Code passes linter rules (`clj-kondo --lint src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [X] No new reflection warnings (`clojure -M:check-reflection`)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. Toolbars > Camera Tool) -->
<!-- The current list of all Modules is: -->
<!-- Layers, Side Panel, Point Info, Toolbars, Match Drop, Misc., Mobile -->
Layers > Active Fires

## Testing
#### Role
<!-- Visitor, User, Admin -->
Visitor

#### Steps
 1. Navigate to the **Pyrecast** landing page
 2. Go to the "Active Fires" tab
 3. Change the opacity of the fire icons with the slider

#### Desired Outcome
The opacity of the Fire Icon and Labeled Text changed as expected.

