### PR TITLE
PYR1-1010 Add U.S State and county boundaries optional layers

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -192,7 +192,7 @@
                           (merge-fn (split-isochrones-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)
-                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|conus-buildings|us-transmission-lines|boundaries).*" full-name))
+                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|conus-buildings|us-transmission-lines|.*boundaries).*" full-name))
                           (merge-fn (split-fire-detections full-name))
 
                           (str/starts-with? full-name "fuels")

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -192,7 +192,7 @@
                           (merge-fn (split-isochrones-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)
-                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|conus-buildings|us-transmission-lines).*" full-name))
+                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|conus-buildings|us-transmission-lines|boundaries).*" full-name))
                           (merge-fn (split-fire-detections full-name))
 
                           (str/starts-with? full-name "fuels")

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -33,6 +33,14 @@
 
 (def near-term-forecast-underlays
   (array-map
+   :state-boundaries        {:opt-label     "U.S. States"
+                             :z-index       108
+                             :filter-set    #{"fire-detections" "state-boundaries"}
+                             :geoserver-key :shasta}
+   :county-boundaries       {:opt-label     "U.S. Counties"
+                             :z-index       108
+                             :filter-set    #{"fire-detections" "county-boundaries"}
+                             :geoserver-key :shasta}
    :us-trans-lines          {:opt-label     "Transmission lines"
                              :z-index       107
                              :filter-set    #{"fire-detections" "us-transmission-lines"}


### PR DESCRIPTION
and have them display on top of the other layers.

## Related Issues

Part of PYR1-1010

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing

#### Role
ALL

#### Steps and outcome
Click on U.S State and county boundaries optional layers and have them display. Note that this change alone wont do that.

## Screenshots
![Screenshot from 2025-02-18 12-47-31](https://github.com/user-attachments/assets/34e2fa1c-5896-488c-b624-77b7da4a1420)
