### PR TITLE
Add missing PostgreSQL  values for the column org_unique_id in the table organizations to fix the development setup. 

### DIFF
--- a/src/sql/dev_data/dev_data.sql
+++ b/src/sql/dev_data/dev_data.sql
@@ -2,13 +2,13 @@
 
 -- Adds an organization called "Development"
 INSERT INTO organizations
-    (organization_uid, org_name, email_domains, auto_add, auto_accept)
+    (organization_uid, org_unique_id, org_name, email_domains, auto_add, auto_accept)
 VALUES
-    (1, 'Development', '@pyr.dev', TRUE, TRUE),
-    (2, 'Delete Me Inc.', '@deleteme.com,@remove.com', TRUE, FALSE),
-    (3, 'Update My Setttings and Company', '@updateme.com', FALSE, TRUE),
-    (4, 'Acme Labs', '@acme.com,@acmelabs.org', TRUE, TRUE),
-    (5, 'Skunk Works', '@topsecret.net,@seentoomuch.us,@zzyzx.gov,', FALSE, FALSE);
+    (1, 'development', 'Development', '@pyr.dev', TRUE, TRUE),
+    (2, 'delete-me', 'Delete Me Inc.', '@deleteme.com,@remove.com', TRUE, FALSE),
+    (3, 'update-me', 'Update My Setttings and Company', '@updateme.com', FALSE, TRUE),
+    (4, 'acme-labs', 'Acme Labs', '@acme.com,@acmelabs.org', TRUE, TRUE),
+    (5, 'skunk-works', 'Skunk Works', '@topsecret.net,@seentoomuch.us,@zzyzx.gov,', FALSE, FALSE);
 -- Adds an admin and a user
 INSERT INTO users
     (user_uid, email, name, password, verified, settings)


### PR DESCRIPTION
This is necessary because the org_unique_id column is marked with the sql constraint 'NOT NULL', so without these column values, the SQL inserts will fail.

To reproduce this failure, check out git commit 3bf1b49 and, from the command line, run the dev setup command:  `clojure -M:build-db build-all --dev-data`. This will result in the following psql error: 

```
psql:src/sql/dev_data/dev_data.sql:11: ERROR:  null value in column "org_unique_id" of relation "organizations" violates not-null constraint
DETAIL:  Failing row contains (1, Development, null, null, @pyr.dev, t, t, f, 2024-12-04, null).
```
If you checkout the git commit with the fix (this branch), and re-run the dev setup command above, you will notice this error goes away. This is the desired behavior because we want that column, as explained by Oliver in the git issue #887. So we can rule out other possibilities, at the moment, like removing the column.

However, if someone understands the history here a bit better, there might be some insight here that would lead to a different solution. 

Finally, the values chosen (e.g., development, delete-me) were chosen based on my conversation with Oliver in the GitHub issue #877, I have relatively low confidence they are ideal. 