### PR TITLE
HER-68 Adding basic auth to `GetLegendGraphic`, `GetFeatureInfo`, and `GetTile` WMS requests

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -860,7 +860,7 @@
 (defn init-map!
   "Initializes the Mapbox map inside of `container` (e.g. \"map\").
    Specifies the proper project layers based on the forecast type."
-  [container-id layers & [opts]]
+  [container-id layers get-current-layer-geoserver-credentials & [opts]]
   (set! (.-accessToken mapbox) @!/mapbox-access-token)
   (when-not (.supported mapbox)
     (js/alert (str "Your browser does not support Pyregence Forecast.\n"
@@ -869,13 +869,19 @@
   (reset! the-map
           (Map.
            (clj->js (merge {:container   container-id
-                            :dragRotate  false
-                            :maxZoom     20
-                            :minZoom     3
-                            :style       (-> (c/base-map-options) c/base-map-default :source)
-                            :touchPitch  false
-                            :trackResize true
-                            :transition  {:duration 500 :delay 0}}
+                            :dragRotate       false
+                            :maxZoom          20
+                            :minZoom          3
+                            :style            (-> (c/base-map-options) c/base-map-default :source)
+                            :touchPitch       false
+                            :trackResize      true
+                            ;; For PSPS layers, we need to add basic auth to the GetTile requests
+                            :transformRequest (fn [url resource-type]
+                                                (when (and (str/starts-with? url (:psps @!/geoserver-urls))
+                                                           (= resource-type "Tile"))
+                                                  #js {:url     url
+                                                       :headers #js {:authorization (str "Basic " (js/window.btoa (get-current-layer-geoserver-credentials)))}}))
+                            :transition       {:duration 500 :delay 0}}
                            (when-not (:zoom opts)
                              {:bounds c/california-extent})
                            opts)))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -589,7 +589,10 @@
       (reset! !/*forecast (or (keyword forecast)
                               (keyword (forecast-type @!/default-forecasts))))
       (reset! !/*layer-idx (if layer-idx (js/parseInt layer-idx) 0))
-      (mb/init-map! "map" layers (if (every? nil? [lng lat zoom]) {} {:center [lng lat] :zoom zoom}))
+      (mb/init-map! "map"
+                    layers
+                    get-current-layer-geoserver-credentials
+                    (if (every? nil? [lng lat zoom]) {} {:center [lng lat] :zoom zoom}))
       (process-capabilities! (edn/read-string (:body (<! fire-names-chan)))
                              (edn/read-string (:body (<! user-layers-chan)))
                              options-config

--- a/src/sql/changes/2023-12-21_remove-psps-org-column.sql
+++ b/src/sql/changes/2023-12-21_remove-psps-org-column.sql
@@ -1,1 +1,0 @@
-ALTER TABLE users DROP COLUMN psps_org;


### PR DESCRIPTION
## Purpose
Adds basic auth to the `GetLegendGraphic`, `GetFeatureInfo`, and `GetTile` WMS requests for all PSPS (private) layers. Based on the currently selected layer, Pyrecast will now figure out which GeoServer basic auth credentials to use (if applicable). The GeoServer credentials are stored in the Pyrecast DB and are tied to a specific organization that the user is a part of.

## Related Issues
Closes HER-68

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Layers >  Private PSPS layers

#### Role
User

#### Desired Outcome
All private layers, point info, and legends should now load (once logged into an account that has access to them) without needing to be connected to the VPN.

