### PR TITLE
PYR1-905 Add improved vector line styling to Pyrecast

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -242,22 +242,25 @@
     (js->clj %)
     (map (fn [rule]
            (let [label (get rule "title")]
-             {"label"    label
-              "quantity" (if (= label "nodata")
-                           "-9999" ; FIXME: if we end up having different nodata values later on, we will need to do regex on the "filter" key from the returned JSON
-                           label)
-              "color"    (if polygon-layer?
-                           (get-in rule ["symbolizers" 0 "Polygon" "fill"])
-                           (get-in rule ["symbolizers" 0 "Line" "stroke"]))
-              "opacity"  "1.0"}))
-         %)))
+             (if (= label "nolegend")
+               nil ; We don't add any nolegend values to the legend, those values are just there to add extra colors to the actual layer when previewing it on Pyrecast
+               {"label"    label
+                "quantity" (if (= label "nodata")
+                             "-9999" ; FIXME: if we end up having different nodata values later on, we will need to do regex on the "filter" key from the returned JSON
+                             label)
+                "color"    (if polygon-layer?
+                             (get-in rule ["symbolizers" 0 "Polygon" "fill"])
+                             (get-in rule ["symbolizers" 0 "Line" "stroke"]))
+                "opacity"  "1.0"})))
+         %)
+    (filter identity %)))
 
 (defn- process-raster-colormap-legend
   "Parses the JSON data from GetLegendGraphic from a layer using raster colormap styling."
   [rules]
   (as-> rules %
-      (u-misc/try-js-aget % 0 "symbolizers" 0 "Raster" "colormap" "entries")
-      (js->clj %)))
+        (u-misc/try-js-aget % 0 "symbolizers" 0 "Raster" "colormap" "entries")
+        (js->clj %)))
 
 (defn- process-legend!
   "Populates the legend-list atom with the result of the request from GetLegendGraphic.


### PR DESCRIPTION
## Purpose
Adds a custom `nolegend` designation to GeoServer CSS styles which omits any such values from the Pyrecast legend, but still allows for those colors to be displayed on vector line layers. 

## Related Issues
Closes PYR1-905

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
Layers > Transmission Line Vector line layers (fire area, fire volume, impacted structures)

#### Role
Visitor

#### Steps
1. Navigate to the Risk tab.
2. Select the transmission lines ignition pattern option.
3. Select each of the following output layers: fire area, fire volume, and impacted structures.
4. For each of the above output layers, scroll around the map + zoom in and out.

#### Desired Outcome
You should see colors on the layer that don't necessarily correspond exactly with the colors in the legend. i.e. there should be intermediate colors on the map that fall in between the different buckets laid out in the legend.

## Screenshots

### Before
![Screenshot from 2023-09-22 14-40-02](https://github.com/pyregence/pyregence/assets/40574170/3edc7a01-c236-4a77-9840-8f2332af37c1)


### After


![Screenshot from 2023-09-22 14-39-24](https://github.com/pyregence/pyregence/assets/40574170/94f223e9-0853-4668-9fe2-af83c83713f0)
