### PR TITLE
Update Alert California URL

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -219,7 +219,7 @@
    passing in an optional workspace-name allows you to call GetCapabilities
    on just that workspace by passing it into process-layers!."
   [{:strs [geoserver-key workspace-name]}]
-  (let [geoserver-key  (keyword geoserver-key)]
+  (let [geoserver-key (keyword geoserver-key)]
     (if (contains? (get-config :geoserver) geoserver-key)
       (try
         (let [stdout?       (= 0 (count @layers))

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -575,7 +575,7 @@
   (condp = md-status
     2       (do
               (log-str (str "Geoserver workspace is " geoserver-workspace))
-              ;; NOTE: set-capabilities! might be handled by the GeoSync action hook already, but doesn't hurt to leave it in
+              ;; NOTE: set-capabilities! isn't handled by the GeoSync action hook since GeoSync is running in CLI mode in the GeoSync microservice (action hooks only work in server mode).
               (set-capabilities! {"geoserver-key"  "match-drop"
                                   "workspace-name" geoserver-workspace})
               (log-str (str "Match Drop layers successfully added to Pyrecast! "
@@ -587,7 +587,7 @@
     3     (do
             (log-str "Deleting match job #" match-job-id " from the database.")
             (call-sql "delete_match_job" match-job-id)
-            ;; NOTE: remove-workspace! might be handled by the GeoSync action hook already, but doesn't hurt to leave it in
+            ;; NOTE: remove-workspace! isn't handled by the GeoSync action hook since GeoSync is running in CLI mode in the GeoSync microservice (action hooks only work in server mode)
             ;; TODO in the future we should make sure that the front-end is updated as soon as the workspace is removed.
             ;; we will need to do something similar to the refresh-fire-names! fn in match_drop_tool.cljs, but only call
             ;; it once this section of the code is hit.

--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -102,7 +102,7 @@
    [:p "Click"
     [:a {:href   (if (= camera-api-name "alert-wildfire")
                    (str "https://www.alertwildfire.org/region/?camera=" camera-name)
-                   (str "https://alertca.live/cam-console/" (alert-ca-image-url->alert-ca-camera-id camera-image-url)))
+                   (str "https://ops.alertcalifornia.org/cam-console/" (alert-ca-image-url->alert-ca-camera-id camera-image-url)))
          :ref    "noreferrer noopener"
          :target "_blank"}
      " here "]
@@ -118,7 +118,7 @@
     [:label (str "Camera: " camera-name)]]
    [:a {:href   (if (= camera-api-name "alert-wildfire")
                   (str "https://www.alertwildfire.org/region/?camera=" camera-name)
-                  (str "https://alertca.live/cam-console/" (alert-ca-image-url->alert-ca-camera-id camera-image-url)))
+                  (str "https://ops.alertcalifornia.org/cam-console/" (alert-ca-image-url->alert-ca-camera-id camera-image-url)))
         :ref    "noreferrer noopener"
         :target "_blank"}
     [:img {:src   (if (= camera-api-name "alert-wildfire")


### PR DESCRIPTION
## Purpose
> Attention: Starting September 14th, alertca.live will redirect to ops.alertcalifornia.org. Please transition over to ops.alertcalifornia.org to ensure uninterrupted site access.

This PR updates the URL in the necessary places and fixes some indentation issues and comments.
