### PR TITLE
PYR1-1016 logged in users map should stay where they are when switching between tabs

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -410,7 +410,6 @@
                                                                                 :units        "Ignitions/line-mi/hr"
                                                                                 :disabled-for #{:all :tlines}}}}
                                     :pattern    {:opt-label  "Ignition Pattern"
-                                                 :auto-zoom? true
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Fires are ignited randomly across California at various times in the future so their impacts can be modeled. Patterns include:"
                                                               [:br]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -421,9 +421,11 @@
                                                               [:strong "Transmission Lines"]
                                                               " - Fires ignited in close proximity to overhead electrical transmission lines."]
                                                  :options    {:all        {:opt-label    "All-cause fires"
+                                                                           :auto-zoom?   true
                                                                            :filter       "all"
                                                                            :disabled-for #{:plignrate}}
                                                               :tlines     {:opt-label    "Transmission lines"
+                                                                           :auto-zoom?   true
                                                                            :filter       "tlines"
                                                                            :clear-point? true
                                                                            :disabled-for #{:plignrate :crown-fire-area}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -570,7 +570,6 @@
                   :underlays       (merge common-underlays near-term-forecast-underlays)
                   :reverse-legend? true
                   :time-slider?    true
-                  :auto-zoom?      true
                   :hover-text      "Public Safety Power Shutoffs (PSPS) zonal statistics."
                   :params          {:quantity   {:opt-label  "Zonal Quantity"
                                                  :hover-text [:<>

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -575,8 +575,7 @@
                                   (assoc acc
                                          (keyword org-unique-id)
                                          {:opt-label  org-name
-                                          :filter     org-unique-id
-                                          :auto-zoom? true}))
+                                          :filter     org-unique-id}))
                                 {}
                                 user-psps-orgs-list))))
   (reset! !/*params (u-data/mapm


### PR DESCRIPTION
This change disables auto-zooming when on the Risk or PSPS tab. If a Utility Company wants to re-enable auto-zooming for a given Risk Ignition Pattern, we can do that by updating the database like so:

```
UPDATE public.organization_layers
  SET layer_config='{:auto-zoom? true <TODO rest of config ommited>}'
  WHERE org_layer_uid=<TODO>;
```

Note some` < values >` have been omitted. 