### PR TITLE
DRAFT PYR1-1038

### DIFF
--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -190,6 +190,7 @@
 (defn resize-map!
   "Resizes the map."
   []
+  (println "resize-map! @the-map:" @the-map)
   (when @the-map
     (js-invoke @the-map "resize")))
 

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -875,6 +875,7 @@
           (when (and @mb/the-map
                      (not-empty @!/capabilities)
                      (not-empty @!/*params))
-            [control-layer user-id])
-          [map-layer]
+            [:div
+             [control-layer user-id]
+             [map-layer]])
           [pop-up]]])})))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -823,6 +823,13 @@
                   :text-align    "center"}}
      "Loading..."]]])
 
+(defn the-whole-map-component [user-id map]
+  [:div
+   ;;  pass map in: [control-layer user-id map] because control-layer is the only top level component that uses `the-map`
+   ;; inside of it there are other components that uses `the-map` so we could just pass the value around.
+   [control-layer user-id]
+   [map-layer]])
+
 (defn root-component
   "Component definition for the \"Near Term\" and \"Long Term\" Forecast Pages."
   [{:keys [user-id] :as params}]
@@ -875,6 +882,7 @@
           (when (and @mb/the-map
                      (not-empty @!/capabilities)
                      (not-empty @!/*params))
+            #_[the-whole-map-component user-id @mb/the-map]
             [:div
              [control-layer user-id]
              [map-layer]])


### PR DESCRIPTION
This is just to share some findings...... Feel free to grab this code, experiment, etc ... 

The wrong behavior appears when the following events occur in the order below:

1. :reagent-render: @height: 100%
2. :component-did-mount: @height: 650px
3. "init-map!:" fn is called (will resize the map to "100%" aka 32px)
4. :reagent-render @height: 650px

If the events occur in the following order, which is more regular, then the map loads normally:

1. :reagent-render: @height: 100%
2. :component-did-mount: @height: 650px
4. :reagent-render @height: 650px
3. "init-map!:" fn is called (will resize the map to 650px correctly because the component has already be rendered with this size)

The proposal is to defer loading the map after the 2nd :reagent-render