### PR TITLE
PYR1-788 Add a component for when a user is logged in but doesn't have match drop access

### DIFF
--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -15,7 +15,7 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defonce ^{:doc "Whether or not the currently logged in user has match drop access."}
+(defonce ^:private ^{:doc "Whether or not the currently logged in user has match drop access."}
   match-drop-access? (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -80,7 +80,7 @@
   (mb/set-visible-by-title! "fire-history-centroid" @!/show-fire-history?)
   (mb/clear-popup! "fire-history"))
 
-(defn- get-match-drop-access [user-id]
+(defn- set-match-drop-access! [user-id]
   (go
    (let [response (<! (u-async/call-clj-async! "get-user-match-drop-access" user-id))]
      (if (:success response)
@@ -92,7 +92,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn tool-bar [set-show-info! get-any-level-key user-id]
-  (get-match-drop-access user-id)
+  (set-match-drop-access! user-id)
   (fn [_]
     [:div#tool-bar {:style ($/combine $/tool $/tool-bar {:top "16px"})}
      (->> [[:info

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -524,7 +524,7 @@
     (let [{:keys [options-config layers]} (c/get-forecast forecast-type)
           user-layers-chan                (u-async/call-clj-async! "get-user-layers" user-id)
           fire-names-chan                 (u-async/call-clj-async! "get-fire-names" user-id)
-          fire-cameras                    (u-async/call-clj-async! "get-cameras")]
+          fire-cameras-chan               (u-async/call-clj-async! "get-cameras")]
       (reset! !/*forecast-type forecast-type)
       (reset! !/*forecast (or (keyword forecast)
                               (keyword (forecast-type @!/default-forecasts))))
@@ -536,7 +536,7 @@
                              (params->selected-options options-config @!/*forecast params))
       (<! (select-forecast! @!/*forecast))
       (reset! !/user-org-list (edn/read-string (:body (<! (u-async/call-clj-async! "get-organizations" user-id)))))
-      (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras))))
+      (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras-chan))))
       (reset! !/loading? false))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -1,8 +1,6 @@
 (ns pyregence.state
   (:require [reagent.core :as r]))
 
-; TODO: Add detailed docstrings to each of the state atoms.
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Forecast/Layer State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
## Purpose
A user who is logged in but doesn't have Match Drop access should not be able to see the `/dashboard` page. This fixes that bug.

## Related Issues
Closes PYR1-788

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Match Drop > Tool Bar

#### Role
User
#### Steps
1. Log in as the following user:
```
user: solomonlandry@topsecret.net
pass: test456
```
2. Navigate to the `/dashboard` page.

#### Desired Outcome
You should see a custom component telling you that you don't have Match Drop access.

---

#### Role
User
#### Steps
1. Log in as the following user:
```
user: admin@all-orgs.com
pass: test456
```
2. Navigate to the`/dashboard` page.

#### Desired Outcome
You should be able to see and use the Match Drop dashboard.


## Screenshots
![Screenshot from 2022-12-06 16-48-49](https://user-images.githubusercontent.com/40574170/206060661-75e28908-6a28-4537-9117-6f62e6674dfd.png)

