### PR TITLE
PYR1-975 add toast message when there are no active fires

### DIFF
--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -1,8 +1,5 @@
 (ns pyregence.components.forecast-tabs
-  (:require
-   [pyregence.components.common    :refer [tool-tip-wrapper]]
-   [pyregence.components.messaging :refer [toast-message!]]
-   [pyregence.state                :as !]))
+  (:require [pyregence.components.common :refer [tool-tip-wrapper]]))
 
 (defn- $forecast-label [selected?]
   (merge
@@ -25,14 +22,6 @@
               hover-text
               :top
               [:label {:style    ($forecast-label (= current-forecast key))
-                       :on-click
-                       (fn []
-                         (when (= key :active-fire)
-                           (when (and
-                                  (zero? @!/active-fire-count)
-                                  (zero? @!/active-fire-tab-click-count))
-                             (toast-message! "No active fires."))
-                           (swap! !/active-fire-tab-click-count inc))
-                         (select-forecast! key))}
+                       :on-click #(select-forecast! key)}
                opt-label]]))
          capabilities))])

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -1,5 +1,8 @@
 (ns pyregence.components.forecast-tabs
-  (:require [pyregence.components.common :refer [tool-tip-wrapper]]))
+  (:require
+   [pyregence.components.common    :refer [tool-tip-wrapper]]
+   [pyregence.components.messaging :refer [toast-message!]]
+   [pyregence.state                :as !]))
 
 (defn- $forecast-label [selected?]
   (merge
@@ -22,6 +25,17 @@
               hover-text
               :top
               [:label {:style    ($forecast-label (= current-forecast key))
-                       :on-click #(select-forecast! key)}
+                       :on-click
+                       (fn []
+                         (when (and
+                                (= key :active-fire)
+                                (zero? (->> @!/processed-params
+                                            :fire-name
+                                            :options
+                                            count
+                                            ;; dec to remove "active fires"
+                                            dec)))
+                           (toast-message! "No active fires"))
+                         (select-forecast! key))}
                opt-label]]))
          capabilities))])

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -27,14 +27,7 @@
               [:label {:style    ($forecast-label (= current-forecast key))
                        :on-click
                        (fn []
-                         (when (and
-                                (= key :active-fire)
-                                (zero? (->> @!/processed-params
-                                            :fire-name
-                                            :options
-                                            count
-                                            ;; dec to remove "active fires"
-                                            dec)))
+                         (when (and (= key :active-fire) @!/show-no-active-fires?)
                            (toast-message! "No active fires"))
                          (select-forecast! key))}
                opt-label]]))

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -28,7 +28,7 @@
                        :on-click
                        (fn []
                          (when (and (= key :active-fire) @!/show-no-active-fires?)
-                           (toast-message! "No active fires"))
+                           (toast-message! "No active fires."))
                          (select-forecast! key))}
                opt-label]]))
          capabilities))])

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -27,8 +27,12 @@
               [:label {:style    ($forecast-label (= current-forecast key))
                        :on-click
                        (fn []
-                         (when (and (= key :active-fire) @!/show-no-active-fires?)
-                           (toast-message! "No active fires."))
+                         (when (= key :active-fire)
+                           (when (and
+                                  (zero? @!/active-fire-count)
+                                  (zero? @!/active-fire-tab-click-count))
+                             (toast-message! "No active fires."))
+                           (swap! !/active-fire-tab-click-count inc))
                          (select-forecast! key))}
                opt-label]]))
          capabilities))])

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -184,8 +184,11 @@
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
       (when-not (seq @!/param-layers)
-        (toast-message! "There are no layers available for the selected parameters. Please try another combination.")))))
-
+        (toast-message! "There are no layers available for the selected parameters. Please try another combination."))
+      (when
+          (and (= :active-fire @!/*forecast)
+               (zero? @!/active-fire-count))
+          (toast-message! "No active fires.")))))
 (defn- create-share-link
   "Generates a link with forecast and parameters encoded in a URL"
   []

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -180,7 +180,7 @@
                                                (:body (<! (u-async/call-clj-async! "get-layers"
                                                                                    (get-any-level-key :geoserver-key)
                                                                                    (pr-str selected-set)))))
-          no-param-layers? (empty? (seq @!/param-layers))]
+          no-param-layers? (empty? @!/param-layers)]
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -179,16 +179,23 @@
           {:keys [layers model-times]} (t/read (t/reader :json)
                                                (:body (<! (u-async/call-clj-async! "get-layers"
                                                                                    (get-any-level-key :geoserver-key)
-                                                                                   (pr-str selected-set)))))]
+                                                                                   (pr-str selected-set)))))
+          no-param-layers? (empty? (seq @!/param-layers))]
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
       (when-not (seq @!/param-layers)
         (toast-message! "There are no layers available for the selected parameters. Please try another combination."))
-      (when
-          (and (= :active-fire @!/*forecast)
-               (zero? @!/active-fire-count))
-          (toast-message! "No active fires.")))))
+      (cond
+        (and
+          no-param-layers?
+          (= :active-fire @!/*forecast)
+          (zero? @!/active-fire-count))
+        (toast-message! "No active fires.")
+
+        no-param-layers?
+        (toast-message! "There are no layers available for the selected parameters. Please try another combination.")))))
+
 (defn- create-share-link
   "Generates a link with forecast and parameters encoded in a URL"
   []

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -179,20 +179,20 @@
           {:keys [layers model-times]} (t/read (t/reader :json)
                                                (:body (<! (u-async/call-clj-async! "get-layers"
                                                                                    (get-any-level-key :geoserver-key)
-                                                                                   (pr-str selected-set)))))
-          no-param-layers?             (empty? @!/param-layers)]
+                                                                                   (pr-str selected-set)))))]
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
-      (cond
-        (and
-          no-param-layers?
-          (= :active-fire @!/*forecast)
-          (zero? @!/active-fire-count))
-        (toast-message! "No active fires.")
+      (let [no-param-layers? (not (seq @!/param-layers))]
+        (cond
+          (and
+            no-param-layers?
+            (= :active-fire @!/*forecast)
+            (zero? @!/active-fire-count))
+          (toast-message! "There are currently no active fires in the system.")
 
-        no-param-layers?
-        (toast-message! "There are no layers available for the selected parameters. Please try another combination.")))))
+          no-param-layers?
+          (toast-message! "There are no layers available for the selected parameters. Please try another combination."))))))
 
 (defn- create-share-link
   "Generates a link with forecast and parameters encoded in a URL"

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -180,7 +180,7 @@
                                                (:body (<! (u-async/call-clj-async! "get-layers"
                                                                                    (get-any-level-key :geoserver-key)
                                                                                    (pr-str selected-set)))))
-          no-param-layers? (empty? @!/param-layers)]
+          no-param-layers?             (empty? @!/param-layers)]
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -603,7 +603,9 @@
           fire-names-chan                 (u-async/call-clj-async! "get-fire-names" user-id)
           fire-cameras-chan               (u-async/call-clj-async! "get-cameras")
           user-orgs-list-chan             (u-async/call-clj-async! "get-organizations" user-id)
-          psps-orgs-list-chan             (u-async/call-clj-async! "get-psps-organizations")]
+          psps-orgs-list-chan             (u-async/call-clj-async! "get-psps-organizations")
+          fire-names                      (edn/read-string (:body (<! fire-names-chan)))]
+      (reset! !/show-no-active-fires? (-> fire-names count zero?))
       (reset! !/user-orgs-list (edn/read-string (:body (<! user-orgs-list-chan))))
       (reset! !/psps-orgs-list (edn/read-string (:body (<! psps-orgs-list-chan))))
       (reset! !/user-psps-orgs-list (filter (fn [org] (some #(= (:org-unique-id org) %) @!/psps-orgs-list))
@@ -616,7 +618,7 @@
                     layers
                     get-current-layer-geoserver-credentials
                     (if (every? nil? [lng lat zoom]) {} {:center [lng lat] :zoom zoom}))
-      (process-capabilities! (edn/read-string (:body (<! fire-names-chan)))
+      (process-capabilities! fire-names
                              (edn/read-string (:body (<! user-layers-chan)))
                              options-config
                              @!/psps-orgs-list

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -615,7 +615,7 @@
           user-orgs-list-chan             (u-async/call-clj-async! "get-organizations" user-id)
           psps-orgs-list-chan             (u-async/call-clj-async! "get-psps-organizations")
           fire-names                      (edn/read-string (:body (<! fire-names-chan)))]
-      (reset! !/active-fire-count         (count fire-names))
+      (reset! !/active-fire-count (count fire-names))
       (reset! !/user-orgs-list (edn/read-string (:body (<! user-orgs-list-chan))))
       (reset! !/psps-orgs-list (edn/read-string (:body (<! psps-orgs-list-chan))))
       (reset! !/user-psps-orgs-list (filter (fn [org] (some #(= (:org-unique-id org) %) @!/psps-orgs-list))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -605,7 +605,7 @@
           user-orgs-list-chan             (u-async/call-clj-async! "get-organizations" user-id)
           psps-orgs-list-chan             (u-async/call-clj-async! "get-psps-organizations")
           fire-names                      (edn/read-string (:body (<! fire-names-chan)))]
-      (reset! !/show-no-active-fires? (-> fire-names count zero?))
+      (reset! !/active-fire-count         (count fire-names))
       (reset! !/user-orgs-list (edn/read-string (:body (<! user-orgs-list-chan))))
       (reset! !/psps-orgs-list (edn/read-string (:body (<! psps-orgs-list-chan))))
       (reset! !/user-psps-orgs-list (filter (fn [org] (some #(= (:org-unique-id org) %) @!/psps-orgs-list))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -184,8 +184,6 @@
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
-      (when-not (seq @!/param-layers)
-        (toast-message! "There are no layers available for the selected parameters. Please try another combination."))
       (cond
         (and
           no-param-layers?

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -70,8 +70,6 @@ that there are 145 different time steps in this specific forecast."}
   show-red-flag? (r/atom false))
 (defonce ^{:doc "A boolean that maintains UTC or local time display preference."}
   show-utc? (r/atom false))
-(defonce ^{:doc "A boolean that maintains the hide/show of the 'No active fire-toast'"}
-  show-no-active-fires? (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Point Information State
@@ -119,6 +117,10 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
   the-cameras (r/atom nil))
 (defonce ^{:doc "The set of avialable weather dates for Match Drop."}
   md-available-dates (r/atom {}))
+(defonce ^{:doc "An integer that keeps track of the number of active fires."}
+ active-fire-count (r/atom 0))
+(defonce ^{:doc "An Integer that keeps track of the number of times the active fire tab has been clicked."}
+ active-fire-tab-click-count (r/atom 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; config.edn State

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -119,8 +119,6 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
   md-available-dates (r/atom {}))
 (defonce ^{:doc "An integer that keeps track of the number of active fires."}
  active-fire-count (r/atom 0))
-(defonce ^{:doc "An Integer that keeps track of the number of times the active fires tab has been clicked."}
- active-fire-tab-click-count (r/atom 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; config.edn State

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -119,7 +119,7 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
   md-available-dates (r/atom {}))
 (defonce ^{:doc "An integer that keeps track of the number of active fires."}
  active-fire-count (r/atom 0))
-(defonce ^{:doc "An Integer that keeps track of the number of times the active fire tab has been clicked."}
+(defonce ^{:doc "An Integer that keeps track of the number of times the active fires tab has been clicked."}
  active-fire-tab-click-count (r/atom 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -70,6 +70,8 @@ that there are 145 different time steps in this specific forecast."}
   show-red-flag? (r/atom false))
 (defonce ^{:doc "A boolean that maintains UTC or local time display preference."}
   show-utc? (r/atom false))
+(defonce ^{:doc "A boolean that maintains the hide/show of the 'No active fire-toast'"}
+  show-no-active-fires? (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Point Information State


### PR DESCRIPTION
Toast "No active fires." when there are no active fires and it's the first time the active fire tab has been visited.




