### PR TITLE
add selecting default Risk Ignition Pattern through option directly

### DIFF
--- a/src/cljs/pyregence/components/map_controls/panel_dropdown.cljs
+++ b/src/cljs/pyregence/components/map_controls/panel_dropdown.cljs
@@ -4,6 +4,20 @@
             [pyregence.styles               :as $]
             [pyregence.utils.dom-utils      :as u-dom]))
 
+(defn- options->selected-key
+  "given a map of selected-keys to hiccup option tags , return the selected-key
+  associated with the option tag that has the selected? key. This solves the
+  problem of selecting an option through the option (as opposed to the parent),
+  but then passing that information to the parent :select so it can use it in
+  the :select/value which react uses instead of an html option selected
+  attribute"
+  [options]
+  (reduce-kv
+   (fn [_ potential-key {:keys [selected?]}]
+     (when selected? (reduced potential-key)))
+   nil
+   options))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Root component
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -20,7 +34,7 @@
                                :fill   ($/color-picker :font-color)})}
       [svg/help]]]]
    [:select {:style     ($/dropdown)
-             :value     (or val :none)
+             :value     (or (options->selected-key options) val :none)
              :disabled  disabled?
              :on-change #(call-back (u-dom/input-keyword %))}
     (map (fn [[key {:keys [opt-label enabled? disabled-for]}]]


### PR DESCRIPTION
This change adds the ability to select a default Risk Ignition Pattern (e.g. UtilityCompany Energy Lines) by updating the database's Organization Layers table layer_config column to contained a string that's a valid end with a top-level key :selected? set to true. e.g

layer_config                                                                           |
---------------------------------------------------------------------------------------|
{:selected? true :opt-label "UtilityCompany", :filter "...", :geoserver-key "..."}|

This works because that selected key will be available in the panel_drowdown because it's assoced into state along the Organization Layer tabels layer_path. e.g

layer_path                                          |
----------------------------------------------------|
[:fire-risk :params :pattern :options :UtilityCompany]|

And this is available on a per company selection

|org_layer_uid|organization_rid|
|-------------|----------------|
|98           |20              |

Or put another way, this is what the insert SQL insert statement to add the necessary data in this example would look like (assuming a company existed called :UtilityCompany). (NOTE! this insert probably isn't quite right because we dont' want to add a row, we want to replace an existing one, but we don't seem to be going this direction anyway)

```
INSERT INTO public.organization_layers (organization_rid,layer_path,layer_config) VALUES
	 (<todo>,'[:fire-risk :params :pattern :options :utilitycompany]','{:opt-label <todo>, :filter <todo>, :geoserver-key <todo> :disabled-for <todo> :selected? true}');
```


The major downside here is it introduces yet another way to select the default, it takes precedence over the :default-option found in the config.cljs which is used as the "val" in the panel_dropdown.

Why not use the :default-option? Because that will require a change to how we collect the state of the layer_config. Will explore that option in this [commit](https://github.com/pyregence/pyregence/compare/main...pyr1-991-implement-using-default-option). 

I think the difference between these two should be minimal, but using the :default-option seems to require a larger change, which I think indicates a potential improvement to how we store and validate the organization_layers data, but I haven't seen enough examples to understand what a larger change might be so I'm going to lean towards suggesting the smaller of the two which is this PR implemented using the selected key. 

Notice that this PR isn't into the base git branch 'main' to help with some bookkeeping. 

Here are some before and after pictures. First the before, where we default is set just by the config.cljs:

![before](https://github.com/user-attachments/assets/b93e43f7-ce06-4303-b51c-aa60ec42df65)

and now after, assuming you apply this PR and the sql changes:

![After](https://github.com/user-attachments/assets/e7d147d5-df4d-4a8f-9bdd-5019bfb66452)


