### PR TITLE
Update Match Drops to 72 run hours

### DIFF
--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -272,7 +272,7 @@
         north-buffer         12
         num-ensemble-members 200
         ignition-radius      300
-        run-hours            24
+        run-hours            72
         model-time           (u/convert-date-string ignition-time) ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
         wx-start-time        (u/round-down-to-nearest-hour model-time)
         fire-name            (str (get-md-config :md-prefix) "-match-drop-" match-job-id)
@@ -296,7 +296,7 @@
                                                             :north-buffer         north-buffer
                                                             :do-fuel              true
                                                             :fuel-source          "landfire"
-                                                            :fuel-version         "2.2.0"
+                                                            :fuel-version         "2.3.0_2.2.0"
                                                             :do-wx                true
                                                             :wx-start-time        wx-start-time
                                                             :wx-type              wx-type


### PR DESCRIPTION
Updates Match Drops to run for 72 hours (instead of 24).