### PR TITLE
PYR1-949 Allow for multiple orgs to see PSPS tab

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -70,6 +70,14 @@
                          (str "The user with an id of " user-id " does not have Match Drop access."))]
       (data-response response-msg {:status 403}))))
 
+(defn get-user-psps-org [user-id]
+  (if-let [psps-org (sql-primitive (call-sql "get_user_psps_org" user-id))]
+    (data-response psps-org)
+    (let [response-msg (if (nil? user-id)
+                         "There is no user logged in. The PSPS tab will remain disabled."
+                         (str "The user with an id of " user-id " does not have PSPS access."))]
+      (data-response response-msg {:status 403}))))
+
 (defn update-user-name [email new-name]
   (if-let [user-id (sql-primitive (call-sql "get_user_id_by_email" email))]
     (do (call-sql "update_user_name" user-id new-name)

--- a/src/clj/pyregence/remote_api.clj
+++ b/src/clj/pyregence/remote_api.clj
@@ -12,6 +12,7 @@
                                               get-org-member-users
                                               get-user-info
                                               get-user-match-drop-access
+                                              get-user-psps-org
                                               log-in
                                               log-out
                                               remove-org-user
@@ -62,6 +63,7 @@
                "get-user-info"                 get-user-info
                "get-user-layers"               get-user-layers
                "get-user-match-drop-access"    get-user-match-drop-access
+               "get-user-psps-org"             get-user-psps-org
                "get-red-flag-layer"            get-red-flag-layer
                "initiate-md"                   initiate-md!
                "log-in"                        log-in

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -13,10 +13,10 @@
   [:div {:style {:display "flex" :padding ".25rem 0"}}
    (doall
     (map (fn [[key {:keys [allowed-orgs hover-text opt-label]}]]
-           (when (or (nil? allowed-orgs)                         ; Tab isn't organization-specific
-                     (some (fn [{org-unique-id :org-unique-id}]  ; Tab **is** organization-specific
-                             (allowed-orgs org-unique-id))       ; and the user is an admin or member of that org
-                           user-org-list))                       ; (the organization unique id is in their org-list)
+           (when (or (nil? allowed-orgs)                        ; Tab isn't organization-specific, so show it
+                     (some (fn [{org-unique-id :org-unique-id}] ; If tab **is** organization-specific
+                             (allowed-orgs org-unique-id))      ; the user must be an admin or member of one of the allowed orgs
+                           user-org-list))
              ^{:key key}
              [tool-tip-wrapper
               hover-text

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -572,9 +572,8 @@
                                                  :options    {:loading {:opt-label "Loading..."}}}}}
    :psps-zonal   {:opt-label       "PSPS"
                   :geoserver-key   :psps
-                  :filter          "psps-zonal"
                   :underlays       (merge common-underlays near-term-forecast-underlays)
-                  :allowed-orgs    #{"nv-energy"}
+                  :allowed-orgs    #{"nve" "liberty"}
                   :reverse-legend? true
                   :time-slider?    true
                   :auto-zoom?      true
@@ -612,42 +611,31 @@
                                                                [:strong "Note"]
                                                                ": The impacted structrures, fire area, fire volume, and power line ignition rate quantities are only available with the ELMFIRE model."]]
                                                  :options    (array-map
-                                                              :ws    {:opt-label    "Sustained wind speed (mph)"
-                                                                      :filter       "nve"
-                                                                      :units        "mph"}
-                                                              :wg    {:opt-label    "Wind gust (mph)"
-                                                                      :filter       "nve"
-                                                                      :units        "mph"}
-                                                              :wd    {:opt-label    "Wind direction (\u00B0)"
-                                                                      :filter       "nve"
-                                                                      :units        "\u00B0"}
-                                                              :ffwi  {:opt-label    "Fosberg Fire Weather Index"
-                                                                      :filter       "nve"
-                                                                      :units        ""}
-                                                              :rh    {:opt-label    "Relative humidity (%)"
-                                                                      :filter       "nve"
-                                                                      :units        "%"}
-                                                              :tmpf  {:opt-label    "Temperature (\u00B0F)"
-                                                                      :filter       "nve"
-                                                                      :units        "\u00B0F"}
+                                                              :ws    {:opt-label "Sustained wind speed (mph)"
+                                                                      :units     "mph"}
+                                                              :wg    {:opt-label "Wind gust (mph)"
+                                                                      :units     "mph"}
+                                                              :wd    {:opt-label "Wind direction (\u00B0)"
+                                                                      :units     "\u00B0"}
+                                                              :ffwi  {:opt-label "Fosberg Fire Weather Index"
+                                                                      :units     ""}
+                                                              :rh    {:opt-label "Relative humidity (%)"
+                                                                      :units     "%"}
+                                                              :tmpf  {:opt-label "Temperature (\u00B0F)"
+                                                                      :units     "\u00B0F"}
                                                               :pign  {:opt-label "Firebrand ignition probability (%)"
-                                                                      :filter    "nve"
                                                                       :units     "%"}
                                                               :str   {:opt-label    "Impacted structures"
-                                                                      :filter       "nve"
                                                                       :units        "Structures"
                                                                       :disabled-for #{:r :n1 :n2 :g1 :g2 :b}}
                                                               :area  {:opt-label    "Fire area (acres)"
-                                                                      :filter       "nve"
                                                                       :units        "Acres"
                                                                       :disabled-for #{:r :n1 :n2 :g1 :g2 :b}}
                                                               :vol   {:opt-label    "Fire volume (acre-ft)"
-                                                                      :filter       "nve"
                                                                       :units        "Acre-ft"
                                                                       :disabled-for #{:r :n1 :n2 :g1 :g2 :b}}
-                                                              :pligr {:opt-label "Power line ignition rate"
-                                                                      :filter    "nve"
-                                                                      :units     "Ignitions/line-mi/hr"
+                                                              :pligr {:opt-label    "Power line ignition rate"
+                                                                      :units        "Ignitions/line-mi/hr"
                                                                       :disabled-for #{:r :n1 :n2 :g1 :g2 :b}})}
                                     :statistic  {:opt-label      "Statistic"
                                                  :hover-text     "Options are minimum, mean, or maximum."
@@ -691,18 +679,25 @@
                                                                "https://doi.org/10.1016/j.firesaf.2013.08.014"]
                                                               ")."]
                                                  :options    {:r  {:opt-label    "HRRR"
-                                                                   :disabled-for #{:area :str :vol}}
+                                                                   :filter       "psps-zonal"
+                                                                   :disabled-for #{:area :str :vol :pligr}}
                                                               :n1 {:opt-label    "NAM 3 km"
-                                                                   :disabled-for #{:area :str :vol}}
+                                                                   :filter       "psps-zonal"
+                                                                   :disabled-for #{:area :str :vol :pligr}}
                                                               :n2 {:opt-label    "NAM 12 km"
-                                                                   :disabled-for #{:area :str :vol}}
+                                                                   :filter       "psps-zonal"
+                                                                   :disabled-for #{:area :str :vol :pligr}}
                                                               :g1 {:opt-label    "GFS 0.125\u00B0"
-                                                                   :disabled-for #{:area :str :vol}}
+                                                                   :filter       "psps-zonal"
+                                                                   :disabled-for #{:area :str :vol :pligr}}
                                                               :g2 {:opt-label    "GFS 0.250\u00B0"
-                                                                   :disabled-for #{:area :str :vol}}
+                                                                   :filter       "psps-zonal"
+                                                                   :disabled-for #{:area :str :vol :pligr}}
                                                               :b  {:opt-label    "NBM"
-                                                                   :disabled-for #{:area :str :vol}}
-                                                              :m  {:opt-label    "ELMFIRE"}}}
+                                                                   :filter       "psps-zonal"
+                                                                   :disabled-for #{:area :str :vol :pligr}}
+                                                              :m  {:opt-label "ELMFIRE"
+                                                                   :filter    "psps-zonal"}}}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}})

--- a/src/sql/changes/2023-11-16_psps-updates.sql
+++ b/src/sql/changes/2023-11-16_psps-updates.sql
@@ -1,0 +1,18 @@
+ALTER TABLE users
+ADD psps_org text;
+
+UPDATE organizations
+SET org_unique_id = 'nve'
+WHERE org_name = 'NV Energy';
+
+UPDATE users
+set psps_org = 'nve'
+WHERE email = 'demo@nvenergy.com';
+
+UPDATE users
+set email = 'demo@liberty.com'
+WHERE name = 'Liberty';
+
+UPDATE users
+set psps_org = 'liberty'
+WHERE email = 'demo@liberty.com';

--- a/src/sql/changes/2023-11-16_psps-updates.sql
+++ b/src/sql/changes/2023-11-16_psps-updates.sql
@@ -11,7 +11,7 @@ WHERE email = 'demo@nvenergy.com';
 
 UPDATE users
 set email = 'demo@liberty.com'
-WHERE name = 'Liberty';
+WHERE name = 'Liberty Demo Account';
 
 UPDATE users
 set psps_org = 'liberty'

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -172,6 +172,15 @@ CREATE OR REPLACE FUNCTION get_user_match_drop_access(_user_id integer)
 
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION get_user_psps_org(_user_id integer)
+ RETURNS text AS $$
+
+    SELECT psps_org
+    FROM users
+    WHERE user_uid = _user_id
+
+$$ LANGUAGE SQL;
+
 ---
 ---  Organizations
 ---

--- a/src/sql/tables/user_tables.sql
+++ b/src/sql/tables/user_tables.sql
@@ -16,7 +16,8 @@ CREATE TABLE users (
     super_admin       boolean DEFAULT FALSE,
     verified          boolean DEFAULT FALSE,
     reset_key         text DEFAULT NULL,
-    match_drop_access boolean DEFAULT FALSE
+    match_drop_access boolean DEFAULT FALSE,
+    psps_org          text default NULL
 );
 
 -- Stores information about organizations


### PR DESCRIPTION
## Purpose
Allow for multiple orgs  to use the PSPS tab. The new `psps_org` column in the `users` table tells us which PSPS data the logged in user should see when they navigate to the PSPS tab. Note that users can only see PSPS layers from one utility company at a time.

## Related Issues
Closes PYR1-949

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)
