### PR TITLE
PYR1-770 Update the get_organizations function and allow NVE org members (not just admins) to view the PSPS tab

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -66,12 +66,13 @@
 
 (defn get-organizations
   "Given a user's id, returns the list of organizations that they belong to
-   and are an admin of."
+   and are an admin or a member of."
   [user-id]
   (->> (call-sql "get_organizations" user-id)
-       (mapv (fn [{:keys [org_id org_name email_domains auto_add auto_accept]}]
+       (mapv (fn [{:keys [org_id org_name role_id email_domains auto_add auto_accept]}]
                {:opt-id        org_id
                 :opt-label     org_name
+                :role          (if (= role_id 1) "admin" "member")
                 :email-domains email_domains
                 :auto-add?     auto_add
                 :auto-accept?  auto_accept}))

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -13,10 +13,10 @@
   [:div {:style {:display "flex" :padding ".25rem 0"}}
    (doall
     (map (fn [[key {:keys [allowed-org hover-text opt-label]}]]
-           (when (or (nil? allowed-org)
-                     (some (fn [{org-name :opt-label}]
-                             (= org-name allowed-org))
-                           user-org-list))
+           (when (or (nil? allowed-org)                ; Tab isn't organization-specific
+                     (some (fn [{org-name :opt-label}] ; Tab **is** organization-specific
+                             (= org-name allowed-org)) ; and the user is an admin or member of that org
+                           user-org-list))             ; (the organization name is in their org-list)
              ^{:key key}
              [tool-tip-wrapper
               hover-text

--- a/src/cljs/pyregence/pages/admin.cljs
+++ b/src/cljs/pyregence/pages/admin.cljs
@@ -107,7 +107,9 @@
   (go
     (let [response (<! (u-async/call-clj-async! "get-organizations" user-id))]
       (reset! *orgs (if (:success response)
-                      (edn/read-string (:body response))
+                      (->> (:body response)
+                           (edn/read-string)
+                           (filter #(= "admin" (:role %)))) ; only show orgs user is an admin of
                       []))
       (reset! pending-get-organizations? false)
 

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -733,7 +733,10 @@
          [message-modal]
          [nav-bar {:capabilities         @!/capabilities
                    :current-forecast     @!/*forecast
-                   :is-admin?            (> (count @!/user-org-list) 0)
+                   :is-admin?            (->> @!/user-org-list
+                                              (filter #(= "admin" (:role %)))
+                                              (count)
+                                              (< 0)) ; admin of at least one org
                    :logged-in?           user-id
                    :mobile?              @!/mobile?
                    :user-org-list        @!/user-org-list

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -34,13 +34,13 @@ The processed output from `process-capabilities!`:
 notably contains any fire names and/or user layers (obtained from the back-end) that are added to the capabilities atom
 (since the fire names and user layers are not defined initially in config.cljs."}
   capabilities (r/atom {}))
-(defonce ^{:doc "Contains the map associated with the :params key inside of the currently selected forecast in the capabilities atom. 
+(defonce ^{:doc "Contains the map associated with the :params key inside of the currently selected forecast in the capabilities atom.
 For example, the processed-params for a user on the Weather tab would be a map containing the :band, :model, and :model-init maps."}
   processed-params (r/atom []))
-(defonce ^{:doc " A vector of maps containing all of the layers for the current forecast sorted by hour. These layers are obtained from 
-the back-end through the capabilities.clj/get-layers function which returns all layers that match a given set of strings for filtering. 
-For example, if the user is on the Weather tab looking at the Temperature (F) forecast, param-layers will be a vector of length 145 
-where each entry in the vector (which is a map) contains information about one Temperature (F) layer. A length of 145 also indicates 
+(defonce ^{:doc " A vector of maps containing all of the layers for the current forecast sorted by hour. These layers are obtained from
+the back-end through the capabilities.clj/get-layers function which returns all layers that match a given set of strings for filtering.
+For example, if the user is on the Weather tab looking at the Temperature (F) forecast, param-layers will be a vector of length 145
+where each entry in the vector (which is a map) contains information about one Temperature (F) layer. A length of 145 also indicates
 that there are 145 different time steps in this specific forecast."}
   param-layers (r/atom []))
 
@@ -89,17 +89,16 @@ Each entry in the legend contains the legend's label, value, color, and opacity.
 ;; Miscellaneous State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defonce ^{:doc "For the currently logged in user, stores a list of all of the organizations that they belong to as an Admin.
-Will be bound to an empty vector if the following two conditions are not met by the user:
-the user must be linked to atleast one organization and
-the user must have the Admin role on atleast one linked organization"}
+(defonce ^{:doc "For the currently logged in user, stores a list of all of the organizations
+that they belong to as an Admin or a Member. Will be bound to an empty vector if
+the user is not an Admin or Member of at least one organization."}
   user-org-list (r/atom []))
 (defonce ^{:doc "A boolean that enables time-step animation for the Time Slider when true."}
   animate? (r/atom false))
 (defonce ^{:doc "A boolean that maintains the hide/show toggle state of the loading modal dialog."}
   loading? (r/atom true))
 (defonce ^{:doc "A boolean that designates if the browser's innerwidth reaches below the 800 pixel wide breakpoint.
-A browser more narrow than 800 pixels enables a special "mobile" styling across the front-end."}
+A browser more narrow than 800 pixels enables a special mobile styling across the front-end."}
   mobile? (r/atom false))
 (defonce ^{:doc "A boolean that maintains the hide/show toggle state of the 3D Terrain Tool."}
   terrain? (r/atom false))

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -148,25 +148,28 @@ $$ LANGUAGE SQL;
 ---  Organizations
 ---
 
+-- Returns all organizations for a user that they are an admin or member of
 CREATE OR REPLACE FUNCTION get_organizations(_user_id integer)
  RETURNS TABLE (
     org_id           integer,
     org_name         text,
+    role_id          integer,
     email_domains    text,
     auto_add         boolean,
     auto_accept      boolean
  ) AS $$
 
-    SELECT organization_uid,
-        org_name,
-        email_domains,
-        auto_add,
-        auto_accept
-    FROM organizations, organization_users
-    WHERE organization_uid = organization_rid
-        AND user_rid = _user_id
-        AND role_rid = 1
-    ORDER BY org_name
+    SELECT o.organization_uid,
+        o.org_name,
+        ou.role_rid,
+        o.email_domains,
+        o.auto_add,
+        o.auto_accept
+    FROM organizations AS o, organization_users AS ou
+    WHERE (o.organization_uid = ou.organization_rid)
+        AND (ou.user_rid = _user_id)
+        AND (ou.role_rid = 1 OR ou.role_rid = 2)
+    ORDER BY o.org_name
 
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION


## Purpose
Fixes a bug where only admins of the NVE org could view the PSPS tab. Members should also be able to view this tag. To fix this, the `get_organizations` SQL function (and associated calls to it) needed to be updated to return all organizations that a given user is both an admin **and** a member of. Logic on the back and front-end thus needed to be updated accordingly.

## Related Issues
Closes PYR1-770

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Misc > PSPS Tab

#### Role
User

#### Steps
1. Sign into an account that is a member of the NVE organization, but not an admin of it.

#### Desired Outcome
You should be able to see the PSPS tab and all NVE layers.
