### PR TITLE
PYR1-1026 Allow forecast models to interpret the timezone slider timezone.

### DIFF
--- a/src/cljs/pyregence/components/map_controls/time_slider.cljs
+++ b/src/cljs/pyregence/components/map_controls/time_slider.cljs
@@ -40,8 +40,8 @@
     [:div#time-slider {:style ($/combine $/tool $time-slider)}
      (when-not @!/mobile?
        [:div {:style ($/combine $/flex-col {:align-items "flex-start"})}
-        [radio "UTC"   @!/show-utc? true  select-time-zone! true]
-        [radio "Local" @!/show-utc? false select-time-zone! true]])
+        [radio "UTC"   @!/timezone :utc  select-time-zone! true]
+        [radio "Local" @!/timezone :local select-time-zone! true]])
      [:div {:style ($/flex-col)}
       [:input {:style {:width "12rem"}
                :type      "range"

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -205,7 +205,8 @@
                                                                               :disabled-for #{:asp :slp :dem :cc :ch :cbh :cbd}})}
                                   :model-init {:opt-label  "Model Creation Time"
                                                :hover-text "Time the data was created."
-                                               :options    {:loading {:opt-label "Loading..."}}}}}
+                                               :options    {:loading {:opt-label "Loading..."}}}}
+                  :timezone      {:change identity}}
    :fire-weather {:opt-label       "Weather"
                   :filter          "fire-weather-forecast"
                   :geoserver-key   :shasta
@@ -354,7 +355,8 @@
                                                                               :disabled-for #{:apcptot :apcp01 :smoke}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
-                                                 :options    {:loading {:opt-label "Loading..."}}}}}
+                                                 :options    {:loading {:opt-label "Loading..."}}}}
+                  :timezone        {:change (constantly :utc)}}
    :fire-risk    {:opt-label       "Risk"
                   :filter          "fire-risk-forecast"
                   :geoserver-key   :shasta
@@ -459,7 +461,8 @@
                                                                         :filter    "elmfire"}}}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Hundreds of millions of fires are ignited across California at various times in the future and their spread is modeled under forecasted weather conditions. Data are refreshed each day at approximately 5 AM PDT."
-                                                 :options    {:loading {:opt-label "Loading..."}}}}}
+                                                 :options    {:loading {:opt-label "Loading..."}}}}
+                  :timezone        {:change (constantly :utc)}}
    :active-fire  {:opt-label       "Active Fires"
                   :filter          "fire-spread-forecast"
                   :underlays       (merge common-underlays
@@ -564,7 +567,8 @@
                                                                           (filter keyword?)
                                                                           (set))
                                                                      #{:active-fires}))
-                                                 :options    {:loading {:opt-label "Loading..."}}}}}
+                                                 :options    {:loading {:opt-label "Loading..."}}}}
+                  :timezone        {:change  identity}}
    :psps-zonal   {:opt-label       "PSPS"
                   :filter          "psps-zonal"
                   :geoserver-key   :psps
@@ -687,7 +691,8 @@
                                                  :options    {:loading {:opt-label "Loading..."}}}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for forecast cycle, new data comes every 6 hours."
-                                                 :options    {:loading {:opt-label "Loading..."}}}}}})
+                                                 :options    {:loading {:opt-label "Loading..."}}}}
+                  :timezone        {:change identity}}})
 
 (def near-term-forecast-layers
   "All layers added in addition to the default Mapbox layers and their

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -80,7 +80,7 @@
 (defn- get-current-layer-full-time []
   (if-let [sim-time (or (get-current-layer-time)
                         (:sim-time (current-layer)))]
-    (u-time/date-string->iso-string sim-time @!/show-utc?)
+    (u-time/date-string->iso-string sim-time @!/timezone)
     ""))
 
 (defn- get-current-layer-extent []
@@ -153,7 +153,10 @@
   (let [processed-times (into (u-data/reverse-sorted-map)
                               (map (fn [utc-time]
                                      [(keyword utc-time)
-                                      {:opt-label (u-time/date-string->iso-string utc-time @!/show-utc?)
+                                      {:opt-label (u-time/date-string->iso-string
+                                                    utc-time
+                                                    ((get-in @!/capabilities [@!/*forecast :timezone :change])
+                                                     @!/timezone))
                                        :utc-time  utc-time ; TODO is utc-time redundant?
                                        :filter    utc-time}])
                                    model-times))]
@@ -386,8 +389,8 @@
                              (let [js-time (u-time/js-date-from-string sim-time)]
                                  (assoc pi-layer
                                         :js-time js-time
-                                        :date    (u-time/get-date-from-js js-time @!/show-utc?)
-                                        :time    (u-time/get-time-from-js js-time @!/show-utc?)
+                                        :date    (u-time/get-date-from-js js-time @!/timezone)
+                                        :time    (u-time/get-time-from-js js-time @!/timezone)
                                         :hour    hour)))
                            @!/param-layers)))))))
 
@@ -537,21 +540,24 @@
     (do (reset! !/show-info? show?)
         (clear-info!))))
 
-(defn- select-time-zone! [utc?]
-  (reset! !/show-utc? utc?)
+(defn- select-time-zone! [timezone]
+  (reset! !/timezone timezone)
   (swap! !/last-clicked-info #(mapv (fn [{:keys [js-time] :as layer}]
                                       (assoc layer
-                                             :date (u-time/get-date-from-js js-time @!/show-utc?)
-                                             :time (u-time/get-time-from-js js-time @!/show-utc?)))
+                                             :date (u-time/get-date-from-js js-time @!/timezone)
+                                             :time (u-time/get-time-from-js js-time @!/timezone)))
                                     @!/last-clicked-info))
   (swap! !/processed-params  #(update-in %
-                                       [:model-init :options]
-                                       (fn [options]
-                                         (u-data/mapm (fn [[k {:keys [utc-time] :as v}]]
-                                                       [k (assoc v
-                                                                 :opt-label
-                                                                 (u-time/date-string->iso-string utc-time @!/show-utc?))])
-                                                 options)))))
+                                         [:model-init :options]
+                                         (fn [options]
+                                           (u-data/mapm (fn [[k {:keys [utc-time] :as v}]]
+                                                          [k (assoc v
+                                                                    :opt-label
+                                                                    (u-time/date-string->iso-string
+                                                                      utc-time
+                                                                      ((get-in @!/capabilities [@!/*forecast :timezone :change])
+                                                                       @!/timezone)))])
+                                                        options)))))
 
 (defn- params->selected-options
   "Parses url query parameters into the selected options"

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -68,8 +68,6 @@ that there are 145 different time steps in this specific forecast."}
   show-panel? (r/atom true))
 (defonce ^{:doc "A boolean that maintains the hide/show toggle state of the Red Flag Warning Tool."}
   show-red-flag? (r/atom false))
-(defonce ^{:doc "A boolean that maintains UTC or local time display preference."}
-  show-utc? (r/atom false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Point Information State
@@ -119,6 +117,8 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
   md-available-dates (r/atom {}))
 (defonce ^{:doc "An integer that keeps track of the number of active fires."}
  active-fire-count (r/atom 0))
+(defonce timezone ^{:doc "The current selected timezone"}
+  (r/atom :local))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; config.edn State

--- a/src/cljs/pyregence/utils/time_utils.cljs
+++ b/src/cljs/pyregence/utils/time_utils.cljs
@@ -63,13 +63,14 @@
 
 (defn js-date->iso-string
   "Returns a ISO date-time string for a given JS date object in local or UTC timezone."
-  [js-date show-utc?]
-  (str (get-date-from-js js-date show-utc?) " " (get-time-from-js js-date show-utc?)))
+  [js-date timezone]
+  (let [show-utc? (= :utc timezone)]
+    (str (get-date-from-js js-date show-utc?) " " (get-time-from-js js-date show-utc?))))
 
 (defn date-string->iso-string
   "Returns a ISO date-time string for a given date string in local or UTC timezone."
-  [date-str show-utc?]
-  (js-date->iso-string (js-date-from-string date-str) show-utc?))
+  [date-str timezone]
+  (js-date->iso-string (js-date-from-string date-str) timezone))
 
 (defn iso-string->local-datetime-string
   "Converts an ISO date string to a local datetime string. Note that this will


### PR DESCRIPTION
Forecast models are now configured through the config.cljs to independently process the timezone selection made by the time slider.

## Purpose

This allows for the desired outcome of making the forecast start time in the weather and risk tab always be UTC regardless of what the time slider selects.



## Related Issues
Closes PYR1-1026

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Screenshots
Weather tab after change

![image](https://github.com/user-attachments/assets/c9c6846b-fa2b-4c4d-a89c-5b944ede5c78)

Risk tab after change:
![image](https://github.com/user-attachments/assets/15360a67-9456-4d40-82a1-0c959c901f94)


