### PR TITLE
HER-63 Add a utility company dropdown to the PSPS tab

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -70,14 +70,6 @@
                          (str "The user with an id of " user-id " does not have Match Drop access."))]
       (data-response response-msg {:status 403}))))
 
-(defn get-user-psps-org [user-id]
-  (if-let [psps-org (sql-primitive (call-sql "get_user_psps_org" user-id))]
-    (data-response psps-org)
-    (let [response-msg (if (nil? user-id)
-                         "There is no user logged in. The PSPS tab will remain disabled."
-                         (str "The user with an id of " user-id " does not have PSPS access."))]
-      (data-response response-msg {:status 403}))))
-
 (defn update-user-name [email new-name]
   (if-let [user-id (sql-primitive (call-sql "get_user_id_by_email" email))]
     (do (call-sql "update_user_name" user-id new-name)

--- a/src/clj/pyregence/remote_api.clj
+++ b/src/clj/pyregence/remote_api.clj
@@ -13,7 +13,6 @@
                                               get-psps-organizations
                                               get-user-info
                                               get-user-match-drop-access
-                                              get-user-psps-org
                                               log-in
                                               log-out
                                               remove-org-user
@@ -65,7 +64,6 @@
                "get-user-info"                 get-user-info
                "get-user-layers"               get-user-layers
                "get-user-match-drop-access"    get-user-match-drop-access
-               "get-user-psps-org"             get-user-psps-org
                "get-red-flag-layer"            get-red-flag-layer
                "initiate-md"                   initiate-md!
                "log-in"                        log-in

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -561,6 +561,7 @@
                                                                      #{:active-fires}))
                                                  :options    {:loading {:opt-label "Loading..."}}}}}
    :psps-zonal   {:opt-label       "PSPS"
+                  :filter          "psps-zonal"
                   :geoserver-key   :psps
                   :underlays       (merge common-underlays near-term-forecast-underlays)
                   :reverse-legend? true
@@ -668,25 +669,21 @@
                                                                "https://doi.org/10.1016/j.firesaf.2013.08.014"]
                                                               ")."]
                                                  :options    {:r  {:opt-label    "HRRR"
-                                                                   :filter       "psps-zonal"
                                                                    :disabled-for #{:area :str :vol :pligr}}
                                                               :n1 {:opt-label    "NAM 3 km"
-                                                                   :filter       "psps-zonal"
                                                                    :disabled-for #{:area :str :vol :pligr}}
                                                               :n2 {:opt-label    "NAM 12 km"
-                                                                   :filter       "psps-zonal"
                                                                    :disabled-for #{:area :str :vol :pligr}}
                                                               :g1 {:opt-label    "GFS 0.125\u00B0"
-                                                                   :filter       "psps-zonal"
                                                                    :disabled-for #{:area :str :vol :pligr}}
                                                               :g2 {:opt-label    "GFS 0.250\u00B0"
-                                                                   :filter       "psps-zonal"
                                                                    :disabled-for #{:area :str :vol :pligr}}
                                                               :b  {:opt-label    "NBM"
-                                                                   :filter       "psps-zonal"
                                                                    :disabled-for #{:area :str :vol :pligr}}
-                                                              :m  {:opt-label "ELMFIRE"
-                                                                   :filter    "psps-zonal"}}}
+                                                              :m  {:opt-label "ELMFIRE"}}}
+                                    :utility    {:opt-label  "Utility Company"
+                                                 :hover-text "The utility company associated with the displayed zonal statistics."
+                                                 :options    {:loading {:opt-label "Loading..."}}}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}})

--- a/src/sql/changes/2023-12-21_remove-psps-org-column.sql
+++ b/src/sql/changes/2023-12-21_remove-psps-org-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN psps_org;

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -172,15 +172,6 @@ CREATE OR REPLACE FUNCTION get_user_match_drop_access(_user_id integer)
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION get_user_psps_org(_user_id integer)
- RETURNS text AS $$
-
-    SELECT psps_org
-    FROM users
-    WHERE user_uid = _user_id
-
-$$ LANGUAGE SQL;
-
 ---
 ---  Organizations
 ---

--- a/src/sql/tables/user_tables.sql
+++ b/src/sql/tables/user_tables.sql
@@ -16,8 +16,7 @@ CREATE TABLE users (
     super_admin       boolean DEFAULT FALSE,
     verified          boolean DEFAULT FALSE,
     reset_key         text DEFAULT NULL,
-    match_drop_access boolean DEFAULT FALSE,
-    psps_org          text default NULL
+    match_drop_access boolean DEFAULT FALSE
 );
 
 -- Stores information about organizations


### PR DESCRIPTION
## Purpose
Gets rid of the `psps_org` column in the `users` table in place of adding a utility company dropdown on the PSPS tab that's dynamically created based on the PSPS organization that a user is a part of.

## Related Issues
Closes HER-63

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)
