### PR TITLE
PYR1-1035 Introduce other mapbox layer options in base-map-options

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -1103,19 +1103,28 @@
 ;; Mapbox Configuration
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(def mapbox-public-user-name
+  "This is global for all the standard mapbox basemap styles.
+   See documentation at https://docs.mapbox.com/api/maps/styles/#classic-mapbox-styles"
+  "mapbox")
+
 (defn- style-url [id]
-  (str "https://api.mapbox.com/styles/v1/mspencer-sig/" id "?access_token=" @!/mapbox-access-token))
+  (str "https://api.mapbox.com/styles/v1/" mapbox-public-user-name "/" id "?access_token=" @!/mapbox-access-token))
 
 (defn base-map-options
   "Provides the configuration for the different Mapbox map view options."
   []
-  {:mapbox-topo       {:opt-label "Mapbox Street Topo"
-                       :source    (style-url "cka8jaky90i9m1iphwh79wr04")}
-   :mapbox-satellite  {:opt-label "Mapbox Satellite"
-                       :source    (style-url "ckm3suyjm0u6z17nx1t7udnvd")}
-   :mapbox-sat-street {:opt-label "Mapbox Satellite Street"
-                       :source    (style-url "ckm2hgkx04xuw17pahpins029")}})
+  {:mapbox-streets           {:opt-label "Mapbox Streets"
+                              :source    (style-url "streets-v11")}
+   :mapbox-satellite-streets {:opt-label "Mapbox Satellite Streets"
+                              :source    (style-url "satellite-streets-v11")}
+   :mapbox-outdoors          {:opt-label "Mapbox Outdoors"
+                              :source    (style-url "outdoors-v11")}
+   :mapbox-light             {:opt-label "Mapbox Light"
+                              :source    (style-url "light-v11")}
+   :mapbox-dark              {:opt-label "Mapbox Dark"
+                              :source    (style-url "dark-v11")}})
 
-(def base-map-default :mapbox-topo)
+(def base-map-default :mapbox-streets)
 
 (def mapbox-dem-url "mapbox://mapbox.mapbox-terrain-dem-v1")


### PR DESCRIPTION
## Purpose
We want to add other Mapbox base maps to PyreCast

## Related Issues
Closes PYR1-1035

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Change the basemap types in the bottom left menu.
Observe the layer changing.
Add more layers like transmission lines, structures etc. (from the "Otional Layers" menu)
Do some exploration testing changing basemap types, like zooming in/out etc.

#### Role
All

#### Desired Outcome
Should change the baselayer normally

#### Screenshots
![image](https://github.com/user-attachments/assets/b0e09eb5-259b-462f-9dc5-6d275dcd6892)
