### PR TITLE
PYR1-760 Add the point info tool to mobile

### DIFF
--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -37,7 +37,7 @@
    :top       "2rem"
    :width     "10%"})
 
-(defn- $mobile-camera-tool [show?]
+(defn- $mobile-camera-tool []
   {:background-color ($/color-picker :bg-color)
    :box-shadow       (str "1px 0 5px " ($/color-picker :dark-gray 0.3))
    :color            ($/color-picker :font-color)
@@ -46,17 +46,16 @@
    :width            "100%"
    :z-index          "105"})
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- mobile-camera-tool-header []
   [:div#collapsible-camera-header
-   {:style {:background-color ($/color-picker :header-color)
+   {:style {:align-items      "center"
+            :background-color ($/color-picker :header-color)
             :display          "flex"
             :justify-content  "space-between"
-            :align-items      "center"
             :padding             "0 1rem"}}
    [:span {:style {:fill         ($/color-picker :font-color)
                    :height       "1.5rem"
@@ -110,86 +109,86 @@
                                         (reset! exit-chan
                                                 (u-async/refresh-on-interval! #(go (reset! image-src (<! (get-camera-image-chan @active-camera))))
                                                                               60000)))))))
-               render-content (fn [_ _]
-                                (cond
-                                  (nil? @active-camera)
-                                  [:div {:style {:padding "1.2em"}}
-                                   "Click on a camera to view the most recent image. Powered by "
-                                   [:a {:href   "http://www.alertwildfire.org/"
-                                        :ref    "noreferrer noopener"
-                                        :target "_blank"}
-                                    "Alert Wildfire"] "."]
-
-                                  (>= @camera-age 4)
-                                  [:div {:style {:padding "1.2em"}}
-                                   [:p (str "This camera has not been refreshed for " (u-num/to-precision 1 @camera-age) " hours. Please try again later.")]
-                                   [:p "Click"
-                                    [:a {:href   (str "https://www.alertwildfire.org/region/?camera=" (:name @active-camera))
-                                         :ref    "noreferrer noopener"
-                                         :target "_blank"}
-                                     " here "]
-                                    "for more information about the " (:name @active-camera) " camera."]]
-
-                                  @image-src
-                                  [:div
-                                   [:div {:style {:display         "flex"
-                                                  :justify-content "center"
-                                                  :position        "absolute"
-                                                  :top             "2rem"
-                                                  :width           "100%"}}
-                                    [:label (str "Camera: " (:name @active-camera))]]
-                                   [:img {:src   "images/awf_logo.png"
-                                          :style ($/combine $awf-logo-style)}]
-                                   (when @!/terrain?
-                                     [tool-tip-wrapper
-                                      "Zoom Out to 2D"
-                                      :left
-                                      [:button {:class    (<class $/p-themed-button)
-                                                :on-click reset-view
-                                                :style    {:bottom   "1.25rem"
-                                                           :padding  "2px"
-                                                           :position "absolute"
-                                                           :left     "1rem"}}
-                                       [:div {:style {:height "32px"
-                                                      :width  "32px"}}
-                                        [svg/return]]]])
-                                   [tool-tip-wrapper
-                                    "Zoom Map to Camera"
-                                    :right
-                                    [:button {:class    (<class $/p-themed-button)
-                                              :on-click zoom-camera
-                                              :style    {:bottom   "1.25rem"
-                                                         :padding  "2px"
-                                                         :position "absolute"
-                                                         :right    "1rem"}}
-                                     [:div {:style {:height "32px"
-                                                    :width  "32px"}}
-                                      [svg/binoculars]]]]
-                                   [:img {:src   @image-src
-                                          :style {:height "auto" :width "100%"}}]]
-
-                                  :else
-                                  [:div {:style {:padding "1.2em"}}
-                                   (str "Loading camera " (:name
-                                                           @active-camera) "...")]))
                ;; TODO, this form is sloppy.  Maybe return some value to store or convert to form 3 component.
                _              (take! (mb/create-camera-layer! "fire-cameras")
                                      #(mb/add-feature-highlight!
                                        "fire-cameras" "fire-cameras"
                                        :click-fn on-click))]
-    (if @!/mobile?
-      [:div#wildfire-mobile-camera-tool
-       {:style ($/combine $/tool ($mobile-camera-tool @!/show-camera?))}
-       [mobile-camera-tool-header]
-       [render-content 0 0]]
-      [:div#wildfire-camera-tool
-       [resizable-window
-        parent-box
-        290
-        460
-        "Wildfire Camera Tool"
-        close-fn!
-        render-content]])
+    (let [render-content (fn []
+                           (cond
+                             (nil? @active-camera)
+                             [:div {:style {:padding "1.2em"}}
+                              "Click on a camera to view the most recent image. Powered by "
+                              [:a {:href   "http://www.alertwildfire.org/"
+                                   :ref    "noreferrer noopener"
+                                   :target "_blank"}
+                               "Alert Wildfire"] "."]
+
+                             (>= @camera-age 4)
+                             [:div {:style {:padding "1.2em"}}
+                              [:p (str "This camera has not been refreshed for " (u-num/to-precision 1 @camera-age) " hours. Please try again later.")]
+                              [:p "Click"
+                               [:a {:href   (str "https://www.alertwildfire.org/region/?camera=" (:name @active-camera))
+                                    :ref    "noreferrer noopener"
+                                    :target "_blank"}
+                                " here "]
+                               "for more information about the " (:name @active-camera) " camera."]]
+
+                             @image-src
+                             [:div
+                              [:div {:style {:display         "flex"
+                                             :justify-content "center"
+                                             :position        "absolute"
+                                             :top             "2rem"
+                                             :width           "100%"}}
+                               [:label (str "Camera: " (:name @active-camera))]]
+                              [:img {:src   "images/awf_logo.png"
+                                     :style ($/combine $awf-logo-style)}]
+                              (when @!/terrain?
+                                [tool-tip-wrapper
+                                 "Zoom Out to 2D"
+                                 :left
+                                 [:button {:class    (<class $/p-themed-button)
+                                           :on-click reset-view
+                                           :style    {:bottom   "1.25rem"
+                                                      :padding  "2px"
+                                                      :position "absolute"
+                                                      :left     "1rem"}}
+                                  [:div {:style {:height "32px"
+                                                 :width  "32px"}}
+                                   [svg/return]]]])
+                              [tool-tip-wrapper
+                               "Zoom Map to Camera"
+                               :right
+                               [:button {:class    (<class $/p-themed-button)
+                                         :on-click zoom-camera
+                                         :style    {:bottom   "1.25rem"
+                                                    :padding  "2px"
+                                                    :position "absolute"
+                                                    :right    "1rem"}}
+                                [:div {:style {:height "32px"
+                                               :width  "32px"}}
+                                 [svg/binoculars]]]]
+                              [:img {:src   @image-src
+                                     :style {:height "auto" :width "100%"}}]]
+
+                             :else
+                             [:div {:style {:padding "1.2em"}}
+                              (str "Loading camera " (:name
+                                                      @active-camera) "...")]))]
+      (if @!/mobile?
+        [:div#wildfire-mobile-camera-tool
+         {:style ($/combine $/tool $mobile-camera-tool)}
+         [mobile-camera-tool-header]
+         [render-content]]
+        [:div#wildfire-camera-tool
+         [resizable-window
+          parent-box
+          290
+          460
+          "Wildfire Camera Tool"
+          close-fn!
+          render-content]]))
     (finally
       (u-async/stop-refresh! @exit-chan)
       (mb/remove-layer! "fire-cameras")

--- a/src/cljs/pyregence/components/map_controls/information_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/information_tool.cljs
@@ -4,9 +4,11 @@
             [pyregence.components.map-controls.tool-button :refer [tool-button]]
             [pyregence.components.mapbox                   :as mb]
             [pyregence.components.resizable-window         :refer [resizable-window]]
+            [pyregence.components.svg-icons                :as svg]
             [pyregence.components.vega                     :refer [vega-box]]
             [pyregence.config                              :as c]
             [pyregence.state                               :as !]
+            [pyregence.styles                              :as $]
             [pyregence.utils.data-utils                    :as u-data]
             [pyregence.utils.misc-utils                    :as u-misc]
             [pyregence.utils.number-utils                  :as u-num]
@@ -15,8 +17,38 @@
             [reagent.dom                                   :as rd]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Styles
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- $mobile-info-tool []
+  {:background-color ($/color-picker :bg-color)
+   :box-shadow       (str "1px 0 5px " ($/color-picker :dark-gray 0.3))
+   :color            ($/color-picker :font-color)
+   :height           "290px"
+   :display          "block"
+   :width            "100%"
+   :z-index          "105"})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- mobile-info-tool-header []
+  [:div {:style {:align-items      "center"
+                 :background-color ($/color-picker :header-color)
+                 :display          "flex"
+                 :justify-content  "space-between"
+                 :padding          "0 1rem"}}
+   [:span {:style {:fill         ($/color-picker :font-color)
+                   :height       "1.5rem"
+                   :margin-right "0.5rem"
+                   :width        "1.5rem"}}
+    [svg/info]]
+   [:label {:style {:font-size "1rem"}}
+    "Point Information"]
+   [:span {:style {:margin-right "-.5rem"
+                   :visibility   (if (and @!/show-info? @!/mobile?) "visible" "hidden")}}
+    [tool-button :close #(reset! !/show-info? false)]]])
 
 (defn- loading-cover [box-height box-width message]
   [:div#loading-cover {:style {:height   box-height
@@ -26,21 +58,24 @@
                                :z-index  "1"}}
    [:label message]])
 
-(defn- information-div [units info-height convert]
+(defn- information-div [units info-height convert mobile?]
   (r/create-class
    {:component-did-mount
     (fn [this]
-      (reset! info-height
-              (-> this
-                  (rd/dom-node)
-                  (.getBoundingClientRect)
-                  (aget "height"))))
+      (when-not mobile?
+        (reset! info-height
+                (-> this
+                    (rd/dom-node)
+                    (.getBoundingClientRect)
+                    (aget "height")))))
+
     :render
     (fn [_]
       (let [cleaned-last-clicked-info (u-data/replace-no-data-nil @!/last-clicked-info
-                                                             @!/no-data-quantities)
+                                                                  @!/no-data-quantities)
             current-point             (get cleaned-last-clicked-info @!/*layer-idx)]
-        [:div {:style {:bottom "0" :position "absolute" :width "100%"}}
+        [:div {:style ($/combine {:display "flex" :justify-content "space-between"}
+                                 (when mobile? {:background-color ($/color-picker :bg-color)}))}
          [:label {:style {:margin-top ".6rem" :text-align "center" :width "100%"}}
           (if-let [value (:band current-point)]
             (str (if (fn? convert)
@@ -48,23 +83,27 @@
                    (u-num/round-last-clicked-info value))
                  (u-num/clean-units units))
             "No info available for this timestep.")]
-         [:div {:style {:bottom "0" :position "absolute" :right "4px"}}
+         [:div
           [tool-tip-wrapper
            "Center on selected point"
            :bottom
            [tool-button :center-on-point #(mb/center-on-overlay!)]]]]))}))
 
-(defn- vega-information [box-height box-width select-layer! units cur-hour convert]
-  (r/with-let [info-height (r/atom 0)]
-    [:<>
+(defn- vega-information [box-height box-width select-layer! units cur-hour convert mobile?]
+  (r/with-let [info-height (if mobile?
+                             (r/atom box-height)
+                             (r/atom 0))]
+    [:div {:style {:display "flex" :flex-direction "column"}}
      [vega-box
-      (- box-height @info-height)
+      (if mobile?
+        @info-height
+        (- box-height @info-height))
       box-width
       select-layer!
       units
       cur-hour
       convert]
-     [information-div units info-height convert]]))
+     [information-div units info-height convert mobile?]]))
 
 (defn- fbfm40-info []
   [:div {:style {:margin "0.125rem 0.75rem"}}
@@ -128,11 +167,11 @@
 (defn information-tool
   "The point information tool component. Supports both single point info and
    multiple point info. The units, convert, and no-convert arguments
-   are set in the :options key of a forecasts options map in config.cljs.
-   For example, the :ch options key on the near term forecast fuels tab specifes
-   that the units are meters, the value returned from get-point-info! should be
-   converted using the provided function, and the value from get-point-info!
-   should not be converted when using the :cfo Source."
+   are set in the `:options` key of a forecasts options map in config.cljs.
+   For example, the `:ch` options key on the near term forecast fuels tab specifes
+   that the units are meters, the value returned from `get-point-info!` should be
+   converted using the provided function, and the value from `get-point-info!`
+   should not be converted when using the `:cfo` Source."
   [get-point-info!
    parent-box
    select-layer!
@@ -142,69 +181,76 @@
    cur-hour
    close-fn!]
   (r/with-let [click-event (mb/add-single-click-popup! #(get-point-info! (mb/get-overlay-bbox)))]
-    [:div#info-tool
-     [resizable-window
-      parent-box
-      290
-      460
-      "Point Information"
-      close-fn!
-      (fn [box-height box-width]
-        (let [has-point?    (mb/get-overlay-center)
-              single-point? (number? @!/last-clicked-info)
-              no-info?      (if single-point?
-                              (contains? @!/no-data-quantities (str @!/last-clicked-info))
-                              (or (empty? @!/last-clicked-info)
-                                  (->> @!/last-clicked-info
-                                    (map (fn [entry]
-                                           (contains? @!/no-data-quantities (str (:band entry)))))
-                                    (every? true?))))]
-          (cond
-            (not has-point?)
-            [loading-cover
-             box-height
-             box-width
-             "Click on the map to view the value(s) of particular point."]
+    (let [render-content (fn [box-height box-width mobile?]
+                          (let [has-point?    (mb/get-overlay-center)
+                                single-point? (number? @!/last-clicked-info)
+                                no-info?      (if single-point?
+                                                (contains? @!/no-data-quantities (str @!/last-clicked-info))
+                                                (or (empty? @!/last-clicked-info)
+                                                    (->> @!/last-clicked-info
+                                                      (map (fn [entry]
+                                                             (contains? @!/no-data-quantities (str (:band entry)))))
+                                                      (every? true?))))]
+                            (cond
+                              (not has-point?)
+                              [loading-cover
+                               box-height
+                               box-width
+                               "Click on the map to view the value(s) of particular point."]
 
-            @!/point-info-loading?
-            [loading-cover
-             box-height
-             box-width
-             "Loading..."]
+                              @!/point-info-loading?
+                              [loading-cover
+                               box-height
+                               box-width
+                               "Loading..."]
 
-            (and (nil? @!/last-clicked-info) (empty? @!/legend-list))
-            [loading-cover
-             box-height
-             box-width
-             "There was an issue getting point information for this layer."]
+                              (and (nil? @!/last-clicked-info) (empty? @!/legend-list))
+                              [loading-cover
+                               box-height
+                               box-width
+                               "There was an issue getting point information for this layer."]
 
-            (and @!/last-clicked-info (empty? @!/legend-list))
-            [loading-cover
-             box-height
-             box-width
-             "There was an issue getting the legend for this layer."]
+                              (and @!/last-clicked-info (empty? @!/legend-list))
+                              [loading-cover
+                               box-height
+                               box-width
+                               "There was an issue getting the legend for this layer."]
 
-            no-info?
-            [loading-cover
-             box-height
-             box-width
-             "This point does not have any information."]
+                              no-info?
+                              [loading-cover
+                               box-height
+                               box-width
+                               "This point does not have any information."]
 
-            single-point?
-            [single-point-info
-             box-height
-             box-width
-             units
-             convert
-             no-convert]
+                              single-point?
+                              [single-point-info
+                               box-height
+                               box-width
+                               units
+                               convert
+                               no-convert]
 
-            :else
-            [vega-information
-             box-height
-             box-width
-             select-layer!
-             units
-             cur-hour
-             convert])))]]
+                              :else
+                              [vega-information
+                               box-height
+                               box-width
+                               select-layer!
+                               units
+                               cur-hour
+                               convert
+                               mobile?])))]
+      (if @!/mobile?
+        [:div#info-tool
+         {:style ($/combine $/tool $mobile-info-tool)}
+         [mobile-info-tool-header]
+         [render-content "290px" "100%" true]]
+        [:div#info-tool
+         [resizable-window
+          parent-box
+          290
+          460
+          "Point Information"
+          close-fn!
+          render-content nil nil false]]))
     (finally
       (mb/remove-event! click-event))))

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -78,13 +78,12 @@
 
 (defn tool-bar [set-show-info! get-any-level-key user-id]
   [:div#tool-bar {:style ($/combine $/tool $/tool-bar {:top "16px"})}
-   (->> [(when-not @!/mobile?
-           [:info
-            (str (hs-str @!/show-info?) " point information")
-            #(do (set-show-info! (not @!/show-info?))
-                 (reset! !/show-match-drop? false)
-                 (reset! !/show-camera? false))
-            @!/show-info?])
+   (->> [[:info
+          (str (hs-str @!/show-info?) " point information")
+          #(do (set-show-info! (not @!/show-info?))
+               (reset! !/show-match-drop? false)
+               (reset! !/show-camera? false))
+          @!/show-info?]
          (when (and (c/feature-enabled? :match-drop) (number? user-id) (not @!/mobile?))
            [:flame
             (str (hs-str @!/show-match-drop?) " match drop tool")

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -88,6 +88,7 @@
                                                  :type   "quantitative"
                                                  :scale  (create-color-scale processed-legend)
                                                  :legend false}}}
+                            ; The black point to show the currently selected hour (point)
                             {:transform [{:filter {:field "hour" :equal current-hour}}]
                              :mark      {:type   "point"
                                          :filled false


### PR DESCRIPTION
## Purpose
Adding the point info tool to mobile. Fixing some code with the camera tool on mobile.

## Related Issues
Closes PYR1-760

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Mobile > Point Info

#### Role
Visitor

#### Steps
1. Make sure you're on a mobile device.
2. Click on the point info tool.
3. On each tab (fuels, weather, risk) try using the point info tool normally.

#### Desired Outcome
The point info tool should work normally. The currently selected point should be highlighted in black and navigating to different hours of a forecast should update that point as well as the value displayed underneath the graph. On the fuels tab, the info that is returned should match up with what you clicked on.

---


## Screenshots
![Screenshot from 2022-11-07 15-44-29](https://user-images.githubusercontent.com/40574170/200472284-48210da8-52bf-4094-a418-add8d258bac0.png)
![Screenshot from 2022-11-07 15-44-35](https://user-images.githubusercontent.com/40574170/200472285-4614ba86-18fa-4d52-a779-761fd5188c15.png)
![Screenshot from 2022-11-07 22-15-43](https://user-images.githubusercontent.com/40574170/200472287-f356cc96-a32f-4b65-87d7-49ebb6281502.png)

