### PR TITLE
Update Runway to use HTTPS

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -23,10 +23,10 @@
         ring/ring-ssl              {:mvn/version "0.3.0"}
         ring/ring-json             {:mvn/version "0.5.0"}
         seancorfield/next.jdbc     {:mvn/version "1.1.569"}
-        sig-gis/runway             {:git/url "https://gitlab.sig-gis.com/sig-gis/runway.git"
-                                    :sha     "dab2012202935f0982f05f18fc43ab297be09e45"}
+        sig-gis/runway             {:git/url "https://gitlab.sig-gis.com/sig-gis/runway"
+                                    :git/sha "dab2012202935f0982f05f18fc43ab297be09e45"}
         sig-gis/triangulum         {:git/url "https://github.com/sig-gis/triangulum"
-                                    :sha     "934b35fc2b29dd25e5feb28844a42854afb11387"}}
+                                    :git/sha "934b35fc2b29dd25e5feb28844a42854afb11387"}}
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :config           {:main-opts ["-m" "triangulum.config"]}
            :https            {:main-opts ["-m" "triangulum.https"]}


### PR DESCRIPTION
## Purpose
Updates Runway in `deps.edn` to use HTTPS instead of SSH.