### PR TITLE
PYR1-1076 add pyrecast tool usage ga4 events

### DIFF
--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -1,14 +1,15 @@
 (ns pyregence.analytics)
 
 (defn gtag
-  "Call `gtag` with a given `info` (a clojure map with the info we want to track)"
+  "Call `gtag` with a given `info` (a clojure map with the info we want to track)
+  `gtag` is a function provided by google analytics tool.
+   See https://developers.google.com/analytics/devguides/collection/ga4"
   [event-name info]
   (js/gtag "event" event-name (clj->js info)))
 
 (defn gtag-tool-clicked
-  "Call `gtag` for a specific togglable tool named `tool-name`
-  `gtag` is a function provided by google analytics tool.
-  See https://developers.google.com/analytics/devguides/collection/ga4"
+  "Call `gtag` passing the `tool-usage` event.
+   If the tool is toggable, `show?` it the current state."
   ([event-name]
    (gtag "tool-usage" {:tool-clicked event-name}))
   ([show? tool-name]

--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -1,0 +1,9 @@
+(ns pyregence.analytics)
+
+(defn gtag-tool
+  "Call `gtag` for a specific togglable tool named `tool-name`
+  `gtag` is a function provided by google analytics tool.
+  See https://developers.google.com/analytics/devguides/collection/ga4"
+  [show? tool-name]
+  (let [event-name (str (if show? "show-" "hide-") tool-name)]
+    (js/gtag "event" "registered-user" (clj->js {:tool-clicked event-name}))))

--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -1,14 +1,14 @@
 (ns pyregence.analytics)
 
+(defn gtag
+  "Call `gtag` with a given `info` (a clojure map with the info we want to track)"
+  [info]
+  (js/gtag "event" "registered-user" (clj->js info)))
+
 (defn gtag-tool
   "Call `gtag` for a specific togglable tool named `tool-name`
   `gtag` is a function provided by google analytics tool.
   See https://developers.google.com/analytics/devguides/collection/ga4"
   [show? tool-name]
   (let [event-name (str (if show? "show-" "hide-") tool-name)]
-    (js/gtag "event" "registered-user" (clj->js {:tool-clicked event-name}))))
-
-(defn gtag
-  "Call `gtag` with a given `info` (a clojure map with the info we want to track)"
-  [info]
-  (js/gtag "event" "registered-user" (clj->js info)))
+    (gtag {:tool-clicked event-name})))

--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -7,3 +7,8 @@
   [show? tool-name]
   (let [event-name (str (if show? "show-" "hide-") tool-name)]
     (js/gtag "event" "registered-user" (clj->js {:tool-clicked event-name}))))
+
+(defn gtag
+  "Call `gtag` with a given `info` (a clojure map with the info we want to track)"
+  [info]
+  (js/gtag "event" "registered-user" (clj->js info)))

--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -2,15 +2,15 @@
 
 (defn gtag
   "Call `gtag` with a given `info` (a clojure map with the info we want to track)"
-  [info]
-  (js/gtag "event" "tool-usage" (clj->js info)))
+  [event-name info]
+  (js/gtag "event" event-name (clj->js info)))
 
 (defn gtag-tool-clicked
   "Call `gtag` for a specific togglable tool named `tool-name`
   `gtag` is a function provided by google analytics tool.
   See https://developers.google.com/analytics/devguides/collection/ga4"
   ([event-name]
-   (gtag {:tool-clicked event-name}))
+   (gtag "tool-usage" {:tool-clicked event-name}))
   ([show? tool-name]
    (let [event-name (str (if show? "show-" "hide-") tool-name)]
      (gtag-tool-clicked event-name))))

--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -3,7 +3,7 @@
 (defn gtag
   "Call `gtag` with a given `info` (a clojure map with the info we want to track)"
   [info]
-  (js/gtag "event" "registered-user" (clj->js info)))
+  (js/gtag "event" "tool-usage" (clj->js info)))
 
 (defn gtag-tool-clicked
   "Call `gtag` for a specific togglable tool named `tool-name`

--- a/src/cljs/pyregence/analytics.cljs
+++ b/src/cljs/pyregence/analytics.cljs
@@ -5,10 +5,12 @@
   [info]
   (js/gtag "event" "registered-user" (clj->js info)))
 
-(defn gtag-tool
+(defn gtag-tool-clicked
   "Call `gtag` for a specific togglable tool named `tool-name`
   `gtag` is a function provided by google analytics tool.
   See https://developers.google.com/analytics/devguides/collection/ga4"
-  [show? tool-name]
-  (let [event-name (str (if show? "show-" "hide-") tool-name)]
-    (gtag {:tool-clicked event-name})))
+  ([event-name]
+   (gtag {:tool-clicked event-name}))
+  ([show? tool-name]
+   (let [event-name (str (if show? "show-" "hide-") tool-name)]
+     (gtag-tool-clicked event-name))))

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -1,7 +1,7 @@
 (ns pyregence.components.map-controls.tool-bar
   (:require
    [clojure.core.async                            :refer [<! go]]
-   [pyregence.analytics                           :refer [gtag-tool]]
+   [pyregence.analytics                           :refer [gtag-tool-clicked]]
    [pyregence.components.common                   :refer [hs-str
                                                           tool-tip-wrapper]]
    [pyregence.components.map-controls.tool-button :refer [tool-button]]
@@ -41,7 +41,7 @@
   "Toggles the red-flag warning layer."
   []
   (swap! !/show-red-flag? not)
-  (gtag-tool @!/show-red-flag? "red-flag")
+  (gtag-tool-clicked @!/show-red-flag? "red-flag")
   (if @!/show-red-flag?
     (mb/add-feature-highlight! "red-flag" "red-flag" :click-fn init-red-flag-popup!)
     (mb/clear-highlight! "red-flag" :selected))
@@ -62,7 +62,7 @@
   "Toggles the fire history layer."
   []
   (swap! !/show-fire-history? not)
-  (gtag-tool @!/show-fire-history? "fire-history-layer")
+  (gtag-tool-clicked @!/show-fire-history? "fire-history-layer")
   (if @!/show-fire-history?
     (do
       (mb/add-feature-highlight! "fire-history" "fire-history"
@@ -106,7 +106,7 @@
                  (reset! !/show-measure-tool? false)
                  (reset! !/show-match-drop? false)
                  (reset! !/show-camera? false)
-                 (gtag-tool @!/show-info? "point-information"))
+                 (gtag-tool-clicked @!/show-info? "point-information"))
             @!/show-info?]
            (when (and (c/feature-enabled? :match-drop) ; enabled in `config.edn`
                       (number? user-id)                ; logged in user
@@ -118,7 +118,7 @@
                    (reset! !/show-measure-tool? false)
                    (set-show-info! false)
                    (reset! !/show-camera? false)
-                   (gtag-tool @!/show-match-drop? "match-drop"))
+                   (gtag-tool-clicked @!/show-match-drop? "match-drop"))
               @!/show-match-drop?])
            (when-not (get-any-level-key :disable-camera?)
              [:camera
@@ -127,7 +127,7 @@
                    (set-show-info! false)
                    (reset! !/show-match-drop? false)
                    (reset! !/show-measure-tool? false)
-                   (gtag-tool @!/show-camera? "camera"))
+                   (gtag-tool-clicked @!/show-camera? "camera"))
               @!/show-camera?])
            (when-not (get-any-level-key :disable-flag?)
              [:flag
@@ -143,11 +143,11 @@
                  (reset! !/show-camera? false)
                  (reset! !/show-match-drop? false)
                  (swap! !/show-measure-tool? not)
-                 (gtag-tool @!/show-measure-tool? "measure-distance"))]
+                 (gtag-tool-clicked @!/show-measure-tool? "measure-distance"))]
            [:legend
             (str (hs-str @!/show-legend?) " legend")
             #(do (swap! !/show-legend? not)
-                 (gtag-tool @!/show-legend? "legend"))
+                 (gtag-tool-clicked @!/show-legend? "legend"))
             false]]
           (remove nil?)
           (map-indexed (fn [i [icon hover-text on-click active?]]

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -1,15 +1,19 @@
 (ns pyregence.components.map-controls.tool-bar
-  (:require [clojure.core.async                            :refer [<! go]]
-            [pyregence.components.common                   :refer [tool-tip-wrapper hs-str]]
-            [pyregence.components.map-controls.tool-button :refer [tool-button]]
-            [pyregence.components.mapbox                   :as mb]
-            [pyregence.components.messaging                :refer [toast-message!]]
-            [pyregence.components.popups                   :refer [red-flag-popup fire-history-popup]]
-            [pyregence.config                              :as c]
-            [pyregence.state                               :as !]
-            [pyregence.styles                              :as $]
-            [pyregence.utils.async-utils                   :as u-async]
-            [reagent.core                                  :as r]))
+  (:require
+   [clojure.core.async                            :refer [<! go]]
+   [pyregence.analytics                           :refer [gtag-tool]]
+   [pyregence.components.common                   :refer [hs-str
+                                                          tool-tip-wrapper]]
+   [pyregence.components.map-controls.tool-button :refer [tool-button]]
+   [pyregence.components.mapbox                   :as mb]
+   [pyregence.components.messaging                :refer [toast-message!]]
+   [pyregence.components.popups                   :refer [fire-history-popup
+                                                          red-flag-popup]]
+   [pyregence.config                              :as c]
+   [pyregence.state                               :as !]
+   [pyregence.styles                              :as $]
+   [pyregence.utils.async-utils                   :as u-async]
+   [reagent.core                                  :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State
@@ -21,14 +25,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn gtag-tool [show? tool-name]
-  (let [event-name (str (if show? "show-" "hide-") tool-name)]
-    (js/gtag "event" "registered-user" (clj->js {:tool-clicked event-name}))))
-
 (defn- init-red-flag-popup! [feature lnglat]
-  (let [properties (-> feature (aget "properties") (js->clj))
+  (let [properties                         (-> feature (aget "properties") (js->clj))
         {:strs [url prod_type onset ends]} properties
-        body       (red-flag-popup url prod_type onset ends)]
+        body                               (red-flag-popup url prod_type onset ends)]
     (mb/init-popup! "red-flag" lnglat body {:width "200px"})))
 
 (defn- init-fire-history-popup! [feature lnglat]

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -39,8 +39,10 @@
   []
   (swap! !/show-red-flag? not)
   (if @!/show-red-flag?
-    (mb/add-feature-highlight! "red-flag" "red-flag" :click-fn init-red-flag-popup!)
-    (mb/clear-highlight! "red-flag" :selected))
+    (do (mb/add-feature-highlight! "red-flag" "red-flag" :click-fn init-red-flag-popup!)
+        (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-red-flag})))
+    (do (mb/clear-highlight! "red-flag" :selected)
+        (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-red-flag}))))
   (go
     (let [data (-> (<! (u-async/call-clj-async! "get-red-flag-layer"))
                    (:body)
@@ -65,10 +67,12 @@
                                  :source-layer "fire-history")
       (mb/add-feature-highlight! "fire-history-centroid" "fire-history-centroid"
                                  :click-fn init-fire-history-popup!
-                                 :source-layer "fire-history-centroid"))
+                                 :source-layer "fire-history-centroid")
+      (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-fire-history-layer})))
     (do
       (mb/clear-highlight! "fire-history" :selected)
-      (mb/clear-highlight! "fire-history-centroid" :selected)))
+      (mb/clear-highlight! "fire-history-centroid" :selected)
+      (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-fire-history-layer}))))
   (when (and @!/show-fire-history? (not (mb/layer-exists? "fire-history")))
     (mb/create-fire-history-layer! "fire-history"
                                    "fire-detections_fire-history%3Afire-history"
@@ -100,7 +104,10 @@
             #(do (set-show-info! (not @!/show-info?))
                  (reset! !/show-measure-tool? false)
                  (reset! !/show-match-drop? false)
-                 (reset! !/show-camera? false))
+                 (reset! !/show-camera? false)
+                 (if @!/show-info?
+                   (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-point-information}))
+                   (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-point-information}))))
             @!/show-info?]
            (when (and (c/feature-enabled? :match-drop) ; enabled in `config.edn`
                       (number? user-id)                ; logged in user
@@ -111,7 +118,10 @@
               #(do (swap! !/show-match-drop? not)
                    (reset! !/show-measure-tool? false)
                    (set-show-info! false)
-                   (reset! !/show-camera? false))
+                   (reset! !/show-camera? false)
+                   (if @!/show-match-drop?
+                     (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-match-drop}))
+                     (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-match-drop}))))
               @!/show-match-drop?])
            (when-not (get-any-level-key :disable-camera?)
              [:camera
@@ -119,7 +129,10 @@
               #(do (swap! !/show-camera? not)
                    (set-show-info! false)
                    (reset! !/show-match-drop? false)
-                   (reset! !/show-measure-tool? false))
+                   (reset! !/show-measure-tool? false)
+                   (if @!/show-camera?
+                     (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-camera}))
+                     (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-camera}))))
               @!/show-camera?])
            (when-not (get-any-level-key :disable-flag?)
              [:flag
@@ -134,10 +147,16 @@
             #(do (set-show-info! false)
                  (reset! !/show-camera? false)
                  (reset! !/show-match-drop? false)
-                 (swap! !/show-measure-tool? not))]
+                 (swap! !/show-measure-tool? not)
+                 (if @!/show-measure-tool?
+                   (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-measure-distance}))
+                   (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-measure-distance}))))]
            [:legend
             (str (hs-str @!/show-legend?) " legend")
-            #(swap! !/show-legend? not)
+            #(do (swap! !/show-legend? not)
+                 (if @!/show-legend?
+                   (js/gtag "event" "registered-user" (clj->js {:tool-clicked :show-legend}))
+                   (js/gtag "event" "registered-user" (clj->js {:tool-clicked :hide-legend}))))
             false]]
           (remove nil?)
           (map-indexed (fn [i [icon hover-text on-click active?]]

--- a/src/cljs/pyregence/components/map_controls/zoom_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/zoom_bar.cljs
@@ -1,14 +1,16 @@
 (ns pyregence.components.map-controls.zoom-bar
-  (:require [herb.core                                     :refer [<class]]
-            [pyregence.components.common                   :refer [tool-tip-wrapper]]
-            [pyregence.components.help                     :as h]
-            [pyregence.components.map-controls.tool-button :refer [tool-button]]
-            [pyregence.components.mapbox                   :as mb]
-            [pyregence.components.messaging                :refer [set-message-box-content!]]
-            [pyregence.state                               :as !]
-            [pyregence.styles                              :as $]
-            [pyregence.utils.dom-utils                     :as u-dom]
-            [reagent.core                                  :as r]))
+  (:require
+   [herb.core                                     :refer [<class]]
+   [pyregence.analytics                           :refer [gtag-tool-clicked]]
+   [pyregence.components.common                   :refer [tool-tip-wrapper]]
+   [pyregence.components.help                     :as h]
+   [pyregence.components.map-controls.tool-button :refer [tool-button]]
+   [pyregence.components.mapbox                   :as mb]
+   [pyregence.components.messaging                :refer [set-message-box-content!]]
+   [pyregence.state                               :as !]
+   [pyregence.styles                              :as $]
+   [pyregence.utils.dom-utils                     :as u-dom]
+   [reagent.core                                  :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Functions
@@ -77,25 +79,31 @@
                                [tool-button icon on-click]])
                   [[:share
                     "Share current map"
-                    #(set-message-box-content! {:title "Share Current Map"
-                                                :body  [share-inner-modal create-share-link]
-                                                :mode  :close})]
+                    #(do (set-message-box-content! {:title "Share Current Map"
+                                                    :body  [share-inner-modal create-share-link]
+                                                    :mode  :close})
+                         (gtag-tool-clicked "share-current-map"))]
                    [:terrain
                     (str (ed-str @!/terrain?) " 3D terrain")
                     #(do
                        (swap! !/terrain? not)
+                       (gtag-tool-clicked @!/terrain? "3d-terrain")
                        (when @!/terrain? (h/show-help! :terrain))
                        (mb/toggle-dimensions! @!/terrain?)
                        (mb/ease-to! {:pitch (if @!/terrain? 45 0) :bearing 0}))]
                    [:my-location
                     "Center on my location"
-                    #(some-> js/navigator .-geolocation (.getCurrentPosition mb/set-center-my-location!))]
+                    #(do (some-> js/navigator .-geolocation (.getCurrentPosition mb/set-center-my-location!))
+                         (gtag-tool-clicked "center-on-my-location"))]
                    [:extent
                     "Zoom to fit layer"
-                    #(mb/zoom-to-extent! current-layer-extent current-layer)]
+                    #(do (mb/zoom-to-extent! current-layer-extent current-layer)
+                         (gtag-tool-clicked  "zoom-to-fit-layer"))]
                    [:zoom-in
                     "Zoom in"
-                    #(select-zoom! (inc @*zoom))]
+                    #(do (select-zoom! (inc @*zoom))
+                         (gtag-tool-clicked "zoom-in"))]
                    [:zoom-out
                     "Zoom out"
-                    #(select-zoom! (dec @*zoom))]])]))
+                    #(do (select-zoom! (dec @*zoom))
+                         (gtag-tool-clicked "zoom-out"))]])]))

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -1,11 +1,13 @@
 (ns pyregence.pages.login
-  (:require [clojure.core.async             :refer [go <! timeout]]
-            [pyregence.components.common    :refer [simple-form]]
-            [pyregence.components.messaging :refer [toast-message!]]
-            [pyregence.styles               :as $]
-            [pyregence.utils.async-utils    :as u-async]
-            [pyregence.utils.browser-utils  :as u-browser]
-            [reagent.core                   :as r]))
+  (:require
+   [clojure.core.async             :refer [<! go timeout]]
+   [pyregence.analytics            :refer [gtag]]
+   [pyregence.components.common    :refer [simple-form]]
+   [pyregence.components.messaging :refer [toast-message!]]
+   [pyregence.styles               :as $]
+   [pyregence.utils.async-utils    :as u-async]
+   [pyregence.utils.browser-utils  :as u-browser]
+   [reagent.core                   :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State
@@ -26,7 +28,7 @@
       (let [url (:redirect-from (u-browser/get-session-storage) "/forecast")]
         (u-browser/clear-session-storage!)
         (u-browser/jump-to-url! url)
-        (js/gtag "event" "log-in" (clj->js {})))
+        (gtag "log-in" {}))
       ;; TODO, it would be helpful to show the user which of the two errors it actually is.
       (toast-message! ["Invalid login credentials. Please try again."
                        "If you feel this is an error, check your email for the verification email."]))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -7,6 +7,7 @@
    [clojure.string                                      :as str]
    [cognitect.transit                                   :as t]
    [herb.core                                           :refer [<class]]
+   [pyregence.analytics                                 :refer [gtag]]
    [pyregence.components.map-controls.camera-tool       :refer [camera-tool]]
    [pyregence.components.map-controls.collapsible-panel :refer [collapsible-panel]]
    [pyregence.components.map-controls.information-tool  :refer [information-tool]]
@@ -530,7 +531,7 @@
   (go
     (!/set-state-legend-list! [])
     (reset! !/last-clicked-info nil)
-    (js/gtag "event" "select-forecast" (clj->js {:forecast-type (str key)}))
+    (gtag "select-forecast" {:forecast-type (str key)})
     (reset! !/*forecast key)
     (reset! !/processed-params (get-forecast-opt :params))
     (mb/set-multiple-layers-visibility! #"isochrones" false) ; hide isochrones underlay when switching tabs

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -1,12 +1,14 @@
 (ns pyregence.pages.register
-  (:require [clojure.core.async             :refer [go <! timeout]]
-            [pyregence.components.common    :refer [simple-form]]
-            [pyregence.components.messaging :refer [toast-message!]]
-            [pyregence.styles               :as $]
-            [pyregence.utils.async-utils    :as u-async]
-            [pyregence.utils.browser-utils  :as u-browser]
-            [pyregence.utils.data-utils     :as u-data]
-            [reagent.core                   :as r]))
+  (:require
+   [clojure.core.async             :refer [<! go timeout]]
+   [pyregence.analytics            :refer [gtag]]
+   [pyregence.components.common    :refer [simple-form]]
+   [pyregence.components.messaging :refer [toast-message!]]
+   [pyregence.styles               :as $]
+   [pyregence.utils.async-utils    :as u-async]
+   [pyregence.utils.browser-utils  :as u-browser]
+   [pyregence.utils.data-utils     :as u-data]
+   [reagent.core                   :as r]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State
@@ -29,7 +31,7 @@
              (:success (<! (u-async/call-clj-async! "send-email" @email :new-user))))
       (do (toast-message! ["Your account has been created successfully."
                            "Please check your email for a link to complete registration."])
-          (js/gtag "event" "registered-user" (clj->js {}))
+          (gtag "registered-user" {})
           (<! (timeout 4000))
           (u-browser/jump-to-url! "/forecast"))
       (toast-message! ["An error occurred while registering."


### PR DESCRIPTION
## Purpose
Same as https://github.com/pyregence/pyregence/pull/930 and #928 but for all the right sided tools, namely:

1. Point information
2. Cameras
3. Red flags
4. Historical fires
5. Measure distance
6. Legend
7. Share
8. 3D terrain
9. Center on my location
10. Zoom to fit later
11. Zoom in plus
12. Zoom out minus



## Related Issues
Closes PYR1-1076

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
All

#### Role
All

#### Steps
1. Access pyrecast, click a right sided tool
2. Check google analytics to check the triggered event

See how to do `2` #928 and #930 Testing sections

## Screenshots

See there is a `tool-usage`:
![image](https://github.com/user-attachments/assets/28934af8-de4e-4ee2-a407-0b5e4fcbcf49)

Then the `tool-clicked`:
![image](https://github.com/user-attachments/assets/1f524eb7-e981-4155-9c40-53ef6658d9e7)

And the concrete events:
![image](https://github.com/user-attachments/assets/c8b6c9e3-4882-4401-808d-da9fff7fa5af)

![image](https://github.com/user-attachments/assets/eab1a6f7-bedf-4cfe-9549-9201e4a6d1bf)

![image](https://github.com/user-attachments/assets/2ca415b0-d06b-48fa-a479-b3288b3ed6c6)

