### PR TITLE
Oliver jks work around

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,7 +33,7 @@
            :default-ssl-opts {:jvm-opts  ["-Djavax.net.ssl.keyStore=resources/runway.jks"
                                           "-Djavax.net.ssl.keyStorePassword=RomeoUniformNovemberWhiskeyAlfaYankee"]}
            :server           {:main-opts ["-m" "pyregence.server"]}
-           :systemd          {:main-opts ["-m" "triangulum.systemd" ":default-ssl-opts"]}
+           :systemd          {:main-opts ["-m" "triangulum.systemd"]}
            :compile-cljs     {:main-opts ["-m" "pyregence.compile-cljs" "compile-prod.cljs.edn"]}
            :figwheel-lib     {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.13"}}}
            :figwheel         {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.13"}


### PR DESCRIPTION
## Purpose
Don't require the use of `runway.jks` by adding a new alias that can optionally be used (called `:default-ssl-opts`).
