### PR TITLE
PYR1-970 add miles and kilometers to measure distance tool modal

### DIFF
--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -58,9 +58,6 @@
                               :justify-content "center"
                               :margin          ".4rem"
                               :font-size       "1.2rem"}}
-             ;; Below we convert distance-between-points, which is in meters,
-             ;; to both miles and kilometers which is ideal for larger distances
-             ;; and for the majority of our U.S based users.
              (let [[mi km] (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
                                   [@distance-between-points "kilometers" #(/ % 1000)]]
                                  (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l))))]

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -59,8 +59,8 @@
                               :font-size       "1.2rem"}}
              (let [format (fn [number label] (str (cl-format nil "~,1f" number) " " label))
                    meters  @distance-between-points
-                   miles (* 0.00062137 meters)
-                   kilometers (/ meters 1000)
+                   miles (* meters 0.00062137)
+                   kilometers (* meters 0.001)
                    mi (format miles "miles")
                    km (format kilometers "kilometers")]
                (str mi " (" km ")" ))])

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -60,7 +60,8 @@
                               :font-size       "1.2rem"
                               :justify-content "center"
                               :margin          ".4rem"}}
-             (str (meters->miles @distance-between-points) " (" (meters->kilometers @distance-between-points) ")")])
+             (str (meters->miles @distance-between-points)
+                  " (" (meters->kilometers @distance-between-points) ")")])
           [:div {:style {:display        "flex"
                          :flex-direction "column"
                          :margin-top     ".2rem"}}

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -58,6 +58,9 @@
                               :justify-content "center"
                               :margin          ".4rem"
                               :font-size       "1.2rem"}}
+             ;; Below we convert distance-between-points, which is in meters,
+             ;; to both miles and kilometers which is ideal for larger distances
+             ;; and for the majority of our U.S based users.
              (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
                     [@distance-between-points "kilometers" #(/ % 1000)]]
                    (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -63,7 +63,7 @@
                    kilometers (* meters 0.001)
                    mi (format miles "miles")
                    km (format kilometers "kilometers")]
-               (str mi " (" km ")" ))])
+               (str mi " (" km ")"))])
           [:div {:style {:display        "flex"
                          :flex-direction "column"
                          :margin-top     ".2rem"}}

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -53,14 +53,18 @@
            [:p "Note: There is a +/- 0.5% Great-Circle calculation error."]]
           [lon-lat-position "Point One Location" (if @point-one @point-one [0 0])]
           [lon-lat-position "Point Two Location" (if @point-two @point-two [0 0])]
+          (when (> @distance-between-points 0)
+            [:strong {:style {:display         "flex"
+                              :justify-content "center"
+                              :margin          ".4rem"
+                              :font-size       "1.2rem"}}
+             (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
+                    [@distance-between-points "kilometers" #(/ % 1000)]]
+                   (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))
+                   (str/join " / "))])
           [:div {:style {:display         "flex"
                          :flex-direction  "column"
                          :margin-top      ".2rem"}}
-           (when (> @distance-between-points 0)
-             [:p (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
-                        [@distance-between-points "kilometers" #(/ % 1000)]]
-                       (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))
-                       (str/join " / "))])
            [:button {:class    (<class $/p-themed-button)
                      :style    {:margin-bottom "1rem"}
                      :disabled (or (not @point-one)

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -1,6 +1,5 @@
 (ns pyregence.components.map-controls.measure-tool
   (:require [clojure.pprint                        :refer [cl-format]]
-            [clojure.string                        :as str]
             [herb.core                             :refer [<class]]
             [pyregence.components.mapbox           :as mb]
             [pyregence.components.resizable-window :refer [resizable-window]]

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -54,9 +54,9 @@
           [lon-lat-position "Point Two Location" (if @point-two @point-two [0 0])]
           (when (> @distance-between-points 0)
             [:strong {:style {:display         "flex"
+                              :font-size       "1.2rem"
                               :justify-content "center"
-                              :margin          ".4rem"
-                              :font-size       "1.2rem"}}
+                              :margin          ".4rem"}}
              (let [format (fn [number label] (str (cl-format nil "~,1f" number) " " label))
                    meters  @distance-between-points
                    miles (* meters 0.00062137)

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -3,7 +3,6 @@
             [herb.core                             :refer [<class]]
             [pyregence.components.mapbox           :as mb]
             [pyregence.components.resizable-window :refer [resizable-window]]
-            [pyregence.components.common           :refer [radio]]
             [pyregence.geo-utils                   :as geo]
             [pyregence.styles                      :as $]
             [reagent.core                          :as r]))
@@ -33,7 +32,6 @@
   (r/with-let [distance-between-points (r/atom 0)
                point-one               (r/atom nil)
                point-two               (r/atom nil)
-               miles                   (r/atom true)
                click-event             (mb/enqueue-marker-on-click!
                                         #(do (reset! point-one (first %))
                                              (reset! point-two (second %)))
@@ -59,38 +57,13 @@
                          :margin-top      ".2rem"}}
            (when (> @distance-between-points 0)
              [:label {:style ($/padding "1px" :1)}
-
-               ;; -- show both option
               (let [format #(str (cl-format nil "~,1f" %1) " " %2)
                     m->mi #(* 0.00062137 %)
                     m->km #(/ % 1000)
                     meters @distance-between-points]
                 [:p
                  [:span (str (format (m->mi meters) "miles"))]
-                 [:span (str " / " (format  (m->km meters) "kilometers"))]])
-               ;; -- Radio button option
-               ;; this is what was orginal discussed.
-               ;;TODO css classes md-lonlat and md-lon are from the long-lat functionality and
-               ;; though they stylistically in lining things up, the names are confusing here. so
-               ;; consider changing something.
-              #_[:div#md-lonlat {:style {:display "flex"
-                                         :column-gap "10px"}}
-                 [:div#md-lon {:style {:display "flex"
-                                       :align-items "center"}}
-                  (let [format-distance (fn [label distance]
-                                          (str label ": "
-                                               (cl-format nil
-                                                          "~,1f"
-                                                          distance)))]
-                    (if @miles
-                      (format-distance "Miles" (* 0.00062137 @distance-between-points))
-                      (format-distance "Kilometers" (/ @distance-between-points 1000))))]
-                 [:div {:style {:display "flex"
-                                :flex-direction "column"}}
-                  [:<>
-                   [radio "mi" @miles true #(reset! miles true)]
-                   [radio "km" @miles false #(reset! miles false)]]]]])
-
+                 [:span (str " / " (format  (m->km meters) "kilometers"))]])])
            [:button {:class    (<class $/p-themed-button)
                      :style    {:margin-bottom "1rem"}
                      :disabled (or (not @point-one)

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -35,7 +35,10 @@
                click-event             (mb/enqueue-marker-on-click!
                                         #(do (reset! point-one (first %))
                                              (reset! point-two (second %)))
-                                        {:queue-type :lifo :queue-size 2})]
+                                        {:queue-type :lifo :queue-size 2})
+               format                  (fn [number label] (str (cl-format nil "~,1f" number) " " label))
+               meters->miles           #(-> % (* 0.00062137) (format "miles"))
+               meters->kilometers      #(-> % (* 0.001) (format "kilometers"))]
     [:div#measure-tool
      [resizable-window
       parent-box
@@ -57,13 +60,7 @@
                               :font-size       "1.2rem"
                               :justify-content "center"
                               :margin          ".4rem"}}
-             (let [format     (fn [number label] (str (cl-format nil "~,1f" number) " " label))
-                   meters     @distance-between-points
-                   miles      (* meters 0.00062137)
-                   kilometers (* meters 0.001)
-                   mi         (format miles "miles")
-                   km         (format kilometers "kilometers")]
-               (str mi " (" km ")"))])
+             (str (meters->miles @distance-between-points) " (" (meters->kilometers @distance-between-points) ")")])
           [:div {:style {:display        "flex"
                          :flex-direction "column"
                          :margin-top     ".2rem"}}

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -1,5 +1,6 @@
 (ns pyregence.components.map-controls.measure-tool
   (:require [clojure.pprint                        :refer [cl-format]]
+            [clojure.string                        :as str]
             [herb.core                             :refer [<class]]
             [pyregence.components.mapbox           :as mb]
             [pyregence.components.resizable-window :refer [resizable-window]]
@@ -57,13 +58,11 @@
                          :margin-top      ".2rem"}}
            (when (> @distance-between-points 0)
              [:label {:style ($/padding "1px" :1)}
-              (let [format #(str (cl-format nil "~,1f" %1) " " %2)
-                    m->mi #(* 0.00062137 %)
-                    m->km #(/ % 1000)
-                    meters @distance-between-points]
-                [:p
-                 [:span (str (format (m->mi meters) "miles"))]
-                 [:span (str " / " (format  (m->km meters) "kilometers"))]])])
+              [:p
+               (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
+                      [@distance-between-points "kilometers" #(/ % 1000)]]
+                     (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))
+                     (str/join " / "))]])
            [:button {:class    (<class $/p-themed-button)
                      :style    {:margin-bottom "1rem"}
                      :disabled (or (not @point-one)

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -57,12 +57,12 @@
                               :font-size       "1.2rem"
                               :justify-content "center"
                               :margin          ".4rem"}}
-             (let [format (fn [number label] (str (cl-format nil "~,1f" number) " " label))
-                   meters  @distance-between-points
-                   miles (* meters 0.00062137)
+             (let [format     (fn [number label] (str (cl-format nil "~,1f" number) " " label))
+                   meters     @distance-between-points
+                   miles      (* meters 0.00062137)
                    kilometers (* meters 0.001)
-                   mi (format miles "miles")
-                   km (format kilometers "kilometers")]
+                   mi         (format miles "miles")
+                   km         (format kilometers "kilometers")]
                (str mi " (" km ")"))])
           [:div {:style {:display        "flex"
                          :flex-direction "column"

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -58,9 +58,12 @@
                               :justify-content "center"
                               :margin          ".4rem"
                               :font-size       "1.2rem"}}
-             (let [[mi km] (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
-                                  [@distance-between-points "kilometers" #(/ % 1000)]]
-                                 (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l))))]
+             (let [format (fn [number label] (str (cl-format nil "~,1f" number) " " label))
+                   meters  @distance-between-points
+                   miles (* 0.00062137 meters)
+                   kilometers (/ meters 1000)
+                   mi (format miles "miles")
+                   km (format kilometers "kilometers")]
                (str mi " (" km ")" ))])
           [:div {:style {:display        "flex"
                          :flex-direction "column"

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -57,12 +57,10 @@
                          :flex-direction  "column"
                          :margin-top      ".2rem"}}
            (when (> @distance-between-points 0)
-             [:label {:style ($/padding "1px" :1)}
-              [:p
-               (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
-                      [@distance-between-points "kilometers" #(/ % 1000)]]
-                     (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))
-                     (str/join " / "))]])
+             [:p (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
+                        [@distance-between-points "kilometers" #(/ % 1000)]]
+                       (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))
+                       (str/join " / "))])
            [:button {:class    (<class $/p-themed-button)
                      :style    {:margin-bottom "1rem"}
                      :disabled (or (not @point-one)

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -61,13 +61,13 @@
              ;; Below we convert distance-between-points, which is in meters,
              ;; to both miles and kilometers which is ideal for larger distances
              ;; and for the majority of our U.S based users.
-             (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
-                    [@distance-between-points "kilometers" #(/ % 1000)]]
-                   (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l)))
-                   (str/join " / "))])
-          [:div {:style {:display         "flex"
-                         :flex-direction  "column"
-                         :margin-top      ".2rem"}}
+             (let [[mi km] (->>  [[@distance-between-points "miles" #(* 0.00062137 %)]
+                                  [@distance-between-points "kilometers" #(/ % 1000)]]
+                                 (map (fn [[m l f]] (str (cl-format nil "~,1f" (f m)) " " l))))]
+               (str mi " (" km ")" ))])
+          [:div {:style {:display        "flex"
+                         :flex-direction "column"
+                         :margin-top     ".2rem"}}
            [:button {:class    (<class $/p-themed-button)
                      :style    {:margin-bottom "1rem"}
                      :disabled (or (not @point-one)

--- a/src/cljs/pyregence/components/map_controls/measure_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/measure_tool.cljs
@@ -3,6 +3,7 @@
             [herb.core                             :refer [<class]]
             [pyregence.components.mapbox           :as mb]
             [pyregence.components.resizable-window :refer [resizable-window]]
+            [pyregence.components.common           :refer [radio]]
             [pyregence.geo-utils                   :as geo]
             [pyregence.styles                      :as $]
             [reagent.core                          :as r]))
@@ -32,6 +33,7 @@
   (r/with-let [distance-between-points (r/atom 0)
                point-one               (r/atom nil)
                point-two               (r/atom nil)
+               miles                   (r/atom true)
                click-event             (mb/enqueue-marker-on-click!
                                         #(do (reset! point-one (first %))
                                              (reset! point-two (second %)))
@@ -56,9 +58,39 @@
                          :flex-direction  "column"
                          :margin-top      ".2rem"}}
            (when (> @distance-between-points 0)
-             [:div {:style {:height 30 :margin ".2rem"}}
-              [:label {:style ($/padding "1px" :1)}
-               (str (cl-format nil "~,4f" @distance-between-points) " meters")]])
+             [:label {:style ($/padding "1px" :1)}
+
+               ;; -- show both option
+              (let [format #(str (cl-format nil "~,1f" %1) " " %2)
+                    m->mi #(* 0.00062137 %)
+                    m->km #(/ % 1000)
+                    meters @distance-between-points]
+                [:p
+                 [:span (str (format (m->mi meters) "miles"))]
+                 [:span (str " / " (format  (m->km meters) "kilometers"))]])
+               ;; -- Radio button option
+               ;; this is what was orginal discussed.
+               ;;TODO css classes md-lonlat and md-lon are from the long-lat functionality and
+               ;; though they stylistically in lining things up, the names are confusing here. so
+               ;; consider changing something.
+              #_[:div#md-lonlat {:style {:display "flex"
+                                         :column-gap "10px"}}
+                 [:div#md-lon {:style {:display "flex"
+                                       :align-items "center"}}
+                  (let [format-distance (fn [label distance]
+                                          (str label ": "
+                                               (cl-format nil
+                                                          "~,1f"
+                                                          distance)))]
+                    (if @miles
+                      (format-distance "Miles" (* 0.00062137 @distance-between-points))
+                      (format-distance "Kilometers" (/ @distance-between-points 1000))))]
+                 [:div {:style {:display "flex"
+                                :flex-direction "column"}}
+                  [:<>
+                   [radio "mi" @miles true #(reset! miles true)]
+                   [radio "km" @miles false #(reset! miles false)]]]]])
+
            [:button {:class    (<class $/p-themed-button)
                      :style    {:margin-bottom "1rem"}
                      :disabled (or (not @point-one)


### PR DESCRIPTION
## Purpose
Given that most distances calculated are over a thousand meters, it's easier to read in kilometers than in meters. However, our users don't use meters regularly because they are from the U.S., so we should prefer showing the user's miles over kilometers. 


## Related Issues
Closes PYR1-970

## Submission Checklist

- [ i think so? Hard to say] Code passes linter rules (`clj-kondo --lint src`)
- [ runs just fine] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [not sure how to tell if there are new ones, i doubt it ] No new reflection warnings (`clojure -M:check-reflection`)
- [ no need] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
I'm not sure what module was impacted.

#### Role
I assume all roles can see this chnage

#### Steps
measure a distance using the sidebar tool 

#### Desired Outcome
The measured distance should be displayed in miles and kilometers now instead of meters.


## Screenshots

Before, when it was just meters

![image](https://github.com/user-attachments/assets/3a3f1549-ff4b-4e95-9be1-d028af5911ea)

After, it shows miles and kilometers.  (notice i also increased the font size to draw attention to the distance, we can kick this back if we want)
![image](https://github.com/user-attachments/assets/31f2af90-915a-415e-ac13-d1aa0fc99539)




