### PR TITLE
HER-83 Fix a few bugs related to the PSPS underlays

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -134,13 +134,13 @@
 (defn- split-psps-underlays
   "Gets information about a PSPS static layer based on its name (e.g. `psps-static_nve:nve-trans`)."
   [name-string]
-  (let [[workspace layer] (str/split name-string #":")
-        [forecast _]      (str/split workspace #"_")]
+  (let [[workspace layer]  (str/split name-string #":")
+        [forecast utility] (str/split workspace #"_")]
     {:workspace   workspace
      :layer-group ""
      :forecast    forecast
      :type        layer
-     :filter-set  #{forecast layer}
+     :filter-set  #{forecast layer utility}
      :model-init  ""
      :hour        0}))
 

--- a/src/cljs/pyregence/components/map_controls/match_drop_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/match_drop_tool.cljs
@@ -36,7 +36,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def match-drop-instructions
-  "Simulates a 24 hour fire using real-time weather data from the Hybrid model,
+  "Simulates a 72 hour fire using real-time weather data from the Hybrid model,
    which is a blend of the HRRR, NAM 3 km, and GFS 0.125\u00B0 models.
    Click on any CONUS location to \"drop\" a match, then set the date and time to begin
    the simulation. Chrome is currently the only supported browser for Match Drop.")

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -17,6 +17,12 @@ field associated with each layer from the `param-layers`, starts at 0, and is an
 (defonce ^{:doc "A map containing the selected parameters/inputs from each forecast tab.
 Ex: {:fuels {:layer :fbfm40, :model :landfire-2.2.0, :model-init :20210407_000000} ... }"}
   *params (r/atom {}))
+(defonce ^{:doc "A map containing the selected optional layers.
+Ex: {:us-trans-lines {:opt-label \"Transmission lines\", :z-index 107, ...},
+     :conus-buildings {:opt-label \"Structures\", :z-index 104, ...}}"}
+  *optional-layers (r/atom {}))
+(defonce ^{:doc "The most recently enabled optional layer."}
+  most-recent-optional-layer (r/atom {}))
 (defonce ^{:doc "A UTC keyword value, corresponding to the last selected \"Forecast Start Time\""}
   *last-start-time (r/atom nil))
 (defonce ^{:doc "An integer value, from 0 to 100, that designates the opacity for the active layer. Defaults to 100"}

--- a/src/sql/changes/2023-12-29_update-psps-underlays.sql
+++ b/src/sql/changes/2023-12-29_update-psps-underlays.sql
@@ -1,0 +1,99 @@
+--- NVE Transmission Lines
+UPDATE organization_layers
+SET layer_config = '{:opt-label "Transmission Lines (NVE)", :z-index 106, :filter-set #{"nve" "nve-trans" "psps-static"}, :geoserver-key :psps}'
+WHERE org_layer_uid IN (4, 6, 8, 10, 12);
+
+UPDATE organization_layers
+SET layer_path = '[:fuels :underlays :nve-trans]'
+WHERE org_layer_uid = 4;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-weather :underlays :nve-trans]'
+WHERE org_layer_uid = 6;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-risk :underlays :nve-trans]'
+WHERE org_layer_uid = 8;
+
+UPDATE organization_layers
+SET layer_path = '[:active-fire :underlays :nve-trans]'
+WHERE org_layer_uid = 10;
+
+UPDATE organization_layers
+SET layer_path = '[:psps-zonal :underlays :nve-trans]'
+WHERE org_layer_uid = 12;
+
+--- NVE Distribution Lines
+UPDATE organization_layers
+SET layer_config = '{:opt-label "Distribution Lines (NVE)", :z-index 105, :filter-set #{"nve" "nve-dist" "psps-static"}, :geoserver-key :psps}'
+WHERE org_layer_uid IN (5, 7, 9, 11, 13);
+
+UPDATE organization_layers
+SET layer_path = '[:fuels :underlays :nve-dist]'
+WHERE org_layer_uid = 5;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-weather :underlays :nve-dist]'
+WHERE org_layer_uid = 7;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-risk :underlays :nve-dist]'
+WHERE org_layer_uid = 9;
+
+UPDATE organization_layers
+SET layer_path = '[:active-fire :underlays :nve-dist]'
+WHERE org_layer_uid = 11;
+
+UPDATE organization_layers
+SET layer_path = '[:psps-zonal :underlays :nve-dist]'
+WHERE org_layer_uid = 13;
+
+--- Liberty Transmission Lines
+UPDATE organization_layers
+SET layer_config = '{:opt-label "Transmission Lines (Liberty)", :z-index 106, :filter-set #{"liberty" "liberty-trans" "psps-static"}, :geoserver-key :psps}'
+WHERE org_layer_uid IN (14, 16, 18, 20, 22);
+
+UPDATE organization_layers
+SET layer_path = '[:fuels :underlays :liberty-trans]'
+WHERE org_layer_uid = 14;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-weather :underlays :liberty-trans]'
+WHERE org_layer_uid = 16;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-risk :underlays :liberty-trans]'
+WHERE org_layer_uid = 18;
+
+UPDATE organization_layers
+SET layer_path = '[:active-fire :underlays :liberty-trans]'
+WHERE org_layer_uid = 20;
+
+UPDATE organization_layers
+SET layer_path = '[:psps-zonal :underlays :liberty-trans]'
+WHERE org_layer_uid = 22;
+
+--- Liberty Distribution Lines
+UPDATE organization_layers
+SET layer_config = '{:opt-label "Distribution Lines (Liberty)", :z-index 105, :filter-set #{"liberty" "liberty-dist" "psps-static"}, :geoserver-key :psps}'
+WHERE org_layer_uid IN (15, 17, 19, 21, 23);
+
+UPDATE organization_layers
+SET layer_path = '[:fuels :underlays :liberty-dist]'
+WHERE org_layer_uid = 15;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-weather :underlays :liberty-dist]'
+WHERE org_layer_uid = 17;
+
+UPDATE organization_layers
+SET layer_path = '[:fire-risk :underlays :liberty-dist]'
+WHERE org_layer_uid = 19;
+
+UPDATE organization_layers
+SET layer_path = '[:active-fire :underlays :liberty-dist]'
+WHERE org_layer_uid = 21;
+
+UPDATE organization_layers
+SET layer_path = '[:psps-zonal :underlays :liberty-dist]'
+WHERE org_layer_uid = 23;


### PR DESCRIPTION
## Purpose
Fixed a bug where utility company underlays don't load unless you have a layer selected that is associated with that utility company. In order to do so, this PR adds state that tracks the most recently selected optional layer, adds a changefile that updates the optional layers' `:filter-sets`, and updates `capabilities.clj` to mimic this update, 

This PR also cleans up the logic relating to the `get-current-layer-geoserver-credentials` function to make it more legible and fixes a typo on the Match Drop tool.

## Related Issues
Closes HER-83

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
PSPS -> Underlays

#### Role
User

#### Steps
Toggle on and off the PSPS underlays from various tabs.

#### Desired Outcome
The underlays (and other layers) should all load normally.
