### PR TITLE
PYR1-903 Add CANSAC WRF weather model

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -288,7 +288,8 @@
                                                               [:br]
                                                               [:strong "RTMA"]
                                                               " - Real Time Mesoscale Analysis at 2.5 km resolution updated every 15 minutes."]
-                                                 :options    {:hrrr          {:opt-label    "HRRR"
+                                                 :options    (array-map
+                                                              :hrrr          {:opt-label    "HRRR"
                                                                               :filter       "hrrr"}
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
@@ -313,7 +314,7 @@
                                                                               :disabled-for #{:apcp01 :smoke :tcdc}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
-                                                                              :disabled-for #{:apcp :apcp01 :smoke}}}}
+                                                                              :disabled-for #{:apcp :apcp01 :smoke}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -238,7 +238,7 @@
                                                               :apcp01 {:opt-label       "1-hour precipitation (in)"
                                                                        :filter          "apcp01"
                                                                        :units           "inches"
-                                                                       :disabled-for    #{:nam-awip12 :nbm :rtma-ru}
+                                                                       :disabled-for    #{:nam-awip12 :nbm :cansac-wrf :rtma-ru}
                                                                        :reverse-legend? false}
                                                               :vpd    {:opt-label    "Vapor pressure deficit (hPa)"
                                                                        :filter       "vpd"
@@ -251,13 +251,17 @@
                                                               :smoke  {:opt-label    "Smoke density (\u00b5g/m\u00b3)"
                                                                        :filter       "smoke"
                                                                        :units        "\u00b5g/m\u00b3"
-                                                                       :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nam-conusnest :nbm :rtma-ru}}
+                                                                       :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nam-conusnest :nbm :cansac-wrf :rtma-ru}}
                                                               :tcdc   {:opt-label    "Total cloud cover (%)"
                                                                        :filter       "tcdc"
                                                                        :units        "%"
-                                                                       :disabled-for #{:gfs0p125 :gfs0p25 :hrrr :hybrid :nam-awip12 :nam-conusnest :nbm}})}
+                                                                       :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nbm :cansac-wrf}})}
                                     :model      {:opt-label  "Model"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
+                                                              [:strong "HRRR"]
+                                                              " - High Resolution Rapid Refresh at 3 km resolution to 48 hours."
+                                                              [:br]
+                                                              [:br]
                                                               [:strong "NBM"]
                                                               " - National Blend of Models at 2.5 km to 11 days."
                                                               [:br]
@@ -274,10 +278,6 @@
                                                               " - Global Forecast System at 0.250\u00B0 (approx 26 km) resolution to 16 days."
                                                               [:br]
                                                               [:br]
-                                                              [:strong "HRRR"]
-                                                              " - High Resolution Rapid Refresh at 3 km resolution to 48 hours."
-                                                              [:br]
-                                                              [:br]
                                                               [:strong "NAM 12 km"]
                                                               " - North American Mesoscale Model at 12 km resolution to 84 hours."
                                                               [:br]
@@ -289,8 +289,7 @@
                                                               [:strong "RTMA"]
                                                               " - Real Time Mesoscale Analysis at 2.5 km resolution updated every 15 minutes."]
                                                  :options    {:hrrr          {:opt-label    "HRRR"
-                                                                              :filter       "hrrr"
-                                                                              :disabled-for #{:tcdc}}
+                                                                              :filter       "hrrr"}
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
                                                                               :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd}}
@@ -308,7 +307,10 @@
                                                                               :disabled-for #{:apcp01 :smoke :tcdc}}
                                                               :nam-conusnest {:opt-label    "NAM 3 km"
                                                                               :filter       "nam-conusnest"
-                                                                              :disabled-for #{:smoke :tcdc}}
+                                                                              :disabled-for #{:smoke}}
+                                                              :cansac-wrf    {:opt-label    "CANSAC WRF"
+                                                                              :filter       "cansac-wrf"
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
                                                                               :disabled-for #{:apcp :apcp01 :smoke}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -286,6 +286,15 @@
                                                               " -  North American Mesoscale Model at 3 km resolution to 60 hours."
                                                               [:br]
                                                               [:br]
+                                                              [:strong "CANSAC WRF"]
+                                                              " - California and Nevada Smoke and Air Committee (CANSAC) Weather Research and Forecasting (WRF) forecast model from Desert Research Institute."
+                                                              " Two cycles per day (00z and 12z) at very high (1.33 km) resolution. See "
+                                                              [:a {:href   "https://cansac.dri.edu/"
+                                                                    :target "_blank"}
+                                                               "https://cansac.dri.edu/"]
+                                                              " for details."
+                                                              [:br]
+                                                              [:br]
                                                               [:strong "RTMA"]
                                                               " - Real Time Mesoscale Analysis at 2.5 km resolution updated every 15 minutes."]
                                                  :options    (array-map


### PR DESCRIPTION
## Purpose
Adds the CANSAC WRF weather model.

## Related Issues
Closes PYR1-903

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Layers > Weather

#### Role
Visitor
#### Steps
1. Go to the weather tab and select the CANSAC WRF model.

#### Desired Outcome

All layers except for 1 hour precipitation, smoke, and total cloud cover should load for the CANSAC WRF model. Point info should also work for the model.

---


## Screenshots
![Screenshot from 2023-07-05 09-49-28](https://github.com/pyregence/pyregence/assets/40574170/d2b35210-9714-4fd9-bf31-0ab5a030ec00)


