### PR TITLE
PYR1-1011 fix "dom-node" warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "mapbox-gl": "^3.9.3",
         "react": "^16.13.0",
         "react-dom": "^16.13.0",
-        "vega-embed": "^6.0.0"
+        "vega-embed": "^6.29.0"
       },
       "devDependencies": {
         "webpack": "^5.91.0",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.3.tgz",
-      "integrity": "sha512-lOyG3aF4FTKrhpzXfMmBXgeKUUXdAWmP2zSNf8HTAXPqZay6QYT26l64hVizBjq+hJx3pl0DTEyvPi9sTA6VGA==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
+      "integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "mapbox-gl": "^3.9.3",
-    "vega-embed": "^6.0.0",
+    "vega-embed": "^6.29.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   },

--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -1,13 +1,14 @@
 (ns pyregence.components.common
   (:require-macros [pyregence.herb-patch :refer [style->class]])
-  (:require [clojure.core.async           :refer [go <! timeout]]
-            [herb.core                    :refer [<class]]
-            [pyregence.styles             :as $]
-            [pyregence.utils.dom-utils    :as u-dom]
-            [pyregence.utils.string-utils :as u-str]
-            [pyregence.utils.time-utils   :as u-time]
-            [reagent.core                 :as r]
-            [reagent.dom                  :as rd]))
+  (:require
+   [clojure.core.async                   :refer [<! go timeout]]
+   [herb.core                            :refer [<class]]
+   [pyregence.styles                     :as $]
+   [pyregence.utils.dom-utils            :as u-dom]
+   [pyregence.utils.string-utils         :as u-str]
+   [pyregence.utils.time-utils           :as u-time]
+   [react                                :as react]
+   [reagent.core                         :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
@@ -50,12 +51,14 @@
     [-1000 -1000 -1000 -1000]))
 
 (defn- sibling-wrapper [sibling sibling-ref]
-  (r/create-class
-   {:component-did-mount
-    (fn [this] (reset! sibling-ref (rd/dom-node this)))
-
-    :reagent-render
-    (fn [sibling _] sibling)}))
+  (let [ref (react/createRef)]
+    (r/create-class
+     {:component-did-mount
+      (fn [this] (reset! sibling-ref (.-current ref)))
+      :reagent-render
+      (fn [sibling _]
+        [:div {:ref ref}
+         sibling])})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Styles
@@ -245,26 +248,26 @@
 
 (defn- tool-tip []
   (let [tool-ref (atom nil)
-        position (r/atom [-1000 -1000 -1000 -1000])]
+        position (r/atom [-1000 -1000 -1000 -1000])
+        ref      (react/createRef)]
     (r/create-class
      {:component-did-mount
       (fn [this]
         (let [{:keys [sibling-ref arrow-position show?]} (r/props this)]
-          (reset! tool-ref (rd/dom-node this))
+          (reset! tool-ref (.-current ref))
           (reset! position (calc-tool-position sibling-ref @tool-ref arrow-position show?))))
-
       :component-did-update
       (fn [this [_ prev-props]]
         (let [{:keys [tool-tip-text sibling-ref arrow-position show?]} (r/props this)]
           (when (or (not= tool-tip-text (:tool-tip-text prev-props))
                     (not= show?         (:show? prev-props)))
             (reset! position (calc-tool-position sibling-ref @tool-ref arrow-position show?)))))
-
       :render
       (fn [this]
         (let [{:keys [tool-tip-text arrow-position show?]} (r/props this)
-              [tip-x tip-y arrow-x arrow-y] @position]
-          [:div {:style ($tool-tip tip-x tip-y arrow-position show?)}
+              [tip-x tip-y arrow-x arrow-y]                @position]
+          [:div {:style ($tool-tip tip-x tip-y arrow-position show?)
+                 :ref   ref}
            [:div {:style ($arrow arrow-x arrow-y arrow-position show?)}]
            [:div {:style {:position "relative" :width "fit-content" :z-index 203}}
             tool-tip-text]]))})))

--- a/src/cljs/pyregence/components/resizable_window.cljs
+++ b/src/cljs/pyregence/components/resizable_window.cljs
@@ -1,9 +1,10 @@
 (ns pyregence.components.resizable-window
-  (:require [reagent.core     :as r]
-            [reagent.dom      :as rd]
-            [herb.core :refer [<class]]
-            [pyregence.styles :as $]
-            [pyregence.components.svg-icons :refer [close]]))
+  (:require
+   [herb.core                            :refer [<class]]
+   [pyregence.components.svg-icons       :refer [close]]
+   [pyregence.styles                     :as $]
+   [react                                :as react]
+   [reagent.core                         :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; UI Styles
@@ -69,23 +70,23 @@
                       :margin-right "2px"}}]]]))
 
 (defn- title-div [title title-height on-click]
-  (r/create-class
-   {:component-did-mount
-    (fn [this]
-      (reset! title-height
-              (-> this
-                  (rd/dom-node)
-                  (.getBoundingClientRect)
-                  (aget "height"))))
-
-    :render
-    (fn [_]
-      [:div {:style {:border-bottom (str "1px solid " ($/color-picker :border-color)) :width "100%"}}
-       [:label {:style {:margin-left ".5rem" :margin-top ".25rem"}} title]
-       [:span {:class    (<class $/p-add-hover)
-               :style    ($close-button @title-height)
-               :on-click on-click}
-        [close]]])}))
+  (let [ref (react/createRef)]
+    (r/create-class
+     {:component-did-mount
+      (fn [this]
+        (reset! title-height
+                (-> (.-current ref)
+                    (.getBoundingClientRect)
+                    (aget "height"))))
+      :render
+      (fn [_]
+        [:div {:ref   ref
+               :style {:border-bottom (str "1px solid " ($/color-picker :border-color)) :width "100%"}}
+         [:label {:style {:margin-left ".5rem" :margin-top ".25rem"}} title]
+         [:span {:class    (<class $/p-add-hover)
+                 :style    ($close-button @title-height)
+                 :on-click on-click}
+          [close]]])})))
 
 (defn resizable-window
   "A component for a resizable window. Takes in the window's parent, initial dimensions,

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -53,7 +53,6 @@
     {:width    "container"
      :height   "container"
      :autosize {:type "fit" :resize true :contains "content"}
-     :padding  {:left "16" :top "16" :bottom "16"}
      :data     {:values processed-point-info}
      :layer    [{:encoding {:x       {:field "hour"
                                       :type  "quantitative"
@@ -135,6 +134,7 @@
          {:ref   ref
           :style {:height (:box-height (r/props this))
                   :background-color "white"
+                  :padding "16px"
                   :width  (:box-width  (r/props this))}}])})))
 
 (defn vega-box

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -1,14 +1,14 @@
 (ns pyregence.components.vega
   (:require
-   ["vega-embed"                            :as vega-embed :refer [embed]]
-   [cljs.core.async.interop                 :refer-macros [<p!]]
-   [clojure.core.async                      :refer [go]]
-   [pyregence.state                         :as !]
-   [pyregence.utils.data-utils              :as u-data]
-   [pyregence.utils.misc-utils              :as u-misc]
-   [pyregence.utils.number-utils            :as u-num]
-   [react                                   :as react]
-   [reagent.core                            :as r]))
+   ["vega-embed"                 :as vega-embed :refer [embed]]
+   [cljs.core.async.interop      :refer-macros [<p!]]
+   [clojure.core.async           :refer [go]]
+   [pyregence.state              :as !]
+   [pyregence.utils.data-utils   :as u-data]
+   [pyregence.utils.misc-utils   :as u-misc]
+   [pyregence.utils.number-utils :as u-num]
+   [react                        :as react]
+   [reagent.core                 :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
@@ -132,13 +132,13 @@
       (fn [this]
         [:div#vega-canvas
          {:ref   ref
-          :style {:height (:box-height (r/props this))
-                  :background-color "white"
-                  :padding-left "16px"
-                  :padding-bottom "16px"
-                  :padding-top "16px"
-                  :padding-right "32px"
-                  :width  (:box-width  (r/props this))}}])})))
+          :style {:background-color "white"
+                  :height           (:box-height (r/props this))
+                  :padding-left     "10px"
+                  :padding-bottom   "16px"
+                  :padding-top      "16px"
+                  :padding-right    "32px"
+                  :width            (:box-width (r/props this))}}])})))
 
 (defn vega-box
   "A function to create a Vega line plot."

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -134,7 +134,10 @@
          {:ref   ref
           :style {:height (:box-height (r/props this))
                   :background-color "white"
-                  :padding "16px"
+                  :padding-left "16px"
+                  :padding-bottom "16px"
+                  :padding-top "16px"
+                  :padding-right "32px"
                   :width  (:box-width  (r/props this))}}])})))
 
 (defn vega-box

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -1,13 +1,14 @@
 (ns pyregence.components.vega
-  (:require [cljs.core.async.interop      :refer-macros [<p!]]
-            ["vega-embed"                 :as vega-embed :refer [embed]]
-            [clojure.core.async           :refer [go]]
-            [pyregence.state              :as !]
-            [pyregence.utils.data-utils   :as u-data]
-            [pyregence.utils.misc-utils   :as u-misc]
-            [pyregence.utils.number-utils :as u-num]
-            [reagent.core                 :as r]
-            [reagent.dom                  :as rd]))
+  (:require
+   ["vega-embed"                            :as vega-embed :refer [embed]]
+   [cljs.core.async.interop                 :refer-macros [<p!]]
+   [clojure.core.async                      :refer [go]]
+   [pyregence.state                         :as !]
+   [pyregence.utils.data-utils              :as u-data]
+   [pyregence.utils.misc-utils              :as u-misc]
+   [pyregence.utils.number-utils            :as u-num]
+   [react                                   :as react]
+   [reagent.core                            :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
@@ -118,22 +119,22 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- vega-canvas []
-  (r/create-class
-   {:component-did-mount
-    (fn [this]
-      (let [{:keys [spec layer-click!]} (r/props this)]
-        (render-vega spec layer-click! (rd/dom-node this))))
-
-    :component-did-update
-    (fn [this _]
-      (let [{:keys [spec layer-click!]} (r/props this)]
-        (render-vega spec layer-click! (rd/dom-node this))))
-
-    :render
-    (fn [this]
-      [:div#vega-canvas
-       {:style {:height (:box-height (r/props this))
-                :width  (:box-width  (r/props this))}}])}))
+  (let [ref (react/createRef)]
+    (r/create-class
+     {:component-did-mount
+      (fn [this]
+        (let [{:keys [spec layer-click!]} (r/props this)]
+          (render-vega spec layer-click! (.-current ref))))
+      :component-did-update
+      (fn [this _]
+        (let [{:keys [spec layer-click!]} (r/props this)]
+          (render-vega spec layer-click! (.-current ref))))
+      :render
+      (fn [this]
+        [:div#vega-canvas
+         {:ref   ref
+          :style {:height (:box-height (r/props this))
+                  :width  (:box-width  (r/props this))}}])})))
 
 (defn vega-box
   "A function to create a Vega line plot."

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -52,8 +52,8 @@
         x-axis-units         ({:near-term "Hour" :long-term "Year"} @!/*forecast-type)]
     {:width    "container"
      :height   "container"
-     :autosize {:type "fit" :resize true}
-     :padding  {:left "16" :top "16" :right "16" :bottom "16"}
+     :autosize {:type "fit" :resize true :contains "content"}
+     :padding  {:left "16" :top "16" :bottom "16"}
      :data     {:values processed-point-info}
      :layer    [{:encoding {:x       {:field "hour"
                                       :type  "quantitative"

--- a/src/cljs/pyregence/components/vega.cljs
+++ b/src/cljs/pyregence/components/vega.cljs
@@ -134,6 +134,7 @@
         [:div#vega-canvas
          {:ref   ref
           :style {:height (:box-height (r/props this))
+                  :background-color "white"
                   :width  (:box-width  (r/props this))}}])})))
 
 (defn vega-box


### PR DESCRIPTION
## Purpose
Remove deprecated code
```clojure
(rd/dom-node this)
```

And replace with
```clojure
(.-current ref) ;; (let [ref (react/createRef)])
```

Issue: When upgrading to reagent 1.2.0 we’ve started to get deprecation notes when compiling or working with fighweel: reagent.dom/dom-node is deprecated
Fix: re-write code in such a way that fixes the warning.
Reference: re-com [issue](https://github.com/day8/re-com/issues/329)
re-com commit that fixes it: [Merge RolT PR: Removed deprecated usage of react dom node](https://github.com/day8/re-com/commit/e8a9d14)

## Related Issues
Closes PYR1-1011

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
All

#### Role
All

#### Steps
1. Configure the app to run in dev mode (call `bb dev`)
2. Test the app thoroughly. Everything should work as before.
3. Configure the app to run in prod mode (call `bb prod`)
4. Test the app thoroughly. Everything should work as before.
