### PR TITLE
PYR1-780 Pass in the GeoServer URL to match drop request

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -17,7 +17,7 @@
                      :fire-history true
                      :structures   true
                      :gridfire     false}
- :geoserver         {;:match-drop  "TODO"
+ :geoserver         {:match-drop  "https://sierra.pyregence.org/geoserver"
                      :psps        "https://energy.pyregence.org:8443/geoserver"
                      :pyreclimate "https://climate.pyregence.org/geoserver"
                      :shasta      "https://shasta.pyregence.org/geoserver"

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -156,6 +156,7 @@
                                                             :north-buffer        24}
                                              :geosync-args {:action              "add"
                                                             :data-dir            data-dir
+                                                            :geoserver-url       (get-config :geoserver :match-drop)
                                                             :geoserver-workspace geoserver-workspace}}}
         match-job           {:display-name        (or display-name (str "Match Drop " match-job-id))
                              :md-status           2


### PR DESCRIPTION
## Purpose
Passes in the GeoServer URL as an arg to the Match Drop request so that Elmfire and GridFire know which GeoServer to push their layers to.

## Related Issues
Closes PYR1-780

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

