### PR TITLE
PYR1-1038/Improve Mapbox resizing

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -94,7 +94,7 @@
   (with-meta
     {:display         "flex"
      :flex-direction  "column"
-     :height          "calc(100% - 3.25rem)"
+     :height          "100%"
      :justify-content "space-between"
      :overflow-y      "auto"}
     {:pseudo {:last-child {:padding-bottom "0.75rem"}}}))
@@ -304,42 +304,49 @@
     (fn [*params select-param! underlays]
       (let [selected-param-set (->> *params (vals) (filter keyword?) (set))]
         [:div#collapsible-panel {:style ($collapsible-panel @!/show-panel?)}
-         [collapsible-panel-toggle]
-         [collapsible-panel-header]
-         [:div#collapsible-panel-body {:class (<class $collapsible-panel-body)}
-          [:div#section-wrapper
+         [:div {:style {:display "flex"
+                        :flex-direction "column"
+                        :justify-content "space-between"
+                        :overflow-y "auto"
+                        :height "100%"}}
+          [:div
+           [collapsible-panel-toggle]
+           [collapsible-panel-header]
+           [:div#collapsible-panel-body {:class (<class $collapsible-panel-body)}
+            [:div#section-wrapper
+             [collapsible-panel-section
+              "layer-selection"
+              [:<>
+               (map (fn [[key {:keys [opt-label hover-text options sort? disabled]}]]
+                      (let [sorted-options (if sort? (sort-by (comp :opt-label second) options) options)]
+                        ^{:key (str (random-uuid))}
+                        [:<>
+                         [panel-dropdown
+                          opt-label
+                          hover-text
+                          (get *params key)
+                          sorted-options
+                          (cond (ifn? disabled)     (disabled *params)
+                                (boolean? disabled) disabled
+                                :else               (= 1 (count sorted-options)))
+                          #(select-param! % key)
+                          selected-param-set]]))
+                    @!/processed-params)
+               [opacity-input]]]
+             [collapsible-panel-section
+              "optional-layers"
+              [optional-layers
+               underlays]]
+             [collapsible-panel-section
+              "base-map"
+              [panel-dropdown
+               "Base Map"
+               "Provided courtesy of Mapbox, we offer three map views. Select from the dropdown menu according to your preference."
+               @*base-map
+               (c/base-map-options)
+               false
+               select-base-map!]]]]]
+          [:div {:style {:padding-bottom "0.75rem"}}
            [collapsible-panel-section
-            "layer-selection"
-            [:<>
-             (map (fn [[key {:keys [opt-label hover-text options sort? disabled]}]]
-                    (let [sorted-options (if sort? (sort-by (comp :opt-label second) options) options)]
-                      ^{:key (str (random-uuid))}
-                      [:<>
-                       [panel-dropdown
-                        opt-label
-                        hover-text
-                        (get *params key)
-                        sorted-options
-                        (cond (ifn? disabled)     (disabled *params)
-                              (boolean? disabled) disabled
-                              :else               (= 1 (count sorted-options)))
-                        #(select-param! % key)
-                        selected-param-set]]))
-                  @!/processed-params)
-             [opacity-input]]]
-           [collapsible-panel-section
-            "optional-layers"
-            [optional-layers
-             underlays]]
-           [collapsible-panel-section
-            "base-map"
-            [panel-dropdown
-             "Base Map"
-             "Provided courtesy of Mapbox, we offer three map views. Select from the dropdown menu according to your preference."
-             @*base-map
-             (c/base-map-options)
-             false
-             select-base-map!]]]
-          [collapsible-panel-section
-           "help"
-           [help-section]]]]))))
+            "help"
+            [help-section]]]]]))))

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -903,4 +903,5 @@
      "load"
      (fn []
        (reset! the-map the-map*)
-       (on-load-fn)))))
+       (on-load-fn)
+       (.resize ^js the-map*)))))

--- a/src/cljs/pyregence/components/page_layout.cljs
+++ b/src/cljs/pyregence/components/page_layout.cljs
@@ -60,7 +60,9 @@
   [root-component & {:keys [footer?]}]
   (process-toast-messages!)
   (fn [_]
-    [:<>
+    [:div {:style {:display        :flex
+                   :flex-direction :column
+                   :height         "100%"}}
      [header]
      [toast-message]
      [root-component]

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -824,46 +824,39 @@
 (defn root-component
   "Component definition for the \"Near Term\" and \"Long Term\" Forecast Pages."
   [{:keys [user-id] :as params}]
-  (let [height (r/atom "100%")]
-    (r/create-class
-     {:component-did-mount
-      (fn [_]
-        (let [update-fn (fn [& _]
-                          (-> js/window (.scrollTo 0 0))
-                          (reset! !/mobile? (> 800.0 (.-innerWidth js/window)))
-                          (reset! height  (str (- (.-innerHeight js/window)
-                                                  (-> js/document
-                                                      (.getElementById "header")
-                                                      .getBoundingClientRect
-                                                      (aget "height")))
-                                               "px"))
-                          (js/setTimeout mb/resize-map! 50))]
-          (-> js/window (.addEventListener "touchend" update-fn))
-          (-> js/window (.addEventListener "resize"   update-fn))
-          (initialize! params)
-          (update-fn)))
-      :reagent-render
-      (fn [_]
-        [:div#near-term-forecast
-         {:style ($/combine $/root {:height @height :padding 0 :position "relative" :overflow :hidden})}
-         [message-box-modal]
-         (when @!/loading? [loading-modal])
-         [message-modal]
-         [nav-bar {:capabilities     @!/capabilities
-                   :current-forecast @!/*forecast
-                   :is-admin?        (->> @!/user-orgs-list
-                                          (filter #(= "admin" (:role %)))
-                                          (count)
-                                          (< 0)) ; admin of at least one org
-                   :logged-in?       user-id
-                   :mobile?          @!/mobile?
-                   :user-orgs-list   @!/user-orgs-list
-                   :select-forecast! select-forecast!
-                   :user-id          user-id}]
-         [:div {:style {:height "100%" :position "relative" :width "100%"}}
-          (when (and @mb/the-map
-                     (not-empty @!/capabilities)
-                     (not-empty @!/*params))
-            [control-layer user-id])
-          [map-layer]
-          [pop-up]]])})))
+  (r/create-class
+   {:component-did-mount
+    (fn [_]
+      (let [update-fn (fn [& _]
+                        (-> js/window (.scrollTo 0 0))
+                        (reset! !/mobile? (> 800.0 (.-innerWidth js/window)))
+                        (js/setTimeout mb/resize-map! 50))]
+        (-> js/window (.addEventListener "touchend" update-fn))
+        (-> js/window (.addEventListener "resize"   update-fn))
+        (initialize! params)
+        (update-fn)))
+    :reagent-render
+    (fn [_]
+      [:div#near-term-forecast
+       {:style ($/combine $/root {:height "100%" :padding 0 :position "relative" :overflow :hidden})}
+       [message-box-modal]
+       (when @!/loading? [loading-modal])
+       [message-modal]
+       [nav-bar {:capabilities     @!/capabilities
+                 :current-forecast @!/*forecast
+                 :is-admin?        (->> @!/user-orgs-list
+                                        (filter #(= "admin" (:role %)))
+                                        (count)
+                                        (< 0)) ; admin of at least one org
+                 :logged-in?       user-id
+                 :mobile?          @!/mobile?
+                 :user-orgs-list   @!/user-orgs-list
+                 :select-forecast! select-forecast!
+                 :user-id          user-id}]
+       [:div {:style {:height "100%" :position "relative" :width "100%"}}
+        (when (and @mb/the-map
+                   (not-empty @!/capabilities)
+                   (not-empty @!/*params))
+          [control-layer user-id])
+        [map-layer]
+        [pop-up]]])}))

--- a/src/cljs/pyregence/styles.cljs
+++ b/src/cljs/pyregence/styles.cljs
@@ -56,6 +56,7 @@
 (defglobal general
   [:* {:box-sizing "border-box"}]
 
+  [:html {:height "100%"}]
   [:label {:font-size     "1rem"
            :font-weight   "bold"
            :margin-bottom "0"}])
@@ -64,6 +65,7 @@
   [:body {:background-color (color-picker :white)
           :height           "100%"
           :position         "relative"}]
+  [:body>section {:height "100%"}]
   [:#app {:height "100%"}]
   [:#near-term-forecast {:display        "flex"
                          :flex-direction "column"


### PR DESCRIPTION
This commit improves mapbox resizing story by calling `mapbox.resize` after mapbox loads, as opposed to on a timer which could be wrong, and by allowing the mapbox's html tag's parent height to be 100% instead of calculating it via the innerHeight.

My gut says the less Javascript involved in timing and styling the better off the browser will behave in general, and testing so far seems to show parity. However, as it's hard to test the actual problem this commit is meant to address (when the map partially loads) however, the jury is still out on how useful this change is overall.

Setting the height to 100% in the html tree necessitated some changes to the collapsible panel tree such that the "help-section" could maintain it's position at the bottom of the page.

## Testing

To reiterate, with an emphasis on testing, it's hard to test this constantly because I believe the issue was a race condition, but I'm not aware of an easy way to capture the state at various points to confirm that. What I saw was that the mapbox element would set it's height it's parent container, which in turn would be smaller then we wanted, and be set by javascript trying to figure out the height. So my intution, is that setting the height to 100% and calling "resize" after the map loads, will mean that mapbox will resize to 100% of it's parent container, which always be what we want as opposed to sometimes not being the javascript height of the window at 50ms after the component mounts. 


