### PR TITLE
PYR1-1026 Time slider utc toggle only affects time slider.

### DIFF
--- a/src/cljs/pyregence/components/map_controls/time_slider.cljs
+++ b/src/cljs/pyregence/components/map_controls/time_slider.cljs
@@ -40,8 +40,8 @@
     [:div#time-slider {:style ($/combine $/tool $time-slider)}
      (when-not @!/mobile?
        [:div {:style ($/combine $/flex-col {:align-items "flex-start"})}
-        [radio "UTC"   @!/show-utc? true  select-time-zone! true]
-        [radio "Local" @!/show-utc? false select-time-zone! true]])
+        [radio "UTC"   @!/show-time-slider-utc? true  select-time-zone! true]
+        [radio "Local" @!/show-time-slider-utc? false select-time-zone! true]])
      [:div {:style ($/flex-col)}
       [:input {:style {:width "12rem"}
                :type      "range"

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -352,9 +352,10 @@
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
                                                                               :disabled-for #{:apcptot :apcp01 :smoke}})}
-                                    :model-init {:opt-label  "Forecast Start Time"
-                                                 :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
-                                                 :options    {:loading {:opt-label "Loading..."}}}}}
+                                    :model-init {:opt-label         "Forecast Start Time"
+                                                 :hover-text        "Start time for the forecast cycle, new data comes every 6 hours."
+                                                 :default-show-utc? true
+                                                 :options           {:loading {:opt-label "Loading..."}}}}}
    :fire-risk    {:opt-label       "Risk"
                   :filter          "fire-risk-forecast"
                   :geoserver-key   :shasta
@@ -457,9 +458,10 @@
                                                               ")."]
                                                  :options    {:elmfire {:opt-label "ELMFIRE"
                                                                         :filter    "elmfire"}}}
-                                    :model-init {:opt-label  "Forecast Start Time"
-                                                 :hover-text "Hundreds of millions of fires are ignited across California at various times in the future and their spread is modeled under forecasted weather conditions. Data are refreshed each day at approximately 5 AM PDT."
-                                                 :options    {:loading {:opt-label "Loading..."}}}}}
+                                    :model-init {:opt-label         "Forecast Start Time"
+                                                 :default-show-utc? true
+                                                 :hover-text        "Hundreds of millions of fires are ignited across California at various times in the future and their spread is modeled under forecasted weather conditions. Data are refreshed each day at approximately 5 AM PDT."
+                                                 :options           {:loading {:opt-label "Loading..."}}}}}
    :active-fire  {:opt-label       "Active Fires"
                   :filter          "fire-spread-forecast"
                   :underlays       (merge common-underlays

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -80,7 +80,7 @@
 (defn- get-current-layer-full-time []
   (if-let [sim-time (or (get-current-layer-time)
                         (:sim-time (current-layer)))]
-    (u-time/date-string->iso-string sim-time @!/show-utc?)
+    (u-time/date-string->iso-string sim-time @!/show-time-slider-utc?)
     ""))
 
 (defn- get-current-layer-extent []
@@ -153,7 +153,12 @@
   (let [processed-times (into (u-data/reverse-sorted-map)
                               (map (fn [utc-time]
                                      [(keyword utc-time)
-                                      {:opt-label (u-time/date-string->iso-string utc-time @!/show-utc?)
+                                      {:opt-label (u-time/date-string->iso-string utc-time
+                                                                                  (or
+                                                                                   (-> @!/processed-params
+                                                                                       :model-init
+                                                                                       :default-show-utc?)
+                                                                                   @!/show-utc?))
                                        :utc-time  utc-time ; TODO is utc-time redundant?
                                        :filter    utc-time}])
                                    model-times))]
@@ -529,21 +534,13 @@
     (do (reset! !/show-info? show?)
         (clear-info!))))
 
-(defn- select-time-zone! [utc?]
-  (reset! !/show-utc? utc?)
+(defn- select-time-slider-time-zone! [utc?]
+  (reset! !/show-time-slider-utc? utc?)
   (swap! !/last-clicked-info #(mapv (fn [{:keys [js-time] :as layer}]
                                       (assoc layer
-                                             :date (u-time/get-date-from-js js-time @!/show-utc?)
-                                             :time (u-time/get-time-from-js js-time @!/show-utc?)))
-                                    @!/last-clicked-info))
-  (swap! !/processed-params  #(update-in %
-                                       [:model-init :options]
-                                       (fn [options]
-                                         (u-data/mapm (fn [[k {:keys [utc-time] :as v}]]
-                                                       [k (assoc v
-                                                                 :opt-label
-                                                                 (u-time/date-string->iso-string utc-time @!/show-utc?))])
-                                                 options)))))
+                                             :date (u-time/get-date-from-js js-time @!/show-time-slider-utc?)
+                                             :time (u-time/get-time-from-js js-time @!/show-time-slider-utc?)))
+                                    @!/last-clicked-info)))
 
 (defn- params->selected-options
   "Parses url query parameters into the selected options"
@@ -716,7 +713,7 @@
            [time-slider
             (get-current-layer-full-time)
             select-layer!
-            select-time-zone!])])})))
+            select-time-slider-time-zone!])])})))
 
 (defn- pop-up []
   [:div#pin {:style ($/fixed-size "2rem")}

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -69,7 +69,9 @@ that there are 145 different time steps in this specific forecast."}
 (defonce ^{:doc "A boolean that maintains the hide/show toggle state of the Red Flag Warning Tool."}
   show-red-flag? (r/atom false))
 (defonce ^{:doc "A boolean that maintains UTC or local time display preference."}
-  show-utc? (r/atom false))
+  show-utc? (r/atom nil))
+(defonce ^{:doc "A boolean that maintains UTC or local time display preference for the time slider."}
+ show-time-slider-utc? (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Point Information State


### PR DESCRIPTION
And showing utc, outside the time slider, is done on a per options basis. e.g weather forecast start time and risk forecast start time each choose to start by showing utc. As where the rest (e.g active fires forecast start time) show local time at the start like they did before.

It's worth mentioning that as far as I can tell, the only way to toggle between utc and is the time slider toggle, so disconnecting the time slider from show-utc? might not be what we want, but it's not clear to me.

Alternatively this functionality be changed so the time slider toggle does affect the options (e.g forecast start time) but then that change (say to-local) is filtered out by a configuration setting (e.g config.cljs option would in addition to having a :default-show-utc? value would also have something like :valid-timezones #{:utc :local}. This alternative is being captured in this [PR](https://github.com/pyregence/pyregence/pull/899)

## Before commit

Here is what the weather tab looked like before this commit on load:
![image](https://github.com/user-attachments/assets/4dd3a6c2-0528-4dc0-ac5f-8e65140bdf83)

Now if you click UTC:
![image](https://github.com/user-attachments/assets/8b862e3c-ee79-4324-96c5-e6fb677b70ac)

## After commit

Here is it looks like after the commit on first load:
![image](https://github.com/user-attachments/assets/01e4d1c0-950f-4447-8827-bd0c9ae2e0c9)

After you click UTC
![image](https://github.com/user-attachments/assets/ce850f5e-fdad-40c1-8cf1-d5c78daeb1bc)

Now, as mentioned above, interperating the jira request of 1026 can go two different ways. First, what this commit does is make it so the time slider toggle only affects itself. The second notion, which this commit doesn't do, is that it keeps affecting the entire apps notion of when to show utc or not, but each spot (e.g forecast) has a way to modify that result. This could be done at the config.cljs layer. 




