### PR TITLE
PYR1-1026 fire and risk forecast now always display in utc.

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -212,6 +212,7 @@
                   :underlays       (merge common-underlays near-term-forecast-underlays)
                   :reverse-legend? true
                   :time-slider?    true
+                  :always-utc?     true
                   :hover-text      "Gridded weather forecasts from several US operational weather models including key parameters that affect wildfire behavior."
                   :params          {:band       {:opt-label  "Weather Parameter"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
@@ -361,6 +362,7 @@
                   :underlays       (merge common-underlays near-term-forecast-underlays)
                   :reverse-legend? true
                   :time-slider?    true
+                  :always-utc?     true
                   :hover-text      "5-day forecast of fire consequence maps. Every day over 500 million hypothetical fires are ignited across California to evaluate potential fire risk.\n"
                   :params          {:output     {:opt-label  "Output"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -142,6 +142,13 @@
          "_"
          (name (get-in @!/*params [:psps-zonal :statistic])))))
 
+(defn- utc-time->opt-label
+  [utc-time]
+  (u-time/date-string->iso-string
+   utc-time
+   (or (get-in @!/capabilities [@!/*forecast :always-utc?])
+        @!/show-utc?)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Data Processing Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -153,7 +160,7 @@
   (let [processed-times (into (u-data/reverse-sorted-map)
                               (map (fn [utc-time]
                                      [(keyword utc-time)
-                                      {:opt-label (u-time/date-string->iso-string utc-time @!/show-utc?)
+                                      {:opt-label (utc-time->opt-label utc-time)
                                        :utc-time  utc-time ; TODO is utc-time redundant?
                                        :filter    utc-time}])
                                    model-times))]
@@ -550,7 +557,7 @@
                                          (u-data/mapm (fn [[k {:keys [utc-time] :as v}]]
                                                        [k (assoc v
                                                                  :opt-label
-                                                                 (u-time/date-string->iso-string utc-time @!/show-utc?))])
+                                                                 (utc-time->opt-label utc-time))])
                                                  options)))))
 
 (defn- params->selected-options


### PR DESCRIPTION
## Purpose
Fire and risk forecasts are now always displayed in UTC.

## Related Issues
Closes PYR1-1026

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)