### PR TITLE
PYR1-892 Some small deployment cleanups

### DIFF
--- a/README.org
+++ b/README.org
@@ -166,7 +166,7 @@ directory and run:
 clojure -M:figwheel
 #+end_src
 
-This will start a web server on ~http://local.pyregence.org:8080~ (also
+This will start a web server on ~http://local.pyrecast.org:8080~ (also
 accessible from ~http://localhost:8080~), which serves up the website in
 dev mode. Any changes to CLJS files will be automatically pushed to
 the browser when the files are saved. Any changes to CLJ files will be

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -197,6 +197,8 @@
 
 ;;; Routes
 
+;; TODO note that calling this fn on a regex does not work properly. Passing in
+;; a workspace name as a regex is a GeoSync use case, so this should be updated to accept a regex
 (defn remove-workspace!
   "Given a specific geoserver-key and a specific workspace-name, removes any
    layers from that workspace from the layers atom."

--- a/src/cljs/pyregence/components/map_controls/match_drop_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/match_drop_tool.cljs
@@ -38,8 +38,8 @@
 (def match-drop-instructions
   "Simulates a 24 hour fire using real-time weather data from the Hybrid model,
    which is a blend of the HRRR, NAM 3 km, and GFS 0.125\u00B0 models.
-   Click on a location to \"drop\" a match, then set the date and time to begin
-   the simulation.")
+   Click on any CONUS location to \"drop\" a match, then set the date and time to begin
+   the simulation. Chrome is currently the only supported browser for Match Drop.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
@@ -288,7 +288,7 @@
     [:div#match-drop-tool
      [resizable-window
       parent-box
-      515
+      560
       400
       "Match Drop Tool"
       close-fn!
@@ -318,4 +318,5 @@
              [datetime-local-picker forecast-weather? md-datetime-local local-time-zone]])
           [md-buttons md-datetime-local forecast-weather? display-name lon-lat user-id]]])]]
     (finally
+      (mb/remove-markers!)
       (mb/remove-event! click-event))))


### PR DESCRIPTION
## Purpose
Increases the size of the Match Drop tool, a small README fix, added documentation to the Match Drop tool, and fixed a bug where the marker wasn't removed upon closing the Match Drop tool.

## Related Issues
Closes PYR1-892

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)