### PR TITLE
PYR1-1074 Now the tooltip for admin correctly displays under the admin pic

### DIFF
--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -39,7 +39,7 @@
           [arrow-y tip-y] (condp #(%1 %2) arrow-position
                             #{:left :right}
                             (let [sibling-y (+ (aget sibling-box "y") (/ (aget sibling-box "height") 2))]
-                              [(- sibling-y 4.7) (+ (- sibling-y (/ tool-height 2)) 4.7)])
+                              [(+ sibling-y 4.7) (+ (- sibling-y (/ tool-height 2)) 9.4)])
 
                             #{:top}
                             (let [sibling-y (+ (aget sibling-box "y") (aget sibling-box "height"))]

--- a/src/cljs/pyregence/components/login_menu.cljs
+++ b/src/cljs/pyregence/components/login_menu.cljs
@@ -17,11 +17,10 @@
           [tool-tip-wrapper
            "Visit the admin page"
            :top
-           [:a {:style      ($/combine ($/fixed-size "1.5rem")
-                                       {:cursor "pointer" :margin-right "1rem"})
+           [:a {:style      {:cursor "pointer" :margin-right "1rem"}
                 :aria-label "Visit the admin page"
                 :href       "/admin"}
-            [svg/admin-user]]])
+            [svg/admin-user :height "25px"]]])
         [:label {:style    {:cursor "pointer" :margin ".16rem .2rem 0 0"}
                  :on-click (fn []
                              (go (<! (u-async/call-clj-async! "log-out"))


### PR DESCRIPTION
This commit has two small changes to the tooltips: 

first the admin tooltip is properly displaying under it:

Before:

![image](https://github.com/user-attachments/assets/cbdb9837-e233-4350-acb6-a3a155dd848f)

After:

![image](https://github.com/user-attachments/assets/483099da-66ae-492e-aaeb-9750eee37ac7)

Secondly, the all the tooltips are more aligned:

Before:
![before-align](https://github.com/user-attachments/assets/f1d5de19-ac06-4a77-b303-11b131808c6a)


After:
![after-align](https://github.com/user-attachments/assets/74b64809-0f4e-44c8-8095-2467e256faf6)
