### PR TITLE
PYR1-1033 Update 2024 fire perimeters to 2025

### DIFF
--- a/README.org
+++ b/README.org
@@ -338,7 +338,7 @@ sudo less +G /var/log/nginx/error.log
 
 ** License and Distribution
 
-Copyright © 2020-2024 Spatial Informatics Group, LLC.
+Copyright © 2020-2025 Spatial Informatics Group, LLC.
 
 Pyregence is distributed by Spatial Informatics Group, LLC. under the
 terms of the Eclipse Public License version 2.0 (EPLv2). See

--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -199,7 +199,7 @@
           " - Microsoft building footprints."
           [:br]
           [:br]
-          [:strong "2024 fire perimeters"]
+          [:strong "2025 fire perimeters"]
           " - Current season fires to date."
           [:br]
           [:br]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -37,7 +37,7 @@
                              :z-index       107
                              :filter-set    #{"fire-detections" "us-transmission-lines"}
                              :geoserver-key :shasta}
-   :current-year-perimeters {:opt-label     "2024 fire perimeters"
+   :current-year-perimeters {:opt-label     "2025 fire perimeters"
                              :z-index       103
                              :filter-set    #{"fire-detections" "current-year-perimeters"}
                              :geoserver-key :shasta}


### PR DESCRIPTION
## Purpose
Updates the text for the fire perimeters underlay from 2024 to 2025 (now that the underlying layer has been updated). Also updates the README.

## Related Issues
Closes PYR1-1033

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
Confirm that the text in the optional layers panel (as well as the help text/tooltip) says "2025 fire perimeters" and not "2024 fire perimeters". 