### PR TITLE
PYR1-769 Send an email upon Match Drop completion

### DIFF
--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -3,22 +3,33 @@
   (:require [triangulum.config   :refer [get-config]]
             [triangulum.database :refer [call-sql]]
             [pyregence.views     :refer [data-response]]
+            [pyregence.utils     :refer [convert-date-string]]
             [postal.core         :refer [send-message]]))
 
 ;; TODO get name for greeting line.
-(defn get-password-reset-message [url email reset-key]
+(defn- get-password-reset-message [base-url email reset-key]
   (str "Hi " email ",\n\n"
        "  To reset your password, simply click the following link:\n\n"
-       "  " url "/reset-password?email=" email "&reset-key=" reset-key "\n\n"
+       "  " base-url "/reset-password?email=" email "&reset-key=" reset-key "\n\n"
        "  - Pyregence Technical Support"))
 
-(defn get-new-user-message [url email reset-key]
+(defn- get-new-user-message [base-url email reset-key]
   (str "Hi " email ",\n\n"
        "  You have been registered for Pyregence. Please verify your email by clicking the following link:\n\n"
-       "  " url "/verify-email?email=" email "&reset-key=" reset-key "\n\n"
+       "  " base-url "/verify-email?email=" email "&reset-key=" reset-key "\n\n"
        "  - Pyregence Technical Support"))
 
-(defn send-reset-key-email! [mail-config email subject message-fn]
+(defn- get-match-drop-message [base-url email {:keys [match-job-id display-name fire-name ignition-time]}]
+  (str "Hi " email ",\n\n"
+       "  Your Match Drop with ID \"" match-job-id "\" and display-name \"" display-name
+       "\" has finished running. Please click the following link to view it "
+       "on Pyrcast:\n\n" base-url "/forecast?zoom=5.5&forecast=active-fire&fuel="
+       "landfire&output=burned&model-init=" (convert-date-string ignition-time)
+       "&layer-idx=0&lat=37.22&fire-name=" fire-name "&lng=-118.79&pattern=all&"
+       "model=elmfire \n\n"
+       "  - Pyregence Technical Support"))
+
+(defn- send-reset-key-email! [mail-config email subject message-fn]
   (let [reset-key (str (UUID/randomUUID))
         result    (send-message
                    (dissoc mail-config :site-url)
@@ -29,15 +40,32 @@
     (call-sql "set_reset_key" email reset-key)
     (data-response email {:status (when-not (= :SUCCESS (:error result)) 400)})))
 
-(defn send-email [email email-type]
+(defn- send-match-drop-email! [mail-config email subject message-fn match-drop-args]
+  (let [result (send-message
+                (dissoc mail-config :site-url)
+                {:from    (mail-config :user)
+                 :to      email
+                 :subject subject
+                 :body    (message-fn (:site-url mail-config) email match-drop-args)})]
+    (if (= :SUCCESS (:error result))
+      (data-response "Match Drop email successfully sent.")
+      (data-response "There was an issue sending the Match Drop email." {:status 400}))))
+
+(defn send-email! [email email-type & [match-drop-args]]
   (let [mail-config (get-config :mail)]
     (condp = email-type
-      :reset    (send-reset-key-email! mail-config
-                                       email
-                                       "Pyregence Password Reset"
-                                       get-password-reset-message)
-      :new-user (send-reset-key-email! mail-config
-                                       email
-                                       "Pyregence New User"
-                                       get-new-user-message)
-      (data-response "Invalid email type." {:status 400}))))
+      :reset      (send-reset-key-email! mail-config
+                                         email
+                                         "Pyregence Password Reset"
+                                         get-password-reset-message)
+      :new-user   (send-reset-key-email! mail-config
+                                         email
+                                         "Pyregence New User"
+                                         get-new-user-message)
+      :match-drop (send-match-drop-email! mail-config
+                                          email
+                                          "Match Drop Finished Running"
+                                          get-match-drop-message
+                                          match-drop-args)
+      (data-response "Invalid email type. Options are `:reset`, `:new-user`, or `:match-drop.`"
+                     {:status 400}))))

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -1,6 +1,5 @@
 (ns pyregence.match-drop
-  (:import  [java.util TimeZone UUID]
-            [java.text SimpleDateFormat])
+  (:import  [java.util UUID])
   (:require [clojure.data.json :as json]
             [clojure.string    :as str]
             [clojure.set       :refer [rename-keys]]
@@ -10,7 +9,7 @@
             [triangulum.sockets         :refer [send-to-server!]]
             [triangulum.type-conversion :refer [json->clj clj->json]]
             [pyregence.capabilities :refer [set-capabilities!]]
-            [pyregence.utils        :refer [nil-on-error]]
+            [pyregence.utils        :refer [nil-on-error convert-date-string]]
             [pyregence.views        :refer [data-response]]))
 
 ;;; Helper Functions
@@ -35,13 +34,7 @@
          (cons (first words))
          (str/join ""))))
 
-(defn- convert-date-string [date-str]
-  (let [in-format  (SimpleDateFormat. "yyyy-MM-dd HH:mm z")
-        out-format (doto (SimpleDateFormat. "yyyyMMdd_HHmmss")
-                     (.setTimeZone (TimeZone/getTimeZone "UTC")))]
-    (->> date-str
-         (.parse in-format)
-         (.format out-format))))
+
 
 (defn- get-md-config [k]
   (get-config :match-drop k))

--- a/src/clj/pyregence/remote_api.clj
+++ b/src/clj/pyregence/remote_api.clj
@@ -35,7 +35,8 @@
                                               remove-workspace!]]
             [pyregence.match-drop     :refer [initiate-md! delete-match-drop! get-md-status get-match-drops]]
             [pyregence.red-flag       :refer [get-red-flag-layer]]
-            [pyregence.email          :refer [send-email]]
+            [pyregence.email          :refer [send-email!]]
+            [pyregence.utils          :refer [get-email-by-user-id]]
             [pyregence.views          :refer [data-response]]))
 
 (def name->fn {"add-org-user"                  add-org-user
@@ -44,6 +45,7 @@
                "get-all-layers"                get-all-layers
                "get-cameras"                   get-cameras
                "get-current-image"             get-current-image
+               "get-email-by-user-id"          get-email-by-user-id
                "get-fire-names"                get-fire-names
                "get-layers"                    get-layers
                "get-layer-name"                get-layer-name
@@ -60,7 +62,7 @@
                "log-in"                        log-in
                "log-out"                       log-out
                "remove-org-user"               remove-org-user
-               "send-email"                    send-email
+               "send-email"                    send-email!
                "set-capabilities"              set-capabilities!
                "set-all-capabilities"          set-all-capabilities!
                "set-user-password"             set-user-password

--- a/src/clj/pyregence/utils.clj
+++ b/src/clj/pyregence/utils.clj
@@ -1,4 +1,8 @@
-(ns pyregence.utils)
+(ns pyregence.utils
+  (:import  [java.util TimeZone]
+            [java.text SimpleDateFormat])
+  (:require [triangulum.database :refer [call-sql sql-primitive]]
+            [pyregence.views     :refer [data-response]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility Functions
@@ -9,3 +13,19 @@
   [& body]
   (let [_ (gensym)]
     `(try ~@body (catch Exception ~_ nil))))
+
+(defn convert-date-string
+  "Converts a date str in the format of '2022-12-01 18:00 UTC' to '20221201_180000'."
+  [date-str]
+  (let [in-format  (SimpleDateFormat. "yyyy-MM-dd HH:mm z")
+        out-format (doto (SimpleDateFormat. "yyyyMMdd_HHmmss")
+                     (.setTimeZone (TimeZone/getTimeZone "UTC")))]
+    (->> date-str
+         (.parse in-format)
+         (.format out-format))))
+
+(defn get-email-by-user-id [user-id]
+  (if-let [email (sql-primitive (call-sql "get_email_by_user_id" user-id))]
+    (data-response email)
+    (data-response (str "There is no user with the id " user-id)
+                   {:status 403})))

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -48,6 +48,16 @@ CREATE OR REPLACE FUNCTION get_user_id_by_email(_email text)
 
 $$ LANGUAGE SQL;
 
+-- Returns user email for a given user id
+CREATE OR REPLACE FUNCTION get_email_by_user_id(_user_id integer)
+ RETURNS text AS $$
+
+    SELECT email
+    FROM users
+    WHERE user_uid = _user_id
+
+$$ LANGUAGE SQL;
+
 -- Inserts a new user with its info
 CREATE OR REPLACE FUNCTION add_new_user(
     _email       text,


### PR DESCRIPTION
## Purpose
Emails a user once their Match Drop is complete with a Share URL taking them directly to that Match Drop.

## Related Issues
Closes PYR1-769

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Match Drop > Email

#### Role
User
#### Steps
1. Sign into an account that's enabled to use Match Drop.
2. Start a Match Drop.

#### Desired Outcome

Once the Match Drop is finished, you should receive an email. Inside of that email, verify that all of the information provided matches the information of the Match Drop in question. Note that the URL won't work since no actual fires are being added to Pyrecast (yet) but it should be in the format of the Share URL.

---

## Screenshots
![Screenshot from 2022-12-13 15-48-19](https://user-images.githubusercontent.com/40574170/207483532-deee7d51-0d36-4b51-9edc-2ca610e37df3.png)

