### PR TITLE
PYR1-766 Fix the Match Drop Dashboard

### DIFF
--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -315,7 +315,7 @@
   "A shortcut for modal styling."
   []
   {:background-color "rgba(0,0,0,0.4)"
-   :height           "100%"
+   :height           "100vh"
    :left             "0"
    :position         "absolute"
    :top              "0"


### PR DESCRIPTION
## Purpose
Fixes the broken Match Drop Dashboard. The dashboard should now load and display information correctly. The log pop up modal should load properly as well.

## Related Issues
Closes PYR1-766

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Match Drop > Dashboard

#### Role
User

#### Steps
1. As a user, initiate a couple of Match Drop runs.
2. Using the button, navigate to the Match Drop dashboard.

#### Desired Outcome
The Dashboard should load properly and all information should be correct. The "View Logs" link should open a popup.

---

## Screenshots
![Screenshot from 2022-11-14 20-39-32](https://user-images.githubusercontent.com/40574170/201812656-52284bdc-b499-4d78-9718-5f577c9dfd8a.png)
![Screenshot from 2022-11-14 21-33-43](https://user-images.githubusercontent.com/40574170/201812658-ce7abe14-bec9-4853-8d5c-ee2b1c432394.png)

