### PR TITLE
PYR1-1077 Tighten up API routing table access (for users) and investigate token visibility during API calls

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -72,6 +72,8 @@
  :triangulum.views/cljs-init        pyregence.client/init
  :triangulum.views/client-keys      {:default-forecasts {:near-term :fire-weather
                                                          :long-term :fire-scenarios}
+                                     :mapbox-access-token "<access-token>"
+                                     :auth-token          "<changeme123456789>"
                                      :dev-mode          true
                                      :features          {:match-drop       true
                                                          :fire-history     true
@@ -118,6 +120,4 @@
                                               :geosync-host   "sierra.pyregence.org"
                                               :geosync-port   31340
                                               :max-queue-size 5
-                                              :md-prefix      "<prod | dev | local>"}
- :pyregence.secrets/mapbox-access-token      "<access-token>"
- :pyregence.secrets/pyr-auth-token           "<changeme123456789>"}
+                                              :md-prefix      "<prod | dev | local>"}}

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -1,11 +1,13 @@
 (ns pyregence.authentication
   (:require [pyregence.utils     :refer [nil-on-error]]
+            [triangulum.config   :refer [get-config]]
             [triangulum.database :refer [call-sql sql-primitive]]
             [triangulum.response :refer [data-response]]))
 
 (defn log-in [email password]
   (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
-    (data-response "" {:session {:user-id (:user_id user)}})
+    (data-response "" {:session (-> {:user-id (:user_id user)}
+                                    (merge (get-config :app :client-keys)))})
     (data-response "" {:status 403})))
 
 (defn log-out [] (data-response "" {:session nil}))

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -6,8 +6,8 @@
 
 (defn log-in [email password]
   (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
-    (data-response "" {:session (-> {:user-id (:user_id user)}
-                                    (merge (get-config :app :client-keys)))})
+    (data-response "" {:session (merge {:user-id (:user_id user)}
+                                       (get-config :app :client-keys))})
     (data-response "" {:status 403})))
 
 (defn log-out [] (data-response "" {:session nil}))

--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -6,28 +6,27 @@
             [pyregence.handlers       :refer [clj-handler]]
             [pyregence.match-drop     :as match-drop]
             [pyregence.red-flag       :as red-flag]
-            [pyregence.secrets        :as secrets]
             [triangulum.views         :refer [render-page]]))
 
 (def routes
   {;; Page Routes
-   [:get "/"]                   {:handler     (render-page "/")}
-   [:get "/admin"]              {:handler     (render-page "/admin")
-                                 :auth-type   :admin
-                                 :auth-action :redirect}
-   [:get "/dashboard"]          {:handler     (render-page "/dashboard")
-                                 :auth-type   :user
-                                 :auth-action :redirect}
-   [:get "/help"]               {:handler     (render-page "/help")}
-   [:get "/login"]              {:handler     (render-page "/login")}
-   [:get "/forecast"]           {:handler     (render-page "/forecast")}
-   [:get "/long-term-forecast"] {:handler     (render-page "/long-term-forecast")}
-   [:get "/near-term-forecast"] {:handler     (render-page "/near-term-forecast")}
-   [:get "/privacy-policy"]     {:handler     (render-page "/privacy-policy")}
-   [:get "/register"]           {:handler     (render-page "/register")}
-   [:get "/reset-password"]     {:handler     (render-page "/reset-password")}
-   [:get "/terms-of-use"]       {:handler     (render-page "/terms-of-use")}
-   [:get "/verify-email"]       {:handler     (render-page "/verify-email")}
+   [:get "/"]                                   {:handler     (render-page "/")}
+   [:get "/admin"]                              {:handler     (render-page "/admin")
+                                                 :auth-type   :admin
+                                                 :auth-action :redirect}
+   [:get "/dashboard"]                          {:handler     (render-page "/dashboard")
+                                                 :auth-type   :user
+                                                 :auth-action :redirect}
+   [:get "/help"]                               {:handler     (render-page "/help")}
+   [:get "/login"]                              {:handler     (render-page "/login")}
+   [:get "/forecast"]                           {:handler     (render-page "/forecast")}
+   [:get "/long-term-forecast"]                 {:handler     (render-page "/long-term-forecast")}
+   [:get "/near-term-forecast"]                 {:handler     (render-page "/near-term-forecast")}
+   [:get "/privacy-policy"]                     {:handler     (render-page "/privacy-policy")}
+   [:get "/register"]                           {:handler     (render-page "/register")}
+   [:get "/reset-password"]                     {:handler     (render-page "/reset-password")}
+   [:get "/terms-of-use"]                       {:handler     (render-page "/terms-of-use")}
+   [:get "/verify-email"]                       {:handler     (render-page "/verify-email")}
 
    ;; Users API
    [:post "/clj/add-new-user"]                  {:handler     (clj-handler authentication/add-new-user)
@@ -92,68 +91,62 @@
                                                  :auth-action :block}
 
    ;; Cameras API
-   [:post "/clj/get-cameras"]       {:handler     (clj-handler cameras/get-cameras)
-                                     :auth-type   :token
-                                     :auth-action :block}
-   [:post "/clj/get-current-image"] {:handler     (clj-handler cameras/get-current-image)
-                                     :auth-type   :token
-                                     :auth-action :block}
+   [:post "/clj/get-cameras"]                   {:handler     (clj-handler cameras/get-cameras)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:post "/clj/get-current-image"]             {:handler     (clj-handler cameras/get-current-image)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
 
    ;; Capabilities API
-   [:post "/clj/get-all-layers"]       {:handler     (clj-handler capabilities/get-all-layers)
-                                        :auth-type   :token
-                                        :auth-action :block}
-   [:post "/clj/get-fire-names"]       {:handler     (clj-handler capabilities/get-fire-names)
-                                        :auth-type   :token
-                                        :auth-action :block}
-   [:post "/clj/get-layers"]           {:handler     (clj-handler capabilities/get-layers)
-                                        :auth-type   :token
-                                        :auth-action :block}
-   [:post "/clj/get-layer-name"]       {:handler     (clj-handler capabilities/get-layer-name)
-                                        :auth-type   :token
-                                        :auth-action :block}
-   [:post "/clj/get-user-layers"]      {:handler     (clj-handler capabilities/get-user-layers)
-                                        :auth-type   #{:user :token}
-                                        :auth-action :block}
-   [:get  "/clj/set-capabilities"]     {:handler     (clj-handler capabilities/set-capabilities!)
-                                        :auth-type   :token
-                                        :auth-action :block}
-   [:get  "/clj/set-all-capabilities"] {:handler     (clj-handler capabilities/set-all-capabilities!)
-                                        :auth-type   :token
-                                        :auth-action :block}
-   [:get  "/clj/remove-workspace"]     {:handler     (clj-handler capabilities/remove-workspace!)
-                                        :auth-type   :token
-                                        :auth-action :block}
+   [:post "/clj/get-all-layers"]                {:handler     (clj-handler capabilities/get-all-layers)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:post "/clj/get-fire-names"]                {:handler     (clj-handler capabilities/get-fire-names)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:post "/clj/get-layers"]                    {:handler     (clj-handler capabilities/get-layers)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:post "/clj/get-layer-name"]                {:handler     (clj-handler capabilities/get-layer-name)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:post "/clj/get-user-layers"]               {:handler     (clj-handler capabilities/get-user-layers)
+                                                 :auth-type   #{:user :token}
+                                                 :auth-action :block}
+   [:get  "/clj/set-capabilities"]              {:handler     (clj-handler capabilities/set-capabilities!)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:get  "/clj/set-all-capabilities"]          {:handler     (clj-handler capabilities/set-all-capabilities!)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
+   [:get  "/clj/remove-workspace"]              {:handler     (clj-handler capabilities/remove-workspace!)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
 
    ;; Email API
-   [:post "/clj/send-email"] {:handler     (clj-handler email/send-email!)
-                              :auth-type   :token
-                              :auth-action :block}
+   [:post "/clj/send-email"]                    {:handler     (clj-handler email/send-email!)
+                                                 :auth-type   :token
+                                                 :auth-action :block}
 
    ;; Match Drop API
-   [:post "/clj/delete-match-drop"]      {:handler     (clj-handler match-drop/delete-match-drop!)
-                                          :auth-type   #{:match-drop :token}
-                                          :auth-action :block}
-   [:post "/clj/get-md-available-dates"] {:handler     (clj-handler match-drop/get-md-available-dates)
-                                          :auth-type   #{:match-drop :token}
-                                          :auth-action :block}
-   [:post "/clj/get-md-status"]          {:handler     (clj-handler match-drop/get-md-status)
-                                          :auth-type   #{:match-drop :token}
-                                          :auth-action :block}
-   [:post "/clj/get-match-drops"]        {:handler     (clj-handler match-drop/get-match-drops)
-                                          :auth-type   #{:match-drop :token}
-                                          :auth-action :block}
-   [:post "/clj/initiate-md"]            {:handler     (clj-handler match-drop/initiate-md!)
-                                          :auth-type   #{:match-drop :token}
-                                          :auth-action :block}
+   [:post "/clj/delete-match-drop"]             {:handler     (clj-handler match-drop/delete-match-drop!)
+                                                 :auth-type   #{:match-drop :token}
+                                                 :auth-action :block}
+   [:post "/clj/get-md-available-dates"]        {:handler     (clj-handler match-drop/get-md-available-dates)
+                                                 :auth-type   #{:match-drop :token}
+                                                 :auth-action :block}
+   [:post "/clj/get-md-status"]                 {:handler     (clj-handler match-drop/get-md-status)
+                                                 :auth-type   #{:match-drop :token}
+                                                 :auth-action :block}
+   [:post "/clj/get-match-drops"]               {:handler     (clj-handler match-drop/get-match-drops)
+                                                 :auth-type   #{:match-drop :token}
+                                                 :auth-action :block}
+   [:post "/clj/initiate-md"]                   {:handler     (clj-handler match-drop/initiate-md!)
+                                                 :auth-type   #{:match-drop :token}
+                                                 :auth-action :block}
 
    ;; Red Flag API
-   [:post "/clj/get-red-flag-layer"] {:handler     (clj-handler red-flag/get-red-flag-layer)
-                                      :auth-type   :token
-                                      :auth-action :block}
-
-   ;; Secrets API
-   [:post "/clj/get-mapbox-access-token"] {:handler     (clj-handler secrets/get-mapbox-access-token)
-                                           :auth-type   :token
-                                           :auth-action :block}
-   [:post "/clj/get-pyr-auth-token"]      {:handler     (clj-handler secrets/get-pyr-auth-token)}})
+   [:post "/clj/get-red-flag-layer"]            {:handler     (clj-handler red-flag/get-red-flag-layer)
+                                                 :auth-type   :token
+                                                 :auth-action :block}})

--- a/src/clj/pyregence/secrets.clj
+++ b/src/clj/pyregence/secrets.clj
@@ -1,9 +1,0 @@
-(ns pyregence.secrets
-  (:require [triangulum.config   :refer [get-config]]
-            [triangulum.response :refer [data-response]]))
-
-(defn get-mapbox-access-token []
-  (data-response (get-config :pyregence.secrets/mapbox-access-token)))
-
-(defn get-pyr-auth-token []
-  (data-response (get-config :pyregence.secrets/pyr-auth-token)))

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -72,8 +72,8 @@
       (reset! !/feature-flags       (get clj-session :features))
       (reset! !/geoserver-urls      (get clj-session :geoserver))
       (reset! !/default-forecasts   (get clj-session :default-forecasts))
-      (reset! !/pyr-auth-token      (edn/read-string (:body (<! (u-async/call-clj-async! "get-pyr-auth-token")))))
-      (reset! !/mapbox-access-token (edn/read-string (:body (<! (u-async/call-clj-async! "get-mapbox-access-token")))))
+      (reset! !/pyr-auth-token      (edn/read-string (get clj-session :auth-token)))
+      (reset! !/mapbox-access-token (edn/read-string (get clj-session :mapbox-access-token)))
       (render-root merged-params))))
 
 (defn- ^:after-load mount-root!

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -72,8 +72,8 @@
       (reset! !/feature-flags       (get clj-session :features))
       (reset! !/geoserver-urls      (get clj-session :geoserver))
       (reset! !/default-forecasts   (get clj-session :default-forecasts))
-      (reset! !/pyr-auth-token      (edn/read-string (get clj-session :auth-token)))
-      (reset! !/mapbox-access-token (edn/read-string (get clj-session :mapbox-access-token)))
+      (reset! !/pyr-auth-token      (get clj-session :auth-token))
+      (reset! !/mapbox-access-token (get clj-session :mapbox-access-token))
       (render-root merged-params))))
 
 (defn- ^:after-load mount-root!


### PR DESCRIPTION

## Purpose
* Use a bearer token, which is more idiomatic for sending authorization tokens. This also paves the way for implementing JWT, allowing the API to be used by other clients. Bearer tokens provide more security than URL tokens, as they don’t appear in server logs, browser history, or can’t be accidentally shared via copied URLs.
* Updated client request functions for GET/POST (multimethod).
* Updated the code that checks for an auth token in the route authenticator to use Bearer.
* Removed the exposed open APIs (in the gsr.secret namespace) that return access tokens. We are now sending the client keys (tokens) as part of the session when the user logs in. Updated the config accordingly.
---
* In the next steps, we would need to create new login routes that would return/refresh tokens like with session. It would sign a payload with the user and their access. 
* Augment Triangulum ring wrappers/middleware authentication/authorization to handle the tokens as part of the request (we can `buddy.auth` for that).

## Related Issues
Closes PYR1-1077

## Testing 
Use updated `config.deafult.edn` pattern, where we put `:mapbox-access-token` and `:auth-token` in `:triangulum.views/client-keys` map.
