### PR TITLE
PYR1-975 Small bug fix with no active fires toast message

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -190,16 +190,14 @@
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
-      (let [no-param-layers? (not (seq @!/param-layers))]
-        (cond
-          (and
-           no-param-layers?
-           (= :active-fire @!/*forecast)
-           (zero? @!/active-fire-count))
-          (toast-message! "There are currently no active fires in the system.")
+      (cond
+        (and
+         (= :active-fire @!/*forecast)
+         (zero? @!/active-fire-count))
+        (toast-message! "There are currently no active fire forecasts in the system.")
 
-          no-param-layers?
-          (toast-message! "There are no layers available for the selected parameters. Please try another combination."))))))
+        (not (seq @!/param-layers))
+        (toast-message! "There are no layers available for the selected parameters. Please try another combination.")))))
 
 (defn- create-share-link
   "Generates a link with forecast and parameters encoded in a URL"


### PR DESCRIPTION
## Purpose
The fix to PYR1-975 wasn't quite working as expected because of an extra check in the `cond` statement altered in this PR. This is because the `no-param-layers?` check was never being hit due to the fact that the active fires icon layer exists even when it doesn't hold any data:

```clojure
cljs.user=> @pyregence.state/param-layers
[{:hour 0, :workspace "fire-detections_active-fires", :layer-group "", :forecast "fire-detections", :times ni
l, :type "active-fires", :model-init "20250127_111200", :layer "fire-detections_active-fires:active-fires_202
50127_111200", :extent ["0.0" "0.0" "-1.0" "-1.0"], :filter-set #{"20250127_111200" "fire-detections" "active
-fires"}}]
```

Simply removing that check restores the functionality that we expect. When there are no active fire forecasts (as per the `active-fire-count` atom), display the toast message that informs the user. A better solution here would be to check whether or not the `active-fires` layer in question has any data associated with it, but there's currently no easy way to do so.


## Related Issues
Closes PYR1-975

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
At the time of writing this PR (1/27/2025) there are currently no active fires. On the `main` branch, navigate to the active fires tab and see that there is no toast message that pops up (even though we would expect one). On this branch, do the same thing and see that the toast message pops up as expected.


