### PR TITLE
PYR1-1030 Select the forecast after the mapbox loads.

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -860,28 +860,29 @@
 (defn init-map!
   "Initializes the Mapbox map inside of `container` (e.g. \"map\").
    Specifies the proper project layers based on the forecast type."
-  [container-id layers get-current-layer-geoserver-credentials & [opts]]
+  [container-id layers get-current-layer-geoserver-credentials on-load-fn & [opts]]
   (set! (.-accessToken mapbox) @!/mapbox-access-token)
   (when-not (.supported mapbox)
     (js/alert (str "Your browser does not support Pyregence Forecast.\n"
                    "Please use the latest version of Chrome, Safari, or Firefox.")))
   (reset! project-layers layers)
-  (reset! the-map
-          (Map.
-           (clj->js (merge {:container   container-id
-                            :dragRotate       false
-                            :maxZoom          20
-                            :minZoom          3
-                            :style            (-> (c/base-map-options) c/base-map-default :source)
-                            :touchPitch       false
-                            :trackResize      true
-                            ;; For PSPS layers, we need to add basic auth to the GetTile requests
-                            :transformRequest (fn [url resource-type]
-                                                (when (and (str/starts-with? url (:psps @!/geoserver-urls))
-                                                           (= resource-type "Tile"))
-                                                  #js {:url     url
-                                                       :headers #js {:authorization (str "Basic " (js/window.btoa (get-current-layer-geoserver-credentials)))}}))
-                            :transition       {:duration 500 :delay 0}}
-                           (when-not (:zoom opts)
-                             {:bounds c/california-extent})
-                           opts)))))
+  (-> the-map
+      (reset! (Map.
+               (clj->js (merge {:container        container-id
+                                :dragRotate       false
+                                :maxZoom          20
+                                :minZoom          3
+                                :style            (-> (c/base-map-options) c/base-map-default :source)
+                                :touchPitch       false
+                                :trackResize      true
+                                ;; For PSPS layers, we need to add basic auth to the GetTile requests
+                                :transformRequest (fn [url resource-type]
+                                                    (when (and (str/starts-with? url (:psps @!/geoserver-urls))
+                                                               (= resource-type "Tile"))
+                                                      #js {:url     url
+                                                           :headers #js {:authorization (str "Basic " (js/window.btoa (get-current-layer-geoserver-credentials)))}}))
+                                :transition       {:duration 500 :delay 0}}
+                               (when-not (:zoom opts)
+                                 {:bounds c/california-extent})
+                               opts))))
+      (.on "load" on-load-fn)))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -632,6 +632,7 @@
       (mb/init-map! "map"
                     layers
                     get-current-layer-geoserver-credentials
+                    #(go (<! (select-forecast! @!/*forecast)))
                     (if (every? nil? [lng lat zoom]) {} {:center [lng lat] :zoom zoom}))
       (process-capabilities! fire-names
                              (edn/read-string (:body (<! user-layers-chan)))
@@ -640,7 +641,6 @@
                              @!/user-psps-orgs-list
                              (params->selected-options options-config @!/*forecast params))
       (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras-chan))))
-      (<! (select-forecast! @!/*forecast))
       (when (and (not-empty @!/capabilities)
                  (not-empty @!/*params))
         (reset! !/loading? false)))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -632,7 +632,7 @@
       (mb/init-map! "map"
                     layers
                     get-current-layer-geoserver-credentials
-                    #(go (<! (select-forecast! @!/*forecast)))
+                    #(select-forecast! @!/*forecast)
                     (if (every? nil? [lng lat zoom]) {} {:center [lng lat] :zoom zoom}))
       (process-capabilities! fire-names
                              (edn/read-string (:body (<! user-layers-chan)))


### PR DESCRIPTION
## Purpose

Selecting the forecast should be done after the mapbox loads because Mapbox asynchronously fetches styles, and likely does other work asynchronously in it's constructor, which means the app needs a way to do work after that async work finishes.

That work cannot be done before, as doing it before will cause issues like the active fire icons not loading, which is really more like a symptom of the whole mapbox program failing.

To facility doing the work explicitly after the mapbox loads, we take advantage of the Mapbox's lifecycle load event. Here is the link:

https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:load

and here is an example from that link:

```
// Initialize the map
const map = new mapboxgl.Map({});
// Set an event listener that fires
// when the map has finished loading.
map.on('load', () => {
    console.log('A load event occurred.');
});
```

To mirror this example in Pyregence, this commit passes the functionality to select the forecast to the mapbox js object called `the-map` after it's returned out of the ratom reset! in the on load spot.

I'll note that I'm not entirely sure why the mapbox object is inside a ratom in the first place, as it's already global mutable state. Is it used to somehow update facilitate rendering a component?


## Related Issues
Closes PYR1-1030

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Mapbox

#### Role
All

#### Steps

To be clear, it's impossible to say for sure this change will fix the problem, because the problem of mapbox misbehaving and not loading things is far to general to be "fixed". Instead, our goal in these steps is just to give a good intution that doing work after the mapbox javascript object is done loading, is the right thing to do, and for the primary step in doing that, is consulting the documentation in the link above. 

Beyond that though, on the few times i saw the active fire icons fail to load, it was accompanied by this type error:

```
Uncaught TypeError: this.stylesheet is undefined
    serialize mapbox-gl-v2.10.0.js:35
    getStyle mapbox-gl-v2.10.0.js:35
    F_ core.cljs:1477
    r0 mapbox.cljs:512
    e near_term_forecast.cljs:530
    mX ioc_helpers.cljs:43
    p7 near_term_forecast.cljs:530
    nN dispatch.cljs:27
    onmessage (index):214
mapbox-gl-v2.10.0.js:35:121710
```

That type error, as you can see, stems from calling getStyleIf you try to call that function, in the commit right before this branch and right after intalizing the map, 

```clojure
(mb/init-map! "map" ...)
(.getStyle @the-map)
```

You will see the app get "stuck" likely on the "loading" screen, if you check the console, you will see the same type error. Whats likely happening is, as the pr description says, the map constructor makes an aysnc call and that call hasn't come back with any data, so the mapbox object isn't ready to answer the question "what are my styles" because it doesn't have them yet. 

This commit moves the first call i could find to get styles into the "on-load" functionality. It doesn't try to find all possible ways the map object might be called before its done loading though. That can be addressed in additional tickets. 



