### PR TITLE
PYR1-778 Sort Match Drops in reverse order

### DIFF
--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -23,8 +23,11 @@
 
 (defn- get-user-match-drops [user-id]
   (go
-    (reset! match-drops
-            (edn/read-string (:body (<! (u-async/call-clj-async! "get-match-drops" user-id)))))))
+    (reset! match-drops (->> (u-async/call-clj-async! "get-match-drops" user-id)
+                             (<!)
+                             (:body)
+                             (edn/read-string)
+                             (sort-by :job-id #(> %1 %2))))))
 
 (defn- delete-match-drop! [job-id]
   (go
@@ -113,8 +116,9 @@
            "Logs"
            "Delete"]]
    [:tbody
-    (reverse (map (fn [{:keys [job-id] :as md}] ^{:key job-id} [match-drop-item md])
-                  @match-drops))]])
+    (map (fn [{:keys [job-id] :as md}] ^{:key job-id}
+           [match-drop-item md])
+         @match-drops)]])
 
 (defn- match-drop-header [user-id]
   [:div {:style {:display "flex" :justify-content "center"}}


### PR DESCRIPTION
## Purpose
Fixes a bug where Match Drops weren't being sorted in reverse order.

## Related Issues
Closes PYR-778

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Match Drop > Dashboard

#### Role
User

#### Steps

1. Start a number of match drops.
2. Navigate to the match drop dashboard.
3. Refresh the page a few times and click the "Refresh" button.

#### Desired Outcome
The match drops should always be in descending order based on the job id (highest job id at the top, lowest job id at the bottom).
