### PR TITLE
PYR1-26: Add fix to prevent the forecast start time from resetting when switching models

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -147,7 +147,9 @@
             (assoc-in (get-forecast-opt :params)
                       [:model-init :options]
                       processed-times))
-    (swap! !/*params assoc-in [@!/*forecast :model-init] (ffirst processed-times))))
+    (swap! !/*params assoc-in [@!/*forecast :model-init]
+           (or (when (processed-times @!/*last-start-time) @!/*last-start-time)
+               (ffirst processed-times)))))
 
 (defn- get-layers! [get-model-times?]
   (go
@@ -429,6 +431,8 @@
   (!/set-state-legend-list! [])
   (reset! !/last-clicked-info nil)
   (let [main-key (first keys)]
+    (when (= main-key :model-init)
+      (reset! !/*last-start-time val))
     (when (= main-key :fire-name)
       (reset! !/*layer-idx 0)
       (swap! !/*params assoc-in (cons @!/*forecast [:burn-pct]) :50)

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -19,6 +19,8 @@ field associated with each layer from the `param-layers`, starts at 0, and is an
 (defonce ^{:doc "A map containing the selected parameters/inputs from each forecast tab.
 Ex: {:fuels {:layer :fbfm40, :model :landfire, :model-init :20210407_000000} ... }"}
   *params (r/atom {}))
+(defonce ^{:doc "A UTC keyword value, corresponding to the last selected \"Forecast Start Time\""}
+  *last-start-time (r/atom nil))
 (defonce ^{:doc "An integer value, from 0 to 100, that designates the opacity for the active layer. Defaults to 100"}
   active-opacity (r/atom 100.0))
 (defonce ^{:doc "A map that combines the values from the `options-config` and the processed output from a call to process-capabilities! in near_term_forecast.cljs.


### PR DESCRIPTION
## Purpose
The purpose of this fix is to prevent the start time from resetting when switching models.

To accomplish this, an atom was introduced that tracks the last selected start time: `*last-start-time`

When switching models, a request for the relevant layers and model times is processed.
The `process-model-times!` function, is responsible for creating an options map; that is used to drive the **Forecast  Start Time** dropdown component,
and for setting the initial value of that dropdown; by `assoc-in` the value onto the `*params` atom.

A change was added during that initial value setting. Before defaulting to the first model-times value, an attempt was added to first set the `*last-start-time`. If its nil, the first value of the sequence is selected.

## Related Issues
Closes [PYR1-26](https://sig-gis.atlassian.net/browse/PYR1-26)

## Submission Checklist
- [X] Included Jira issue in the PR title [e.g. PYR1-### Did something here]
- [X] Code passes linter rules [clj-kondo --lint src]
- [X] Feature(s) work when compiled [clojure -M:compile-cljs]
- [X] No new reflection warnings [clojure -M:check-reflection]

## Module(s) Impacted
Active Fires Tab
