### PR TITLE
PYR1-910 Link to live feed when clicking on logo

### DIFF
--- a/src/clj/pyregence/cameras.clj
+++ b/src/clj/pyregence/cameras.clj
@@ -62,7 +62,7 @@
 ;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- site->feature [api-name {:keys [name site position update_time]}]
+(defn- site->feature [api-name {:keys [name site position image update_time]}]
   {:type       "Feature"
    :geometry   {:type        "Point"
                 :coordinates [(:longitude site) (:latitude site)]}
@@ -73,7 +73,8 @@
                 :pan         (:pan position)
                 :state       (:state site)
                 :tilt        (:tilt position)
-                :update-time update_time}})
+                :update-time update_time
+                :image-url   (:url image)}})
 
 (defn- ->feature-collection [features]
   {:type     "FeatureCollection"

--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -1,5 +1,6 @@
 (ns pyregence.components.map-controls.camera-tool
   (:require [clojure.core.async                            :refer [take! go <!]]
+            [clojure.string                                :as str]
             [herb.core                                     :refer [<class]]
             [pyregence.components.common                   :refer [tool-tip-wrapper]]
             [pyregence.components.help                     :as h]
@@ -27,6 +28,15 @@
          (<!)
          (:body)
          (js/URL.createObjectURL))))
+
+(defn- alert-ca-image-url->alert-ca-camera-id
+  "Parses the camera ID out of the image URL for ALERTCalifornia cameras.
+   Ex: A URL of \"https://prod.weathernode.net/data/img/2428/2023/07/12/Sutro_Tower_1_1689204279_6490.jpg\"
+   returns `2428`."
+  [url]
+  (-> url
+      (str/split #"/")
+      (get 5 nil)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Styles
@@ -70,6 +80,83 @@
    [:span {:style {:margin-right "-.5rem"
                    :visibility   (if (and @!/show-camera? @!/mobile?) "visible" "hidden")}}
     [tool-button :close #(reset! !/show-camera? false)]]])
+
+(defn- camera-tool-intro []
+  [:div {:style {:padding "1.2em"}}
+   "Click on a camera to view the most recent image. Powered by "
+   [:a {:href   "https://www.alertwildfire.org/"
+        :ref    "noreferrer noopener"
+        :target "_blank"}
+    "ALERT Wildfire"]
+   " and "
+   [:a {:href   "https://alertcalifornia.org/"
+        :ref    "noreferrer noopener"
+        :target "_blank"}
+    "ALERTCalifornia"]
+   "."])
+
+(defn- camera-too-old [camera-name camera-api-name camera-image-url camera-age]
+  [:div {:style {:padding "1.2em"}}
+   [:p (str "The " camera-name " camera has not been refreshed for "
+            (u-num/to-precision 1 camera-age) " hours. Please try again later.")]
+   [:p "Click"
+    [:a {:href   (if (= camera-api-name "alert-wildfire")
+                   (str "https://www.alertwildfire.org/region/?camera=" camera-name)
+                   (str "https://alertca.live/cam-console/" (alert-ca-image-url->alert-ca-camera-id camera-image-url)))
+         :ref    "noreferrer noopener"
+         :target "_blank"}
+     " here "]
+    "for more information about the " camera-name " camera."]])
+
+(defn- camera-image [camera-name camera-api-name camera-image-url reset-view zoom-camera image-src]
+  [:div
+   [:div {:style {:display         "flex"
+                  :justify-content "center"
+                  :position        "absolute"
+                  :top             "2rem"
+                  :width           "100%"}}
+    [:label (str "Camera: " camera-name)]]
+   [:a {:href   (if (= camera-api-name "alert-wildfire")
+                  (str "https://www.alertwildfire.org/region/?camera=" camera-name)
+                  (str "https://alertca.live/cam-console/" (alert-ca-image-url->alert-ca-camera-id camera-image-url)))
+        :ref    "noreferrer noopener"
+        :target "_blank"}
+    [:img {:src   (if (= camera-api-name "alert-wildfire")
+                    "images/awf_logo.png"
+                    "images/alert_ca_logo.png")
+           :style ($/combine $alert-logo-style)}]]
+   (when @!/terrain?
+     [tool-tip-wrapper
+      "Zoom Out to 2D"
+      :left
+      [:button {:class    (<class $/p-themed-button)
+                :on-click reset-view
+                :style    {:bottom   "1.25rem"
+                           :padding  "2px"
+                           :position "absolute"
+                           :left     "1rem"}}
+       [:div {:style {:height "32px"
+                      :width  "32px"}}
+        [svg/return]]]])
+   [tool-tip-wrapper
+    "Zoom Map to Camera"
+    :right
+    [:button {:class    (<class $/p-themed-button)
+              :on-click zoom-camera
+              :style    {:bottom   "1.25rem"
+                         :padding  "2px"
+                         :position "absolute"
+                         :right    "1rem"}}
+     [:div {:style {:height "32px"
+                    :width  "32px"}}
+      [svg/binoculars]]]]
+   [:img {:src   @image-src
+          :style {:height "auto" :width "100%"}}]])
+
+
+(defn- loading-camera [camera-name]
+  [:div {:style {:padding "1.2em"}}
+   (str "Loading camera " camera-name "...")])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Root Component
@@ -120,84 +207,28 @@
                                      #(mb/add-feature-highlight!
                                        "fire-cameras" "fire-cameras"
                                        :click-fn on-click))]
-    (let [render-content (fn []
-                           (cond
-                             (nil? @active-camera)
-                             [:div {:style {:padding "1.2em"}}
-                              "Click on a camera to view the most recent image. Powered by "
-                              [:a {:href   "https://www.alertwildfire.org/"
-                                   :ref    "noreferrer noopener"
-                                   :target "_blank"}
-                               "ALERT Wildfire"]
-                              " and "
-                              [:a {:href   "https://alertcalifornia.org/"
-                                   :ref    "noreferrer noopener"
-                                   :target "_blank"}
-                               "ALERTCalifornia"]
-                              "."]
+    (let [camera-name        (:name @active-camera)
+          camera-api-name    (:api-name @active-camera)
+          camera-image-url   (:image-url @active-camera)
+          render-content     (fn []
+                               (cond
+                                 (nil? @active-camera)
+                                 [camera-tool-intro]
 
-                             (>= @camera-age 4)
-                             [:div {:style {:padding "1.2em"}}
-                              [:p (str "The " (:name @active-camera) " camera has not been refreshed for "
-                                       (u-num/to-precision 1 @camera-age) " hours. Please try again later.")]]
-                              ;; If we want to implement this on the ALERTCalifornia side, we'll have to point to a URL such as https://alertca.live/cam-console/2648
-                              ;; This means that we would need to parse out the camera ID from the image > url section of a cameras?name=Axis-LikelyMtn2
-                              ;; On the ALERT Wildfire side, this URL currently doesn't lead to anything helpful for cameras that are down, so we could just omit this section.
-                              ; [:p "Click"
-                              ;  [:a {:href   (str "https://www.alertwildfire.org/region/?camera=" (:name @active-camera))
-                              ;       :ref    "noreferrer noopener"
-                              ;       :target "_blank"}
-                              ;   " here "]
-                              ;  "for more information about the " (:name @active-camera) " camera."]]
+                                 (>= @camera-age 4)
+                                 [camera-too-old camera-name camera-api-name camera-image-url @camera-age]
 
-                             @image-src
-                             [:div
-                              [:div {:style {:display         "flex"
-                                             :justify-content "center"
-                                             :position        "absolute"
-                                             :top             "2rem"
-                                             :width           "100%"}}
-                               [:label (str "Camera: " (:name @active-camera))]]
-                              [:a {:href   (if (= (:api-name @active-camera) "alert-wildfire")
-                                             "https://www.alertwildfire.org/"
-                                             "https://alertcalifornia.org/")
-                                   :ref    "noreferrer noopener"
-                                   :target "_blank"}
-                               [:img {:src   (if (= (:api-name @active-camera) "alert-wildfire")
-                                               "images/awf_logo.png"
-                                               "images/alert_ca_logo.png")
-                                      :style ($/combine $alert-logo-style)}]]
-                              (when @!/terrain?
-                                [tool-tip-wrapper
-                                 "Zoom Out to 2D"
-                                 :left
-                                 [:button {:class    (<class $/p-themed-button)
-                                           :on-click reset-view
-                                           :style    {:bottom   "1.25rem"
-                                                      :padding  "2px"
-                                                      :position "absolute"
-                                                      :left     "1rem"}}
-                                  [:div {:style {:height "32px"
-                                                 :width  "32px"}}
-                                   [svg/return]]]])
-                              [tool-tip-wrapper
-                               "Zoom Map to Camera"
-                               :right
-                               [:button {:class    (<class $/p-themed-button)
-                                         :on-click zoom-camera
-                                         :style    {:bottom   "1.25rem"
-                                                    :padding  "2px"
-                                                    :position "absolute"
-                                                    :right    "1rem"}}
-                                [:div {:style {:height "32px"
-                                               :width  "32px"}}
-                                 [svg/binoculars]]]]
-                              [:img {:src   @image-src
-                                     :style {:height "auto" :width "100%"}}]]
+                                 @image-src
+                                 [camera-image
+                                  camera-name
+                                  camera-api-name
+                                  camera-image-url
+                                  reset-view
+                                  zoom-camera
+                                  image-src]
 
-                             :else
-                             [:div {:style {:padding "1.2em"}}
-                              (str "Loading camera " (:name @active-camera) "...")]))]
+                                 :else
+                                 [loading-camera camera-name]))]
       (if @!/mobile?
         [:div#wildfire-mobile-camera-tool
          {:style ($/combine $/tool $mobile-camera-tool)}


### PR DESCRIPTION
## Purpose
Adds a link to the live camera feed for both ALERT Wildfire and ALERTCalifornia cameras. You can visit this link by clicking on the logo in the top left corner of a camera (or by clicking the link for a camera that hasn't been refreshed for at least four hours).

## Related Issues
Closes PYR1-910

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Toolbars > Cameras

#### Role
Visitor
#### Steps
<!-- All steps needed to test this PR -->
1. Click on the camera tool
2. For both a camera within California and a camera outside of California, click on the image/logo in the top left of the camera's image. This should either be an ALERTCalifornia or an ALERT Wildfire logo respectively.

#### Desired Outcome
You should be taken to (in a new tab) a live feed of the corresponding camera on either the ALERTCalifornia or ALERT Wildfire website.
