### PR TITLE
PYR1-1069  Rename `dev-mode` `config.edn` key to `show-disclaimer` across Pyrecast

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -75,7 +75,7 @@
                                                          :long-term :fire-scenarios}
                                      :mapbox-access-token "<access-token>"
                                      :auth-token          "<changeme123456789>"
-                                     :dev-mode          true
+                                     :show-disclaimer   true
                                      :features          {:match-drop       true
                                                          :fire-history     true
                                                          :structures       true

--- a/src/clj/pyregence/handlers.clj
+++ b/src/clj/pyregence/handlers.clj
@@ -41,8 +41,7 @@
                          #_(when (and (nil? bearer-token) (contains? (:params request) :auth-token))
                              (log-str "Token in URL params detected"))
                          valid-token?)
-                :user  (or (pos? user-id)
-                           (get-config :triangulum.views/client-keys :dev-mode))
+                :user  (pos? user-id)
                 true))
             (if (keyword? auth-type) [auth-type] auth-type))))
 

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -68,7 +68,7 @@
                           (reset! original-session (js->clj session :keywordize-keys true))
                           @original-session)
           merged-params (merge clj-params clj-session)]
-      (reset! !/dev-mode?           (get clj-session :dev-mode))
+      (reset! !/show-disclaimer?    (get clj-session :show-disclaimer))
       (reset! !/feature-flags       (get clj-session :features))
       (reset! !/geoserver-urls      (get clj-session :geoserver))
       (reset! !/default-forecasts   (get clj-session :default-forecasts))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -768,7 +768,7 @@
                :on-mouse-up   #(reset! mouse-down? false)}]))
 
 (defn- message-modal []
-  (r/with-let [show-me? (r/atom (not @!/show-disclaimer?))]
+  (r/with-let [show-me? (r/atom @!/show-disclaimer?)]
     (when @show-me?
       [:div#message-modal {:style ($/modal)}
        [:div {:style ($message-modal false)}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -768,7 +768,7 @@
                :on-mouse-up   #(reset! mouse-down? false)}]))
 
 (defn- message-modal []
-  (r/with-let [show-me? (r/atom (not @!/dev-mode?))]
+  (r/with-let [show-me? (r/atom (not @!/show-disclaimer?))]
     (when @show-me?
       [:div#message-modal {:style ($/modal)}
        [:div {:style ($message-modal false)}

--- a/src/cljs/pyregence/state.cljs
+++ b/src/cljs/pyregence/state.cljs
@@ -126,8 +126,8 @@ California cameras. This atom is used to create the camera layer in mapbox.cljs.
 
 (defonce ^{:doc "A map that defines the default tab to display for the near-term and long-term forecast pages."}
   default-forecasts (atom {}))
-(defonce ^{:doc "A boolean that dictates the development or production mode of the application."}
-  dev-mode? (atom nil))
+(defonce ^{:doc "A boolean that dictates whether to show the disclaimer message or not."}
+  show-disclaimer? (atom nil))
 (defonce ^{:doc "A boolean map describing what features are enabled or disabled."}
   feature-flags (atom nil))
 (defonce ^{:doc "A map of Geoserver URLs that are used to query layer data from."}


### PR DESCRIPTION
## Purpose

Use show-disclaimer instead of dev-mode in the config and update the usage in the cljs state code. 

## Related Issues
Closes PYR1-1069
