### PR TITLE
PYR1-900 Fix a bug with the active fires markers

### DIFF
--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -11,8 +11,7 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def pending? (r/atom false))
-
+(defonce pending? (r/atom false))
 (defonce forgot?  (r/atom false))
 (defonce email    (r/atom ""))
 (defonce password (r/atom ""))

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -12,8 +12,7 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def pending? (r/atom false))
-
+(defonce pending?    (r/atom false))
 (defonce email       (r/atom ""))
 (defonce full-name   (r/atom ""))
 (defonce password    (r/atom ""))

--- a/src/cljs/pyregence/pages/reset_password.cljs
+++ b/src/cljs/pyregence/pages/reset_password.cljs
@@ -12,8 +12,7 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def pending? (r/atom false))
-
+(defonce pending?    (r/atom false))
 (defonce email       (r/atom ""))
 (defonce reset-key   (r/atom ""))
 (defonce password    (r/atom ""))


### PR DESCRIPTION
## Purpose
Fixes a bug where the active fires markers wouldn't always show up the first time you loaded the site.

## Related Issues
Closes PYR1-900

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Layers > Active Fires markers

#### Role
Visitor

#### Steps
- Visit Pyrecast normally
- Do a hard refresh on Pyrecast (Command + Shift + R)
- Open Pyrecast in an incognito window
- Switch between the Active Fires and other tabs on Pyrecast

#### Desired Outcome
The active fires markers should always show up whenever you first hit the Active Fires tab (and thus have "*All Active Fires" selected).
