### PR TITLE
Improve dir locals

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,4 @@
-((nil . ((cider-default-cljs-repl . figwheel-main)
+((nil . ((cider-preferred-build-tool . clojure-cli)
+         (cider-default-cljs-repl . figwheel-main)
          (cider-figwheel-main-default-options . "compile-dev")
-         (cider-clojure-cli-global-options . "-A:figwheel-lib"))))
+         (cider-clojure-cli-aliases . "figwheel-lib"))))


### PR DESCRIPTION
By using `cider-clojure-cli-aliases` which isn't deprecated & picking
the build tool so that the user doesn't have to.