### PR TITLE
PYR1-23 Overhaul the way that the PSPS tab is shown on an organization by organization basis

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Closes PYR1-###
 - [ ] Code passes linter rules (`clj-kondo --lint src`)
 - [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)
 - [ ] No new reflection warnings (`clojure -M:check-reflection`)
+- [ ] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)
 
 ## Testing
 #### Module Impacted

--- a/config.default.edn
+++ b/config.default.edn
@@ -46,4 +46,5 @@
                      :pass     "<pass>"
                      :tls      <true/false>
                      :site-url "<url>"}
+ :psps              {:allowed-orgs nil}
  :ga-id             nil}

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -82,9 +82,10 @@
    and are an admin or a member of."
   [user-id]
   (->> (call-sql "get_organizations" user-id)
-       (mapv (fn [{:keys [org_id org_name role_id email_domains auto_add auto_accept]}]
-               {:opt-id        org_id
-                :opt-label     org_name
+       (mapv (fn [{:keys [org_id org_name org_unique_id role_id email_domains auto_add auto_accept]}]
+               {:org-id        org_id
+                :org-name      org_name
+                :org-unique-id org_unique_id
                 :role          (if (= role_id 1) "admin" "member")
                 :email-domains email_domains
                 :auto-add?     auto_add

--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -68,6 +68,7 @@
                                :features          (get-config :features)
                                :geoserver         (get-config :geoserver)
                                :pyr-auth-token    (get-config :pyr-auth-token)
+                               :psps              (get-config :psps)
                                :announcement      (when (.exists (io/as-file "announcement.txt"))
                                                     (slurp "announcement.txt"))))
         "); };")])

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -69,6 +69,7 @@
     (reset! !/geoserver-urls (:geoserver cur-params))
     (reset! !/default-forecasts (get cur-params :default-forecasts))
     (reset! !/pyr-auth-token (get cur-params :pyr-auth-token))
+    (reset! !/allowed-psps-orgs (get-in cur-params [:psps :allowed-orgs]))
     (set-announcement-text! (:announcement cur-params))
     (render-root cur-params)))
 

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -8,15 +8,15 @@
    (when selected? {:color "white"})))
 
 (defn forecast-tabs
-  "Declares a component that displayes interactive tabs for selecting distinct forecasts"
+  "Declares a component that displayes interactive tabs for selecting distinct forecasts."
   [{:keys [capabilities current-forecast select-forecast! user-org-list]}]
   [:div {:style {:display "flex" :padding ".25rem 0"}}
    (doall
-    (map (fn [[key {:keys [allowed-org hover-text opt-label]}]]
-           (when (or (nil? allowed-org)                ; Tab isn't organization-specific
-                     (some (fn [{org-name :opt-label}] ; Tab **is** organization-specific
-                             (= org-name allowed-org)) ; and the user is an admin or member of that org
-                           user-org-list))             ; (the organization name is in their org-list)
+    (map (fn [[key {:keys [allowed-orgs hover-text opt-label]}]]
+           (when (or (nil? allowed-orgs)                         ; Tab isn't organization-specific
+                     (some (fn [{org-unique-id :org-unique-id}]  ; Tab **is** organization-specific
+                             (allowed-orgs org-unique-id))       ; and the user is an admin or member of that org
+                           user-org-list))                       ; (the organization unique id is in their org-list)
              ^{:key key}
              [tool-tip-wrapper
               hover-text

--- a/src/cljs/pyregence/components/nav_bar.cljs
+++ b/src/cljs/pyregence/components/nav_bar.cljs
@@ -15,7 +15,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn nav-bar
-  "Defines the horizontal navigation component for the application"
+  "Defines the horizontal navigation component for the application."
   [props]
   [:nav {:style ($/combine $nav-bar {:background ($/color-picker :yellow)})}
    [forecast-tabs props]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -574,7 +574,7 @@
                   :geoserver-key   :psps
                   :filter          "psps-zonal"
                   :underlays       (merge common-underlays near-term-forecast-underlays)
-                  :allowed-orgs    #{"nv-energy"}
+                  :allowed-orgs    @!/allowed-psps-orgs
                   :reverse-legend? true
                   :time-slider?    true
                   :hover-text      "Public Safety Power Shutoffs (PSPS) zonal statistics."

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -574,7 +574,7 @@
                   :geoserver-key   :psps
                   :filter          "psps-zonal"
                   :underlays       (merge common-underlays near-term-forecast-underlays)
-                  :allowed-org     "NV Energy"
+                  :allowed-orgs    #{"nv-energy"}
                   :reverse-legend? true
                   :time-slider?    true
                   :hover-text      "Public Safety Power Shutoffs (PSPS) zonal statistics."

--- a/src/cljs/pyregence/pages/admin.cljs
+++ b/src/cljs/pyregence/pages/admin.cljs
@@ -68,13 +68,13 @@
 
 (defn- get-org-by-id [org-list org-id]
   (->> org-list
-       (filter #(= org-id (:opt-id %)))
+       (filter #(= org-id (:org-id %)))
        first))
 
 (defn- set-selected-org! [org]
   (reset! *org               org)
-  (reset! *org-id            (:opt-id        org))
-  (reset! *org-name          (:opt-label     org))
+  (reset! *org-id            (:org-id        org))
+  (reset! *org-name          (:org-name      org))
   (reset! *org-email-domains (:email-domains org))
   (reset! *org-auto-accept?  (:auto-accept?  org))
   (reset! *org-auto-add?     (:auto-add?     org)))
@@ -286,8 +286,8 @@
      [:label {:style ($/padding "1px" :l)} "Organization List"]]
     [:div {:style {:overflow "auto"}}
      [:div {:style {:display "flex" :flex-direction "column"}}
-      (doall (map (fn [{:keys [opt-id opt-label]}]
-                    ^{:key opt-id} [org-item opt-id opt-label])
+      (doall (map (fn [{:keys [org-id org-name]}]
+                    ^{:key org-id} [org-item org-id org-name])
                   orgs))]]]])
 
 (defn- org-settings [_]

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -124,6 +124,8 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
   mapbox-access-token (atom nil))
 (defonce ^{:doc "The Pyrecast auth token for making API requests."}
   pyr-auth-token (r/atom nil))
+(defonce ^{:doc "The organizations that are allowed to view the PSPS tab. A set of unique org ids (strings)."}
+  allowed-psps-orgs (r/atom nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State Setters

--- a/src/sql/changes/2023-10-31_allowed-orgs.sql
+++ b/src/sql/changes/2023-10-31_allowed-orgs.sql
@@ -1,0 +1,26 @@
+ALTER TABLE organizations
+ADD org_unique_id text UNIQUE;
+
+UPDATE organizations
+SET org_unique_id = 'public'
+WHERE org_name = 'Public';
+
+UPDATE organizations
+SET org_unique_id = 'nv-energy'
+WHERE org_name = 'NV Energy';
+
+UPDATE organizations
+SET org_unique_id = 'pyregence-consortium'
+WHERE org_name = 'Pyregence Consortium';
+
+
+UPDATE organizations
+SET org_unique_id = 'liberty'
+WHERE org_name = 'Liberty';
+
+UPDATE organizations
+SET org_unique_id = 'pacificorp'
+WHERE org_name = 'PacifiCorp';
+
+ALTER TABLE organizations
+ALTER COLUMN org_unique_id SET NOT NULL;

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -181,6 +181,7 @@ CREATE OR REPLACE FUNCTION get_organizations(_user_id integer)
  RETURNS TABLE (
     org_id           integer,
     org_name         text,
+    org_unique_id    text,
     role_id          integer,
     email_domains    text,
     auto_add         boolean,
@@ -189,6 +190,7 @@ CREATE OR REPLACE FUNCTION get_organizations(_user_id integer)
 
     SELECT o.organization_uid,
         o.org_name,
+        o.org_unique_id,
         ou.role_rid,
         o.email_domains,
         o.auto_add,
@@ -197,7 +199,7 @@ CREATE OR REPLACE FUNCTION get_organizations(_user_id integer)
     WHERE (o.organization_uid = ou.organization_rid)
         AND (ou.user_rid = _user_id)
         AND (ou.role_rid = 1 OR ou.role_rid = 2)
-    ORDER BY o.org_name
+    ORDER BY o.org_unique_id
 
 $$ LANGUAGE SQL;
 
@@ -373,7 +375,7 @@ DECLARE
   _org_id     integer;
 BEGIN
     SELECT user_uid INTO _user_id FROM users WHERE email = _email;
- 
+
     SELECT organization_uid INTO _org_id FROM organizations WHERE org_name = _org_name;
 
     INSERT INTO organization_users

--- a/src/sql/tables/user_tables.sql
+++ b/src/sql/tables/user_tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE users (
 CREATE TABLE organizations (
     organization_uid    SERIAL PRIMARY KEY,
     org_name            text NOT NULL,
+    org_unique_id       text NOT NULL UNIQUE,
     email_domains       text,
     auto_add            boolean,
     auto_accept         boolean,


### PR DESCRIPTION
## Purpose
Adds a new `org_unique_id` column to the `organizations` table in order to more ergonomically be able to select entire organizations. 

Adds a changefile to add `org_unique_id` values to all existing organizations on production.

Add a new `:psps` key to `config.edn` to keep track of the organizations that are allowed to view the PSPS tab.

Cleans up some of the variable naming surrounding organizations in the codebase.



## Related Issues
Closes PYR1-23 PYR1-707

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)