### PR TITLE
Change the default time display preference to "local".

### DIFF
--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -63,7 +63,7 @@ that there are 145 different time steps in this specific forecast."}
 (defonce ^{:doc "A boolean that maintains the hide/show toggle state of the Red Flag Warning Tool."}
   show-red-flag? (r/atom false))
 (defonce ^{:doc "A boolean that maintains UTC or local time display preference."}
-  show-utc? (r/atom true))
+  show-utc? (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Point Information State


### PR DESCRIPTION
## Purpose
To update the default time display preference from UTC to local.

## Related Issues
Closes [PYR1-724](https://sig-gis.atlassian.net/browse/PYR1-724)

## Submission Checklist
- [X] Included Jira issue in the PR title [e.g. PYR1-### Did something here]
- [X] Code passes linter rules [clj-kondo --lint src]
- [X] Feature(s) work when compiled [clojure -M:compile-cljs]
- [X] No new reflection warnings [clojure -M:check-reflection]

## Module(s) Impacted
Toolbars

## Testing
#### Role
Visitor

#### Steps
 1. Navigate to the "Risk" tab on the **Pyrecast** landing page
    On Development: https://pyregence-dev.sig-gis.com/admin
 5. Observe the listed times available for the "Forecast Start Time" dropdown and the time shown on the Time Slider Control.

#### Desired Outcome
The time entries shown on Pyrecast are "local" time strings and the radio button on the Time Slider Control reflects that the time display preference is "Local".

## Screenshots
![image](https://user-images.githubusercontent.com/1130619/193750214-ecd08544-e1c6-4dee-8c64-bcaac750d413.png)

