### PR TITLE
PYR1-988 Fix various private layer edge cases

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,31 @@
+{:tasks
+ {-project  "cljweb-pyregence"
+  reload    (shell "systemctl --user daemon-reload")
+  status    {:depends [-project]
+             :task (shell (format "systemctl --user status %s" -project))}
+  start     {:depends [-project]
+             :task (shell (format "systemctl --user start %s" -project))}
+  stop      {:depends [-project]
+             :task (shell (format "systemctl --user stop %s" -project))}
+  restart   (do
+              (run 'stop)
+              (run 'start))
+  build-js  (clojure "-M:compile-cljs")
+  pull      (shell "git pull")
+  migrate   (clojure "-M:build-db migrate")
+  functions (clojure "-M:build-db functions")
+  prod         (do
+                 (run 'functions)
+                 (run 'clean)
+                 (run 'compile)
+                 (run 'server-start))
+  dev          (do
+                 (run 'functions)
+                 (shell "clojure -M:default-ssl-opts:figwheel"))
+  deploy    (do
+              (run 'stop)
+              (run 'pull)
+              (run 'build-js)
+              #_(run 'migrate)
+              (run 'functions)
+              (run 'start))}}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -323,9 +323,7 @@
                                                     (and (seq @!/most-recent-optional-layer) ; We're dealing with an optional layer that's associated with a utility company
                                                          ((:filter-set @!/most-recent-optional-layer) (:org-unique-id %))))
                                                @!/user-psps-orgs-list)))]
-        (if (some? matching-psps-org)
-          (:geoserver-credentials matching-psps-org)
-          nil)))))
+        (:geoserver-credentials matching-psps-org)))))
 
 ;; Use <! for synchronous behavior or leave it off for asynchronous behavior.
 (defn- get-legend!


### PR DESCRIPTION
## Purpose
Fixes the following two edge cases with private layers on Pyrecast:

### Bug 1
1. Log in to Pyrecast as an account with PSPS access
2. Go to the weather tab
3. Turn on a utility company specific transmission lines
4. Try to use the point info tool on the weather tab
5. You get a "no point info available" error from the front-end
6. An example request here would be: `https://shasta.pyregence.org/geoserver/wms?SERVICE=WMS&EXCEPTIONS=application/json&VERSION=1.3.0&REQUEST=GetFeatureInfo&INFO_FORMAT=application/json&LAYERS=fire-weather-forecast_hybrid_20240904_12:tmpf&QUERY_LAYERS=fire-weather-forecast_hybrid_20240904_12:tmpf&FEATURE_COUNT=50000&TILED=true&I=0&J=0&WIDTH=1&HEIGHT=1&CRS=EPSG:3857&STYLES=&BBOX=-12913575.405096125,4226460.030664251,-12908599.603543425,4231435.832216952`
Note that when I looked into the response headers here, basic auth was included, which it definitely shouldn't be. Basic auth is only needed and should only be used for PSPS layers

### Bug 2
1. Log in to Pyrecast as an account with PSPS access.
2. Go to the active fires or fuel tab.
3. Turn on a utility company specific transmission lines.
4. The transmission line layer won't show up and CORS errors are thrown in the console.

## Related Issues
Closes PYR1-988

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
The above two bugs should not pop up anymore.

## Screenshots
![Screenshot from 2024-09-09 18-52-53](https://github.com/user-attachments/assets/8de6e87b-b72c-40c8-bddb-29c3533f6d42)

