### PR TITLE
Fix a few small Match Drop bugs

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -276,8 +276,14 @@
                                               (str/split #"match-drop-")
                                               (second)
                                               (Integer/parseInt))]
+                     ;; We either want to pass a fire name to the front end if the fire in question is
+                     ;; an active fire (nil? match-job-id) or it's a Match Drop that matches our deployment
+                     ;; environment. Since development and production Match Drops can have the same ID,
+                     ;; we have to make sure the fire-name starts with the specific md-prefix specified in config.edn
+                     ;; so that we don't double-count the Match Drops.
                      (when (or (nil? match-job-id)
-                               (contains? match-drop-names match-job-id))
+                               (and (contains? match-drop-names match-job-id)
+                                    (str/starts-with? fire-name (get-config :match-drop :md-prefix))))
                        [(keyword fire-name)
                         {:opt-label      (or (get match-drop-names match-job-id)
                                              (fire-name-capitalization fire-name))

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -434,7 +434,7 @@
   "Returns the current status of the given match drop run."
   [match-job-id]
   (data-response (-> (get-match-job-from-match-job-id match-job-id)
-                     (select-keys [:message :md-status :job-log]))))
+                     (select-keys [:display-name :geoserver-workspace :message :md-status :job-log]))))
 
 (defn get-md-available-dates
   "Gets the available dates for Match Drops in UTC. Note that we're shelling out


### PR DESCRIPTION
## Purpose
Fixes the following bugs:

1. dev and prod match drops were being double counted if the Match Drop ID matched.
2. The right fire-name was not being passed into the Match Drop emails.
3. For Match Drops without a user-provided display name, the Match Drop email would not display the default naming convention (e.g. "Match Drop 12").
