### PR TITLE
PYR1-1034 add :ca-fuelscapes-2021

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -205,6 +205,8 @@
                                                                               :disabled-for #{:asp :slp :dem}}
                                                        :ca-fuelscapes        {:opt-label "2022 CA fuelscape"
                                                                               :filter    "ca-2022-fuelscape"}
+                                                       :ca-fuelscapes-2021   {:opt-label "2021 CA fuelscape"
+                                                                              :filter    "ca-2021-fuelscape"}
                                                        :fire-factor          {:opt-label   "Fire Factor 2022"
                                                                               :filter      "fire-factor-2022"
                                                                               :disabled-for #{:asp :slp :dem}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -69,150 +69,150 @@
                   :underlays     (merge common-underlays near-term-forecast-underlays)
                   :time-slider?  false
                   :hover-text    "Layers related to fuel and potential fire behavior."
-                  :params        {:layer {:opt-label  "Layer"
-                                          :hover-text [:p {:style {:margin-bottom "0"}}
-                                                       "Geospatial surface and canopy fuel inputs, forecasted ember ignition probability and head fire spread rate & flame length."
-                                                       [:br]
-                                                       [:br]
-                                                       "Use the "
-                                                       [:strong "Point Information"]
-                                                       " tool for more detailed information about a selected point."]
-                                          :options    (array-map
-                                                       :fbfm40 {:opt-label       "Fire Behavior Fuel Model 40"
-                                                                :filter          "fbfm40"
-                                                                :units           ""
-                                                                :reverse-legend? false}
-                                                       :asp    {:opt-label       "Aspect"
-                                                                :filter          "asp"
-                                                                :units           ""
-                                                                :convert         #(str (u-misc/direction %) " (" % "°)")
-                                                                :reverse-legend? false
-                                                                :disabled-for    #{:cecs :cfo :fire-factor :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
-                                                       :slp    {:opt-label       "Slope (degrees)"
-                                                                :filter          "slp"
-                                                                :units           "\u00B0"
-                                                                :reverse-legend? true
-                                                                :disabled-for    #{:cecs :cfo :fire-factor :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
-                                                       :dem    {:opt-label       "Elevation (ft)"
-                                                                :filter          "dem"
-                                                                :units           "ft"
-                                                                :convert         #(u-num/to-precision 1 (* % 3.28084))
-                                                                :reverse-legend? true
-                                                                :disabled-for    #{:cecs :cfo :fire-factor :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
-                                                       :cc     {:opt-label       "Canopy Cover (%)"
-                                                                :filter          "cc"
-                                                                :units           "%"
-                                                                :reverse-legend? true
-                                                                :disabled-for    #{:cecs}}
-                                                       :ch     {:opt-label       "Canopy Height (m)"
-                                                                :filter          "ch"
-                                                                :units           "m"
-                                                                :no-convert      #{:cfo}
-                                                                :convert         #(u-num/to-precision 1 (/ % 10))
-                                                                :reverse-legend? true
-                                                                :disabled-for    #{:cecs}}
-                                                       :cbh    {:opt-label       "Canopy Base Height (m)"
-                                                                :filter          "cbh"
-                                                                :units           "m"
-                                                                :no-convert      #{:cfo}
-                                                                :convert         #(u-num/to-precision 1 (/ % 10))
-                                                                :reverse-legend? true
-                                                                :disabled-for    #{:cecs}}
-                                                       :cbd    {:opt-label       "Crown Bulk Density (kg/m\u00b3)"
-                                                                :filter          "cbd"
-                                                                :units           "kg/m\u00b3"
-                                                                :convert         #(u-num/to-precision 2 (/ % 100))
-                                                                :no-convert      #{:cfo}
-                                                                :reverse-legend? true
-                                                                :disabled-for    #{:cecs}})}
-                                  :model {:opt-label  "Source"
-                                          :hover-text [:p {:style {:margin-bottom "0"}}
-                                                       [:strong "LANDFIRE"]
-                                                       " –  Stock data provided by "
-                                                       [:a {:href   "https://landfire.gov"
-                                                            :target "_blank"}
-                                                        "LANDFIRE"]
-                                                       " at 30 m resolution. For more detailed version descriptions, please visit "
-                                                       [:a {:href "https://landfire.gov/version_download.php"
-                                                            :target "_blank"}
-                                                        "this link"]
-                                                       " and click the \"LF Version Descriptions\" button."
-                                                       [:br]
-                                                       [:br]
-                                                       [:strong "California Forest Observatory"]
-                                                       " – Summer 2020 at 10 m resolution. Courtesy of the California Forest Observatory ("
-                                                       [:a {:href   "https://forestobservatory.com"
-                                                            :target "_blank"}
-                                                        "https://forestobservatory.com"]
-                                                       "), © Salo Sciences, Inc. 2020."
-                                                       [:br]
-                                                       [:br]
-                                                       [:strong "2022 California fuelscape"]
-                                                       " prepared by Pyrologix, LLC ("
-                                                       [:a {:href   "https://pyrologix.com"
-                                                            :target "_blank"}
-                                                        "https://pyrologix.com"]
-                                                       "), 2022."
-                                                       [:br]
-                                                       [:br]
-                                                       [:strong "Fire Factor 2022\u2122"]
-                                                       " -  Data provided by "
-                                                       [:a {:href   "https://riskfactor.com/methodology/fire"
-                                                            :target "_blank"}
-                                                        "Fire Factor"]
-                                                       ", which uses the "
-                                                       [:a {:href   "https://www.mdpi.com/2571-6255/5/4/117"
-                                                            :target "_blank"}
-                                                        "First Street Foundation Wildfire Model"]
-                                                       "."
-                                                       [:br]
-                                                       [:br]
-                                                       [:strong "California Ecosystem Climate Solutions"]
-                                                       " - Data provided by the "
-                                                       [:a {:href   "https://california-ecosystem-climate.solutions/"
-                                                            :target "_blank"}
-                                                        "California Ecosystem Climate Solutions"]
-                                                       ", Wang et al. (2021)."]
-                                          :options    (array-map
-                                                       :landfire-2.4.0-2.3.0 {:opt-label    "LANDFIRE 2.4.0/2.3.0 (2024/2023 capable)"
-                                                                              :filter       "landfire-2.4.0-2.3.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-2.4.0       {:opt-label    "LANDFIRE 2.4.0 (2024 capable)"
-                                                                              :filter       "landfire-2.4.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-2.3.0       {:opt-label    "LANDFIRE 2.3.0 (2023 capable)"
-                                                                              :filter       "landfire-2.3.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-2.2.0       {:opt-label "LANDFIRE 2.2.0 (2021 capable)"
-                                                                              :filter    "landfire-2.2.0"}
-                                                       :landfire-2.1.0       {:opt-label    "LANDFIRE 2.1.0 (2020 capable)"
-                                                                              :filter       "landfire-2.1.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-2.0.0       {:opt-label    "LANDFIRE 2.0.0 (2019 capable)"
-                                                                              :filter       "landfire-2.0.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-1.4.0       {:opt-label    "LANDFIRE 1.4.0 (2016 capable)"
-                                                                              :filter       "landfire-1.4.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-1.3.0       {:opt-label    "LANDFIRE 1.3.0 (2014 capable)"
-                                                                              :filter       "landfire-1.3.0"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :landfire-1.0.5       {:opt-label    "LANDFIRE 1.0.5 (~2008 capable)"
-                                                                              :filter       "landfire-1.0.5"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :cfo                  {:opt-label    "California Forest Obs."
-                                                                              :filter       "cfo-2020"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :ca-fuelscapes-2022        {:opt-label "2022 CA fuelscape"
-                                                                              :filter    "ca-2022-fuelscape"}
-                                                       :ca-fuelscapes-2021   {:opt-label "2021 CA fuelscape"
-                                                                              :filter    "ca-2021-fuelscape"}
-                                                       :fire-factor          {:opt-label   "Fire Factor 2022"
-                                                                              :filter      "fire-factor-2022"
-                                                                              :disabled-for #{:asp :slp :dem}}
-                                                       :cecs                 {:opt-label    "CA Ecosystem Climate Solutions"
-                                                                              :filter       "cecs"
-                                                                              :disabled-for #{:asp :slp :dem :cc :ch :cbh :cbd}})}
+                  :params        {:layer      {:opt-label  "Layer"
+                                               :hover-text [:p {:style {:margin-bottom "0"}}
+                                                            "Geospatial surface and canopy fuel inputs, forecasted ember ignition probability and head fire spread rate & flame length."
+                                                            [:br]
+                                                            [:br]
+                                                            "Use the "
+                                                            [:strong "Point Information"]
+                                                            " tool for more detailed information about a selected point."]
+                                               :options    (array-map
+                                                            :fbfm40 {:opt-label       "Fire Behavior Fuel Model 40"
+                                                                     :filter          "fbfm40"
+                                                                     :units           ""
+                                                                     :reverse-legend? false}
+                                                            :asp    {:opt-label       "Aspect"
+                                                                     :filter          "asp"
+                                                                     :units           ""
+                                                                     :convert         #(str (u-misc/direction %) " (" % "°)")
+                                                                     :reverse-legend? false
+                                                                     :disabled-for    #{:cecs :cfo :fire-factor :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
+                                                            :slp    {:opt-label       "Slope (degrees)"
+                                                                     :filter          "slp"
+                                                                     :units           "\u00B0"
+                                                                     :reverse-legend? true
+                                                                     :disabled-for    #{:cecs :cfo :fire-factor :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
+                                                            :dem    {:opt-label       "Elevation (ft)"
+                                                                     :filter          "dem"
+                                                                     :units           "ft"
+                                                                     :convert         #(u-num/to-precision 1 (* % 3.28084))
+                                                                     :reverse-legend? true
+                                                                     :disabled-for    #{:cecs :cfo :fire-factor :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
+                                                            :cc     {:opt-label       "Canopy Cover (%)"
+                                                                     :filter          "cc"
+                                                                     :units           "%"
+                                                                     :reverse-legend? true
+                                                                     :disabled-for    #{:cecs}}
+                                                            :ch     {:opt-label       "Canopy Height (m)"
+                                                                     :filter          "ch"
+                                                                     :units           "m"
+                                                                     :no-convert      #{:cfo}
+                                                                     :convert         #(u-num/to-precision 1 (/ % 10))
+                                                                     :reverse-legend? true
+                                                                     :disabled-for    #{:cecs}}
+                                                            :cbh    {:opt-label       "Canopy Base Height (m)"
+                                                                     :filter          "cbh"
+                                                                     :units           "m"
+                                                                     :no-convert      #{:cfo}
+                                                                     :convert         #(u-num/to-precision 1 (/ % 10))
+                                                                     :reverse-legend? true
+                                                                     :disabled-for    #{:cecs}}
+                                                            :cbd    {:opt-label       "Crown Bulk Density (kg/m\u00b3)"
+                                                                     :filter          "cbd"
+                                                                     :units           "kg/m\u00b3"
+                                                                     :convert         #(u-num/to-precision 2 (/ % 100))
+                                                                     :no-convert      #{:cfo}
+                                                                     :reverse-legend? true
+                                                                     :disabled-for    #{:cecs}})}
+                                  :model      {:opt-label  "Source"
+                                               :hover-text [:p {:style {:margin-bottom "0"}}
+                                                            [:strong "LANDFIRE"]
+                                                            " –  Stock data provided by "
+                                                            [:a {:href   "https://landfire.gov"
+                                                                 :target "_blank"}
+                                                             "LANDFIRE"]
+                                                            " at 30 m resolution. For more detailed version descriptions, please visit "
+                                                            [:a {:href   "https://landfire.gov/version_download.php"
+                                                                 :target "_blank"}
+                                                             "this link"]
+                                                            " and click the \"LF Version Descriptions\" button."
+                                                            [:br]
+                                                            [:br]
+                                                            [:strong "California Forest Observatory"]
+                                                            " – Summer 2020 at 10 m resolution. Courtesy of the California Forest Observatory ("
+                                                            [:a {:href   "https://forestobservatory.com"
+                                                                 :target "_blank"}
+                                                             "https://forestobservatory.com"]
+                                                            "), © Salo Sciences, Inc. 2020."
+                                                            [:br]
+                                                            [:br]
+                                                            [:strong "2022 California fuelscape"]
+                                                            " prepared by Pyrologix, LLC ("
+                                                            [:a {:href   "https://pyrologix.com"
+                                                                 :target "_blank"}
+                                                             "https://pyrologix.com"]
+                                                            "), 2022."
+                                                            [:br]
+                                                            [:br]
+                                                            [:strong "Fire Factor 2022\u2122"]
+                                                            " -  Data provided by "
+                                                            [:a {:href   "https://riskfactor.com/methodology/fire"
+                                                                 :target "_blank"}
+                                                             "Fire Factor"]
+                                                            ", which uses the "
+                                                            [:a {:href   "https://www.mdpi.com/2571-6255/5/4/117"
+                                                                 :target "_blank"}
+                                                             "First Street Foundation Wildfire Model"]
+                                                            "."
+                                                            [:br]
+                                                            [:br]
+                                                            [:strong "California Ecosystem Climate Solutions"]
+                                                            " - Data provided by the "
+                                                            [:a {:href   "https://california-ecosystem-climate.solutions/"
+                                                                 :target "_blank"}
+                                                             "California Ecosystem Climate Solutions"]
+                                                            ", Wang et al. (2021)."]
+                                               :options    (array-map
+                                                            :landfire-2.4.0-2.3.0 {:opt-label    "LANDFIRE 2.4.0/2.3.0 (2024/2023 capable)"
+                                                                                   :filter       "landfire-2.4.0-2.3.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-2.4.0       {:opt-label    "LANDFIRE 2.4.0 (2024 capable)"
+                                                                                   :filter       "landfire-2.4.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-2.3.0       {:opt-label    "LANDFIRE 2.3.0 (2023 capable)"
+                                                                                   :filter       "landfire-2.3.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-2.2.0       {:opt-label "LANDFIRE 2.2.0 (2021 capable)"
+                                                                                   :filter    "landfire-2.2.0"}
+                                                            :landfire-2.1.0       {:opt-label    "LANDFIRE 2.1.0 (2020 capable)"
+                                                                                   :filter       "landfire-2.1.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-2.0.0       {:opt-label    "LANDFIRE 2.0.0 (2019 capable)"
+                                                                                   :filter       "landfire-2.0.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-1.4.0       {:opt-label    "LANDFIRE 1.4.0 (2016 capable)"
+                                                                                   :filter       "landfire-1.4.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-1.3.0       {:opt-label    "LANDFIRE 1.3.0 (2014 capable)"
+                                                                                   :filter       "landfire-1.3.0"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :landfire-1.0.5       {:opt-label    "LANDFIRE 1.0.5 (~2008 capable)"
+                                                                                   :filter       "landfire-1.0.5"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :cfo                  {:opt-label    "California Forest Obs."
+                                                                                   :filter       "cfo-2020"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :ca-fuelscapes-2022   {:opt-label "2022 CA fuelscape"
+                                                                                   :filter    "ca-2022-fuelscape"}
+                                                            :ca-fuelscapes-2021   {:opt-label "2021 CA fuelscape"
+                                                                                   :filter    "ca-2021-fuelscape"}
+                                                            :fire-factor          {:opt-label    "Fire Factor 2022"
+                                                                                   :filter       "fire-factor-2022"
+                                                                                   :disabled-for #{:asp :slp :dem}}
+                                                            :cecs                 {:opt-label    "CA Ecosystem Climate Solutions"
+                                                                                   :filter       "cecs"
+                                                                                   :disabled-for #{:asp :slp :dem :cc :ch :cbh :cbd}})}
                                   :model-init {:opt-label  "Model Creation Time"
                                                :hover-text "Time the data was created."
                                                :options    {:loading {:opt-label "Loading..."}}}}}
@@ -340,8 +340,8 @@
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
                                                                               :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd}}
-                                                              :hrrr          {:opt-label    "HRRR"
-                                                                              :filter       "hrrr"}
+                                                              :hrrr          {:opt-label "HRRR"
+                                                                              :filter    "hrrr"}
                                                               :hybrid        {:opt-label    "Hybrid"
                                                                               :filter       "hybrid"
                                                                               :disabled-for #{:apcptot :smoke :tcdc}}
@@ -432,15 +432,15 @@
                                                               [:br]
                                                               [:strong "Transmission Lines"]
                                                               " - Fires ignited in close proximity to overhead electrical transmission lines."]
-                                                 :options    {:all        {:opt-label    "All-cause fires"
-                                                                           :auto-zoom?   true
-                                                                           :filter       "all"
-                                                                           :disabled-for #{:plignrate}}
-                                                              :tlines     {:opt-label    "Transmission lines"
-                                                                           :auto-zoom?   true
-                                                                           :filter       "tlines"
-                                                                           :clear-point? true
-                                                                           :disabled-for #{:plignrate :crown-fire-area}}}}
+                                                 :options    {:all    {:opt-label    "All-cause fires"
+                                                                       :auto-zoom?   true
+                                                                       :filter       "all"
+                                                                       :disabled-for #{:plignrate}}
+                                                              :tlines {:opt-label    "Transmission lines"
+                                                                       :auto-zoom?   true
+                                                                       :filter       "tlines"
+                                                                       :clear-point? true
+                                                                       :disabled-for #{:plignrate :crown-fire-area}}}}
                                     :fuel       {:opt-label  "Fuel"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Source of surface and canopy fuel inputs:"
@@ -450,7 +450,7 @@
                                                                    :target "_blank"}
                                                                "LANDFIRE"]
                                                               " 2.3.0/2.2.0 at 30 m resolution. For more detailed version descriptions, please visit "
-                                                              [:a {:href "https://landfire.gov/version_download.php"
+                                                              [:a {:href   "https://landfire.gov/version_download.php"
                                                                    :target "_blank"}
                                                                "this link"]
                                                               " and click the \"LF Version Descriptions\" button."]
@@ -490,12 +490,12 @@
                                                  :sort?          true
                                                  :hover-text     "Provides a list of active fires for which forecasts are available. To zoom to a specific fire, select it from the dropdown menu."
                                                  :default-option :active-fires
-                                                 :options        {:active-fires    {:opt-label     "*All Active Fires"
-                                                                                    :style-fn      :default
-                                                                                    :filter-set    #{"fire-detections" "active-fires"}
-                                                                                    :auto-zoom?    true
-                                                                                    :time-slider?  false
-                                                                                    :geoserver-key :shasta}}}
+                                                 :options        {:active-fires {:opt-label     "*All Active Fires"
+                                                                                 :style-fn      :default
+                                                                                 :filter-set    #{"fire-detections" "active-fires"}
+                                                                                 :auto-zoom?    true
+                                                                                 :time-slider?  false
+                                                                                 :geoserver-key :shasta}}}
                                     :output     {:opt-label  "Output"
                                                  :hover-text "Available outputs are fire location, crown fire type (surface fire, passive, or active), flame length (ft), and surface fire spread rate (ft/min). Time can be advanced with the slider centered below."
                                                  :options    {:burned       {:opt-label       "Forecasted fire location"
@@ -644,7 +644,6 @@
                                                               :pign  {:opt-label    "Firebrand ignition probability (%)"
                                                                       :units        "%"
                                                                       :disabled-for #{:m}})}
-
                                     :statistic  {:opt-label      "Statistic"
                                                  :hover-text     "Options are minimum, mean, or maximum."
                                                  :default-option :a

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -203,7 +203,7 @@
                                                        :cfo                  {:opt-label    "California Forest Obs."
                                                                               :filter       "cfo-2020"
                                                                               :disabled-for #{:asp :slp :dem}}
-                                                       :ca-fuelscapes        {:opt-label "2022 CA fuelscape"
+                                                       :ca-fuelscapes-2022        {:opt-label "2022 CA fuelscape"
                                                                               :filter    "ca-2022-fuelscape"}
                                                        :ca-fuelscapes-2021   {:opt-label "2021 CA fuelscape"
                                                                               :filter    "ca-2021-fuelscape"}


### PR DESCRIPTION
## Purpose
Add new source fuel layers

## Related Issues
Closes PYR1-1034
Original files can also be downloaded from the jira ticket (https://sig-gis.atlassian.net/browse/PYR1-1034?focusedCommentId=17573) but are the below:
- [ca-2022](https://www.dropbox.com/scl/fi/vh699cvp7841h33oo9mcm/CAL2022_FireSeasonFuelscape_20220502.zip?rlkey=7bvicerizwfnlk8zbd499sw6b&e=2&st=ghidexyr&dl=0)
- [ca-2021](https://www.dropbox.com/scl/fi/2ljk7irmaqjiyxxyom6lz/CAL2021_FireSeasonFuelscape_20210527.zip?rlkey=7ldk1ahjo0bsw07fe89asatqw&st=7x1mdjbc&dl=0)

After downloading them, I've kept only the .tif ones and renamed them to asp.tif, cbd.tif etc.

See https://sig-gis.atlassian.net/browse/PYR1-1034?focusedCommentId=17573 
transcprition:
> Since the original files were not recognized by the geoserver, I had to "manually" change the files in order for it to work:
In summary:
SHASTA:
Original files: kept in dsilva@shasta:/home/dsilva/CAL2021/original/ and dsilva@shasta:/home/dsilva/CAL2022/original/
Modified files (after calling gdal_edit.py): kept in dsilva@shasta:/home/dsilva/CAL2021/modified/ and dsilva@shasta:/home/dsilva/CAL2022/modified/
Modified files are the original ones after calling:
Calls:
gdal_edit.py -a_srs EPSG:3310 asp.tif
gdal_edit.py -a_srs EPSG:3310 cbd.tif
gdal_edit.py -a_srs EPSG:3310 cbh.tif
gdal_edit.py -a_srs EPSG:3310 cc.tif
gdal_edit.py -a_srs EPSG:3310 ch.tif
gdal_edit.py -a_srs EPSG:3310 dem.tif
gdal_edit.py -a_srs EPSG:3310 fbfm40.tif
gdal_edit.py -a_srs EPSG:3310 slp.tif
Then removed the fuels-and-topography_ca-202*-fuelscape workspaces via the web UI (https://shasta.pyregence.org/geoserver/web)
Then called /opt/geosync-scripts/shasta/sync-layers.sh -s fuels_and_topography

Backed the files up: (https://sig-gis.atlassian.net/browse/PYR1-1034?focusedCommentId=17576)
```bash
dsilva@shasta:/mnt/tahoe/wg3/fuels_and_topography$ ls -a *work* -l
ca-2021-fuelscape-working:
total 2216415
drwxrwxr-x  2 sig-app domain users        10 Mar 14 16:01 .
drwxrwxr-x 19 sig-app domain users        19 Mar 14 16:00 ..
-rwxrwxr-x  1 sig-app domain users 632972044 Mar 14 16:01 asp.tif
-rwxrwxr-x  1 sig-app domain users 132987860 Mar 14 16:01 cbd.tif
-rwxrwxr-x  1 sig-app domain users 141612184 Mar 14 16:01 cbh.tif
-rwxrwxr-x  1 sig-app domain users 184025484 Mar 14 16:01 cc.tif
-rwxrwxr-x  1 sig-app domain users 171087760 Mar 14 16:01 ch.tif
-rwxrwxr-x  1 sig-app domain users 624509712 Mar 14 16:01 dem.tif
-rwxrwxr-x  1 sig-app domain users 171890688 Mar 14 16:01 fbfm40.tif
-rwxrwxr-x  1 sig-app domain users 352464728 Mar 14 16:01 slp.tif
ca-2022-fuelscape-working:
total 2163213
drwxrwxr-x  2 sig-app domain users        10 Mar 14 16:02 .
drwxrwxr-x 19 sig-app domain users        19 Mar 14 16:00 ..
-rwxrwxr-x  1 sig-app domain users 596774502 Mar 14 16:01 asp.tif
-rwxrwxr-x  1 sig-app domain users 132113624 Mar 14 16:01 cbd.tif
-rwxrwxr-x  1 sig-app domain users 143921616 Mar 14 16:01 cbh.tif
-rwxrwxr-x  1 sig-app domain users 181832028 Mar 14 16:01 cc.tif
-rwxrwxr-x  1 sig-app domain users 170619682 Mar 14 16:01 ch.tif
-rwxrwxr-x  1 sig-app domain users 624320020 Mar 14 16:02 dem.tif
-rwxrwxr-x  1 sig-app domain users 173529008 Mar 14 16:02 fbfm40.tif
-rwxrwxr-x  1 sig-app domain users 334104422 Mar 14 16:02 slp.tif
```

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Fuels

#### Role
All

#### Steps
1. Click `fuels tab`
2. Click `2021 CA fuelscape` in `Source` and see the layer appears
3. Click `2022 CA fuelscape` in `Source` and see the layer appears

#### Desired Outcome
Both layers work

## Screenshots
2022:

![image](https://github.com/user-attachments/assets/38cb2e6e-86f0-45c4-aec9-692901047671)

2021

![image](https://github.com/user-attachments/assets/5da15bf2-74f0-4849-9192-94f48e4cf825)
