### PR TITLE
Fix a bug with the PSPS tab always showing

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -46,5 +46,4 @@
                      :pass     "<pass>"
                      :tls      <true/false>
                      :site-url "<url>"}
- :psps              {:allowed-orgs nil}
  :ga-id             nil}

--- a/src/clj/pyregence/views.clj
+++ b/src/clj/pyregence/views.clj
@@ -68,7 +68,6 @@
                                :features          (get-config :features)
                                :geoserver         (get-config :geoserver)
                                :pyr-auth-token    (get-config :pyr-auth-token)
-                               :psps              (get-config :psps)
                                :announcement      (when (.exists (io/as-file "announcement.txt"))
                                                     (slurp "announcement.txt"))))
         "); };")])

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -1,7 +1,6 @@
 (ns ^:figwheel-hooks pyregence.client
   (:require [goog.dom                           :as dom]
             [reagent.dom                        :refer [render]]
-            [pyregence.config                   :as c]
             [pyregence.state                    :as !]
             [pyregence.pages.admin              :as admin]
             [pyregence.pages.dashboard          :as dashboard]
@@ -69,7 +68,6 @@
     (reset! !/geoserver-urls (:geoserver cur-params))
     (reset! !/default-forecasts (get cur-params :default-forecasts))
     (reset! !/pyr-auth-token (get cur-params :pyr-auth-token))
-    (reset! !/allowed-psps-orgs (get-in cur-params [:psps :allowed-orgs]))
     (set-announcement-text! (:announcement cur-params))
     (render-root cur-params)))
 

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -574,7 +574,7 @@
                   :geoserver-key   :psps
                   :filter          "psps-zonal"
                   :underlays       (merge common-underlays near-term-forecast-underlays)
-                  :allowed-orgs    @!/allowed-psps-orgs
+                  :allowed-orgs    #{"nv-energy"}
                   :reverse-legend? true
                   :time-slider?    true
                   :hover-text      "Public Safety Power Shutoffs (PSPS) zonal statistics."

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -124,8 +124,6 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
   mapbox-access-token (atom nil))
 (defonce ^{:doc "The Pyrecast auth token for making API requests."}
   pyr-auth-token (r/atom nil))
-(defonce ^{:doc "The organizations that are allowed to view the PSPS tab. A set of unique org ids (strings)."}
-  allowed-psps-orgs (r/atom nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State Setters


### PR DESCRIPTION
## Purpose
Fixes a bug with storing the `allowed-psps-orgs` in `config.edn` and instead places them inline in `config.cljs`.
