### PR TITLE
PYR1-767 Adding info on the weather model used on the Active Fires tab and Match Drop

### DIFF
--- a/src/cljs/pyregence/components/map_controls/match_drop_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/match_drop_tool.cljs
@@ -119,14 +119,14 @@
     [:div#match-drop-tool
      [resizable-window
       parent-box
-      350
+      400
       300
       "Match Drop Tool"
       close-fn!
       (fn [_ _]
         [:div {:style {:display "flex" :flex-direction "column" :height "inherit"}}
          [:div {:style {:flex-grow 1 :font-size "0.9rem" :margin "0.5rem 1rem"}}
-          [:div {:style {:font-size "0.8rem" :margin "0.5rem 0"}}
+          [:div {:style {:font-size "0.85rem" :margin "0.5rem 0"}}
            c/match-drop-instructions]
           [labeled-input "Name:" display-name {:placeholder "New Fire"}]
           [lon-lat-position $match-drop-location "Location" @lon-lat]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -464,7 +464,7 @@
                                                                        :filter    "30"}
                                                                   :10 {:opt-label "Smallest (10th percentile)"
                                                                        :filter    "10"}}}
-                                    :fuel       {:opt-label  "Fuel"
+                                    :fuel       {:opt-label  "Fuels"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Source of surface and canopy fuel inputs:"
                                                               [:br]
@@ -485,6 +485,11 @@
                                                               "), © Salo Sciences, Inc. 2020."]
                                                  :options    {:landfire {:opt-label "CA fuelscape / LANDFIRE 2.2.0"
                                                                          :filter    "landfire"}}}
+                                    :weather    {:opt-label  "Weather Model"
+                                                 :hover-text [:p {:style {:margin-bottom "0"}}
+                                                              [:strong "Hybrid"]
+                                                              " - Blend of HRRR, NAM 3 km, and GFS 0.125\u00B0 to 8 days."]
+                                                 :options    {:hybrid {:opt-label "Hybrid"}}}
                                     :model      {:opt-label  "Model"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               [:strong "ELMFIRE"]
@@ -993,7 +998,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def match-drop-instructions
-  "Simulates a fire using real-time weather data.
+  "Simulates a fire using real-time weather data from the Hybrid model,
+   which is a blend of the HRRR, NAM 3 km, and GFS 0.125\u00B0 models.
    Click on a location to \"drop\" a match,
    then set the date and time to begin the simulation.")
 


### PR DESCRIPTION


## Purpose
Adding info on the weather model used (Hybrid) on the Active Fires tab and Match Drop

## Related Issues
Closes PYR1-767

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Screenshots
![Screenshot from 2022-11-09 19-47-51](https://user-images.githubusercontent.com/40574170/200973359-e77b8cb3-9064-4ea6-a656-2911d756a2bc.png)
![Screenshot from 2022-11-09 19-47-58](https://user-images.githubusercontent.com/40574170/200973360-843cf6cd-4c81-44b2-9709-78e8b83c2c83.png)

