### PR TITLE
HER-443 Fix some edge cases with Pyrecast deployments

### DIFF
--- a/src/clj/pyregence/jobs.clj
+++ b/src/clj/pyregence/jobs.clj
@@ -11,10 +11,12 @@
 ;; Set Capabilities
 
 (defn start-set-all-capabilities-job! []
-  (log-str "Calling pyregence.capabilities/set-all-capabilities!")
-  (set-all-capabilities!))
+  (future
+    (log-str "Calling pyregence.capabilities/set-all-capabilities!")
+    (set-all-capabilities!)))
 
-(def stop-set-all-capabilities-job! (constantly nil))
+(defn stop-set-all-capabilities-job! [fut]
+  (future-cancel fut))
 
 ;; Clean up service
 


### PR DESCRIPTION
## Purpose
Adds a timeout clause to `GetCapabilities` calls and allows for the web server to be started without waiting on `set-all-capabilities!` to finish.

## Related Issues
Closes HER-443
