### PR TITLE
PYR1-963 Add GeoServer credentials to organizations

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -90,14 +90,15 @@
    and are an admin or a member of."
   [user-id]
   (->> (call-sql "get_organizations" user-id)
-       (mapv (fn [{:keys [org_id org_name org_unique_id role_id email_domains auto_add auto_accept]}]
-               {:org-id        org_id
-                :org-name      org_name
-                :org-unique-id org_unique_id
-                :role          (if (= role_id 1) "admin" "member")
-                :email-domains email_domains
-                :auto-add?     auto_add
-                :auto-accept?  auto_accept}))
+       (mapv (fn [{:keys [org_id org_name org_unique_id geoserver_credentials role_id email_domains auto_add auto_accept]}]
+               {:org-id                org_id
+                :org-name              org_name
+                :org-unique-id         org_unique_id
+                :geoserver-credentials geoserver_credentials
+                :role                  (if (= role_id 1) "admin" "member")
+                :email-domains         email_domains
+                :auto-add?             auto_add
+                :auto-accept?          auto_accept}))
        (data-response)))
 
 (defn get-org-member-users

--- a/src/sql/changes/2023-12-15_geoserver-logins.sql
+++ b/src/sql/changes/2023-12-15_geoserver-logins.sql
@@ -1,2 +1,2 @@
 ALTER TABLE organizations
-ADD geoserver_credentials text;
+ADD geoserver_credentials varchar(72);

--- a/src/sql/changes/2023-12-15_geoserver-logins.sql
+++ b/src/sql/changes/2023-12-15_geoserver-logins.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organizations
+ADD geoserver_credentials text;

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -188,18 +188,20 @@ $$ LANGUAGE SQL;
 -- Returns all organizations for a user that they are an admin or member of
 CREATE OR REPLACE FUNCTION get_organizations(_user_id integer)
  RETURNS TABLE (
-    org_id           integer,
-    org_name         text,
-    org_unique_id    text,
-    role_id          integer,
-    email_domains    text,
-    auto_add         boolean,
-    auto_accept      boolean
+    org_id                integer,
+    org_name              text,
+    org_unique_id         text,
+    geoserver_credentials text,
+    role_id               integer,
+    email_domains         text,
+    auto_add              boolean,
+    auto_accept           boolean
  ) AS $$
 
     SELECT o.organization_uid,
         o.org_name,
         o.org_unique_id,
+        o.geoserver_credentials,
         ou.role_rid,
         o.email_domains,
         o.auto_add,

--- a/src/sql/tables/user_tables.sql
+++ b/src/sql/tables/user_tables.sql
@@ -22,15 +22,16 @@ CREATE TABLE users (
 
 -- Stores information about organizations
 CREATE TABLE organizations (
-    organization_uid    SERIAL PRIMARY KEY,
-    org_name            text NOT NULL,
-    org_unique_id       text NOT NULL UNIQUE,
-    email_domains       text,
-    auto_add            boolean,
-    auto_accept         boolean,
-    archived            boolean DEFAULT FALSE,
-    created_date        date DEFAULT NOW(),
-    archived_date       date
+    organization_uid      SERIAL PRIMARY KEY,
+    org_name              text NOT NULL,
+    org_unique_id         text NOT NULL UNIQUE,
+    geoserver_credentials varchar(72),
+    email_domains         text,
+    auto_add              boolean,
+    auto_accept           boolean,
+    archived              boolean DEFAULT FALSE,
+    created_date          date DEFAULT NOW(),
+    archived_date         date
 );
 
 -- Creates a relationship between users and organizations


### PR DESCRIPTION
## Purpose
Adds a `geoserver_credentials` column to the `organizations` table.

## Related Issues
Closes PYR1-963

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)
