### PR TITLE
PYR1-1048 show active fires forecast when there are some, otherwise show the weather tab.

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -625,7 +625,19 @@
       (reset! !/user-psps-orgs-list (filter (fn [org] (some #(= (:org-unique-id org) %) @!/psps-orgs-list))
                                             @!/user-orgs-list))
       (reset! !/*forecast-type forecast-type)
-      (reset! !/*forecast (if (zero? active-fire-count) :fire-weather :active-fire))
+
+      (reset! !/*forecast
+              (cond
+                (= :long-term forecast-type)
+                (or (keyword forecast)
+                    (keyword (forecast-type @!/default-forecasts)))
+
+                ;; other wise it's near term
+                (zero? active-fire-count)
+                :fire-weather
+
+                :else
+                :active-fire))
       (reset! !/*layer-idx (if layer-idx (js/parseInt layer-idx) 0))
       (mb/init-map! "map"
                     layers

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -617,15 +617,15 @@
           fire-cameras-chan               (u-async/call-clj-async! "get-cameras")
           user-orgs-list-chan             (u-async/call-clj-async! "get-organizations" user-id)
           psps-orgs-list-chan             (u-async/call-clj-async! "get-psps-organizations")
-          fire-names                      (edn/read-string (:body (<! fire-names-chan)))]
-      (reset! !/active-fire-count (count fire-names))
+          fire-names                      (edn/read-string (:body (<! fire-names-chan)))
+          active-fire-count               (count fire-names)]
+      (reset! !/active-fire-count active-fire-count)
       (reset! !/user-orgs-list (edn/read-string (:body (<! user-orgs-list-chan))))
       (reset! !/psps-orgs-list (edn/read-string (:body (<! psps-orgs-list-chan))))
       (reset! !/user-psps-orgs-list (filter (fn [org] (some #(= (:org-unique-id org) %) @!/psps-orgs-list))
                                             @!/user-orgs-list))
       (reset! !/*forecast-type forecast-type)
-      (reset! !/*forecast (or (keyword forecast)
-                              (keyword (forecast-type @!/default-forecasts))))
+      (reset! !/*forecast (if (zero? active-fire-count) :fire-weather :active-fire))
       (reset! !/*layer-idx (if layer-idx (js/parseInt layer-idx) 0))
       (mb/init-map! "map"
                     layers


### PR DESCRIPTION
## Purpose

This change makes it so the browser app shows the active fire forecasts when there are some; otherwise, it sends the user to the weather forecast tab. This behavior happens on the first load.

## Related Issues
Closes PYR1-1048

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
It affects which forecast tab shows on the first load. 

#### Role
ALL

#### Steps
Run the local dev setup and hardcode the active-fire-count (line 621 in near_term_forecast.cljs) to zero. Then do a hard refresh and notice that it will take you to the weather page. Now hardcode the active-fire-count to 1 and do a hard refresh, it will go to the active fire tab as desired.
