### PR TITLE
PYR1-1081 Fixing the red flag layer

### DIFF
--- a/src/clj/pyregence/red_flag.clj
+++ b/src/clj/pyregence/red_flag.clj
@@ -13,7 +13,7 @@
 ;; Constants
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def ^:private hazards-url   "https://www.wrh.noaa.gov/map/json/WR_All_Hazards.json")
+(def ^:private hazards-url   "https://www.weather.gov/source/wrh/hazards/json/WR_All_Hazards.json")
 (def ^:private cache-max-age (* 60 1000)) ; Once an hour
 (def ^:private keep-hazards  #{"FW" "Fire Weather"})
 


### PR DESCRIPTION
## Purpose
The NWS hazards API endpoint changed, breaking the red flag warnings layer on Pyrecast. This PR updates the endpoint. I found the new endpoint by going to https://www.weather.gov/wrh/hazards and scrolling through the network tab until I found the request they were making to pull in the red flags layer.

## Related Issues
Closes PYR1-1081

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
Make sure the red flag warnings layer works.
