### PR TITLE
PYR1-1073 add user conversion events to ga4 in pyrecast

### DIFF
--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -25,7 +25,8 @@
     (if (:success (<! (u-async/call-clj-async! "log-in" @email @password)))
       (let [url (:redirect-from (u-browser/get-session-storage) "/forecast")]
         (u-browser/clear-session-storage!)
-        (u-browser/jump-to-url! url))
+        (u-browser/jump-to-url! url)
+        (js/gtag "event" "log-in" (clj->js {})))
       ;; TODO, it would be helpful to show the user which of the two errors it actually is.
       (toast-message! ["Invalid login credentials. Please try again."
                        "If you feel this is an error, check your email for the verification email."]))))

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -29,6 +29,7 @@
              (:success (<! (u-async/call-clj-async! "send-email" @email :new-user))))
       (do (toast-message! ["Your account has been created successfully."
                            "Please check your email for a link to complete registration."])
+          (js/gtag "event" "registered-user" (clj->js {}))
           (<! (timeout 4000))
           (u-browser/jump-to-url! "/forecast"))
       (toast-message! ["An error occurred while registering."


### PR DESCRIPTION
This PR must be merged only after https://github.com/pyregence/pyregence/pull/928 (mainly for the purpose of showing a sample gtag-id in the [config.edn](https://github.com/pyregence/pyregence/pull/928/files#diff-2269e6f261ddc8af81995b116b45d24d83919a208aefbb51339a4b1f460c8658R72) file)

## Purpose
Start tracking:

- User is successfully registered (as indicated on the successful registration API)
- User is successfully logged in

## Related Issues
Closes PYR1-1073

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Login/registration

#### Role
All

#### Steps
1. To really test you could create a google analytics account for yourself
2. Then configure it and get a G-* tag
3. Then start pyrecast with your G-* tag in the config.edn file (:triangulum.views/gtag-id entry)
4. Then register a new user successfully
5. And check the event in google analytics at Reports -> Realtime Overview -> "Event count by Event name" card (see Screenshots)
6. Login with some user and then do step `5.`

#### Desired Outcome
Events are sent to google and appear in google analytics

## Screenshots

Login is being registered:
![image](https://github.com/user-attachments/assets/2122a3a0-d576-4009-be07-ea603837c6f7)

Registered user:
![image](https://github.com/user-attachments/assets/ed059847-666d-41f5-beb1-26be88f7a2ba)

