### PR TITLE
PYR1-1080  Add dev-norepl to bb to start without repl as an option

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -32,6 +32,10 @@
                  (run 'install)
                  (run 'functions)
                  (clojure "-M:default-ssl-opts:figwheel"))
+  dev-norepl    (do
+                  (run 'install)
+                  (run 'functions)
+                  (shell "clojure -M:default-ssl-opts:figwheel-lib -m figwheel.main -b \"compile-dev\""))
   install      (shell "npm install")
   deploy       (do
                  (run 'stop)


### PR DESCRIPTION
## Purpose

We add an option to start the cljs compilation/figwheel server in dev mode without having to start the repl for folks who don't want repl or experiencing weird timeout errors when repl is on (like me). 

## Related Issues
Closes PYR1-1080

