### PR TITLE
HER-66 Extend `set-capabilities` for PSPS

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -24,6 +24,8 @@
                      :match-drop  "https://sierra.pyregence.org/geoserver"
                      :pyreclimate "https://climate.pyregence.org/geoserver"
                      :psps        "https://energy.pyregence.org:8443/geoserver"}
+ :psps              {:geoserver-admin-username "admin"
+                     :geoserver-admin-password "password"}
  :match-drop        {:app-name       "Pyrecast Match Drop Server"
                      :app-host       "localhost"
                      :app-port       31337

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -135,3 +135,11 @@
 (defn remove-org-user [org-user-id]
   (call-sql "remove_org_user" org-user-id)
   (data-response ""))
+
+(defn get-psps-organizations
+  "Returns the list of all organizations that have PSPS layers (currently denoted
+   by the presence of a value in the `geoserver_credentials` column)."
+  []
+  (->> (call-sql "get_psps_organizations")
+       (mapv #(:org_unique_id %))
+       (data-response)))

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -14,6 +14,8 @@
 (defonce layers (atom {}))
 
 (def site-url (get-config :mail :site-url))
+(def psps-geoserver-admin-username (get-config :psps :geoserver-admin-username))
+(def psps-geoserver-admin-password (get-config :psps :geoserver-admin-password))
 (def private-layer-geoservers #{:psps})
 
 ;;; Helper Functions
@@ -147,14 +149,17 @@
    to generate a vector of layer entries where each entry is a map. The info
    in each entry map is generated based on the title of the layer. Different layer
    types have their information generated in different ways using the split-
-   functions above."
-  [geoserver-url workspace-name]
-  (let [xml-response (-> geoserver-url
+   functions above. Optionally can provide `basic-auth`, which is used for password
+   protected workspaces. `basic-auth` must be either a string of the form
+   \"username:password\" or a tuple of the form `[username passwords]`."
+  [geoserver-url workspace-name & [basic-auth]]
+  (let [base-url     (-> geoserver-url
                          (u/end-with "/")
                          (str "wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities"
                               (when workspace-name
-                                (str "&NAMESPACE=" workspace-name)))
-                         (client/get)
+                                (str "&NAMESPACE=" workspace-name))))
+        xml-response (-> base-url
+                         (client/get (when basic-auth {:basic-auth basic-auth}))
                          (:body))]
     (as-> xml-response xml
       (str/replace xml "\n" "")
@@ -223,16 +228,16 @@
 (defn set-capabilities!
   "Populates the layers atom with all of the layers that are returned
    from a call to GetCapabilities on a specific GeoServer. Passing in a
-   geoserver-key specifies which GeoServer to call GetCapabilities on and
-   passing in an optional workspace-name allows you to call GetCapabilities
-   on just that workspace by passing it into process-layers!."
-  [{:strs [geoserver-key workspace-name]}]
+   `geoserver-key` specifies which GeoServer to call GetCapabilities on and
+   passing in an optional `workspace-name` allows you to call GetCapabilities
+   on just that workspace by passing it into `process-layers!`."
+  [{:strs [geoserver-key workspace-name basic-auth]}]
   (let [geoserver-key (keyword geoserver-key)]
     (if (contains? (get-config :geoserver) geoserver-key)
       (try
         (let [stdout?       (= 0 (count @layers))
               geoserver-url (get-config :geoserver geoserver-key)
-              new-layers    (process-layers! geoserver-url workspace-name)
+              new-layers    (process-layers! geoserver-url workspace-name basic-auth)
               message       (str (count new-layers) " layers from " geoserver-url " added to " site-url ".")]
           (if workspace-name
             (do
@@ -251,7 +256,11 @@
    for those that relate to private layers."
   []
   (doseq [geoserver-key (keys (get-config :geoserver))]
-    (when-not (private-layer-geoservers geoserver-key)
+    (if (private-layer-geoservers geoserver-key)
+      (set-capabilities! {"geoserver-key" (name geoserver-key)
+                          "basic-auth"    (str psps-geoserver-admin-username
+                                               ":"
+                                               psps-geoserver-admin-password)})
       (set-capabilities! {"geoserver-key" (name geoserver-key)})))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " site-url ".")))

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -252,8 +252,7 @@
       (log-str "Failed to load capabilities. The GeoServer URL passed in was not found in config.edn."))))
 
 (defn set-all-capabilities!
-  "Calls set-capabilities! on all GeoServer URLs provided in config.edn except
-   for those that relate to private layers."
+  "Calls set-capabilities! on all GeoServer URLs provided in config.edn."
   []
   (doseq [geoserver-key (keys (get-config :geoserver))]
     (if (private-layer-geoservers geoserver-key)

--- a/src/clj/pyregence/remote_api.clj
+++ b/src/clj/pyregence/remote_api.clj
@@ -10,6 +10,7 @@
                                               get-organizations
                                               get-org-non-member-users
                                               get-org-member-users
+                                              get-psps-organizations
                                               get-user-info
                                               get-user-match-drop-access
                                               get-user-psps-org
@@ -60,6 +61,7 @@
                "get-organizations"             get-organizations
                "get-org-non-member-users"      get-org-non-member-users
                "get-org-member-users"          get-org-member-users
+               "get-psps-organizations"        get-psps-organizations
                "get-user-info"                 get-user-info
                "get-user-layers"               get-user-layers
                "get-user-match-drop-access"    get-user-match-drop-access

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -9,14 +9,14 @@
 
 (defn forecast-tabs
   "Declares a component that displayes interactive tabs for selecting distinct forecasts."
-  [{:keys [capabilities current-forecast select-forecast! user-org-list]}]
+  [{:keys [capabilities current-forecast select-forecast! user-orgs-list]}]
   [:div {:style {:display "flex" :padding ".25rem 0"}}
    (doall
     (map (fn [[key {:keys [allowed-orgs hover-text opt-label]}]]
            (when (or (nil? allowed-orgs)                        ; Tab isn't organization-specific, so show it
                      (some (fn [{org-unique-id :org-unique-id}] ; If tab **is** organization-specific
                              (allowed-orgs org-unique-id))      ; the user must be an admin or member of one of the allowed orgs
-                           user-org-list))
+                           user-orgs-list))
              ^{:key key}
              [tool-tip-wrapper
               hover-text

--- a/src/cljs/pyregence/components/login_menu.cljs
+++ b/src/cljs/pyregence/components/login_menu.cljs
@@ -25,6 +25,7 @@
         [:label {:style    {:cursor "pointer" :margin ".16rem .2rem 0 0"}
                  :on-click (fn []
                              (go (<! (u-async/call-clj-async! "log-out"))
+                                 ;; TODO also remove workspace for PSPS orgs??
                                  (-> js/window .-location .reload)))}
          "Log Out"]]
        ;; [:label {:style {:margin-right "1rem" :cursor "pointer"}

--- a/src/cljs/pyregence/components/login_menu.cljs
+++ b/src/cljs/pyregence/components/login_menu.cljs
@@ -25,7 +25,6 @@
         [:label {:style    {:cursor "pointer" :margin ".16rem .2rem 0 0"}
                  :on-click (fn []
                              (go (<! (u-async/call-clj-async! "log-out"))
-                                 ;; TODO also remove workspace for PSPS orgs??
                                  (-> js/window .-location .reload)))}
          "Log Out"]]
        ;; [:label {:style {:margin-right "1rem" :cursor "pointer"}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -563,7 +563,6 @@
    :psps-zonal   {:opt-label       "PSPS"
                   :geoserver-key   :psps
                   :underlays       (merge common-underlays near-term-forecast-underlays)
-                  :allowed-orgs    #{"nve" "liberty"}
                   :reverse-legend? true
                   :time-slider?    true
                   :auto-zoom?      true

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -90,7 +90,11 @@ Each entry in the legend contains the legend's label, value, color, and opacity.
 (defonce ^{:doc "For the currently logged in user, stores a list of all of the organizations
 that they belong to as an Admin or a Member. Will be bound to an empty vector if
 the user is not an Admin or Member of at least one organization."}
-  user-org-list (r/atom []))
+  user-orgs-list (r/atom []))
+(defonce ^{:doc "Stores a list of all organizations that have PSPS data."}
+  psps-orgs-list (r/atom []))
+(defonce ^{:doc "Stores a list of all PSPS organizations that a user belongs to."}
+  user-psps-orgs-list (r/atom []))
 (defonce ^{:doc "A boolean that enables time-step animation for the Time Slider when true."}
   animate? (r/atom false))
 (defonce ^{:doc "A boolean that maintains the hide/show toggle state of the loading modal dialog."}

--- a/src/sql/changes/2023-12-15_geoserver-logins.sql
+++ b/src/sql/changes/2023-12-15_geoserver-logins.sql
@@ -1,2 +1,0 @@
-ALTER TABLE organizations
-ADD geoserver_credentials varchar(72);

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -214,6 +214,16 @@ CREATE OR REPLACE FUNCTION get_organizations(_user_id integer)
 
 $$ LANGUAGE SQL;
 
+-- Returns all organizations that have PSPS data (denoted by presence of geoserver_credentials)
+CREATE OR REPLACE FUNCTION get_psps_organizations()
+RETURNS TABLE (org_unique_id text) AS $$
+
+    SELECT org_unique_id
+    FROM organizations
+    WHERE geoserver_credentials IS NOT NULL;
+
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION update_org_info(
     _org_id           integer,
     _org_name         text,

--- a/src/sql/tables/user_tables.sql
+++ b/src/sql/tables/user_tables.sql
@@ -25,7 +25,7 @@ CREATE TABLE organizations (
     organization_uid      SERIAL PRIMARY KEY,
     org_name              text NOT NULL,
     org_unique_id         text NOT NULL UNIQUE,
-    geoserver_credentials varchar(72),
+    geoserver_credentials text,
     email_domains         text,
     auto_add              boolean,
     auto_accept           boolean,


### PR DESCRIPTION
## Purpose
Uses basic auth to call `set-capabilities!` for PSPS orgs. Dynamically sets the `allowed-orgs` for the PSPS tab based on the PSPS orgs in the database. Adds scaffolding such that a list of the currently signed in user's PSPS is easily accessible (including the relevant GeoServer credentials).

## Related Issues
Closes PYR1-962 HER-66

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)