### PR TITLE
Support building a jar

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
            funcool/decimal            {:mvn/version "1.0.2"}
            herb/herb                  {:mvn/version "0.10.0"}
            hiccup/hiccup              {:mvn/version "2.0.0-alpha2"}
-           org.clojure/clojure        {:mvn/version "1.11.1"}
+           org.clojure/clojure        {:mvn/version "1.12.0"}
            org.clojure/clojurescript  {:mvn/version "1.10.866"}
            org.clojure/core.async     {:mvn/version "1.2.603"}
            org.clojure/data.json      {:mvn/version "1.0.0"}
@@ -23,8 +23,13 @@
                                        :git/sha "a3a2b218e15e9144af5e9064f686d253198f0c85"
                                        :git/tag "2024.06.05-a3a2b21"}
            sig-gis/triangulum         {:git/url "https://github.com/sig-gis/triangulum"
-                                       :git/sha "edbb7dac5770278741f0985f5b67ed17aa9dea93"}}
+                                       :git/sha "084de9f8c3e23ca3ab93e692d826aab622bd1ed3"}}
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
+           :build-uberjar    {:exec-fn   pyregence.packaging/build-uberjar!
+                              :exec-args {:app-name      pyregence
+                                          :src-dirs      ["src/clj"]
+                                          :main-ns       pyregence.cli
+                                          :resource-dirs ["resources" "target" "src/cljs" "src/sql"]}}
            :check-deps       {:deps      {com.github.liquidz/antq {:mvn/version "RELEASE"}}
                               :main-opts ["-m" "antq.core"]}
            :check-reflection {:main-opts ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
@@ -32,6 +37,7 @@
                                           "-e" "(require,'pyregence.jobs)"
                                           "-e" "(require,'pyregence.handlers)"
                                           "-e" "(require,'pyregence.compile-cljs)"]}
+           :cli              {:main-opts ["-m" "pyregence.cli"]}
            :compile-cljs     {:main-opts ["-m" "pyregence.compile-cljs" "compile-prod.cljs.edn"]}
            :config           {:main-opts ["-m" "triangulum.config"]}
            :default-ssl-opts {:jvm-opts ["-Djavax.net.ssl.keyStore=resources/runway.pkcs12"

--- a/src/clj/pyregence/cli.clj
+++ b/src/clj/pyregence/cli.clj
@@ -1,0 +1,24 @@
+(ns pyregence.cli
+  (:gen-class)
+  (:require
+   [triangulum.build-db :as build-db]
+   [triangulum.cli      :refer [get-cli-options]]
+   [triangulum.server   :as server]))
+
+(def cli-actions {:server   {:description "Manage web-server"}
+                  :build-db {:description "Manage database"}})
+
+(defn -main
+  [& args]
+  (if-let [{:keys [action options]}
+           (get-cli-options
+             (take 1 (filter (set (map name (keys cli-actions))) args))
+             {}
+             cli-actions
+             "cli")]
+    (let [subtask-args (remove #{(name action)} args)]
+      (case action
+        :server   (apply triangulum.server/-main subtask-args)
+        :build-db (apply build-db/-main subtask-args)
+        nil))
+    (System/exit 0)))

--- a/src/clj/pyregence/packaging.clj
+++ b/src/clj/pyregence/packaging.clj
@@ -1,0 +1,12 @@
+(ns pyregence.packaging
+  (:require
+   [clojure.java.shell     :refer [sh]]
+   [pyregence.compile-cljs :as compile-cljs]
+   [triangulum.packaging   :as packaging]))
+
+(defn build-uberjar!
+  "Build an uberjar with compiled clj and cljs."
+  [m]
+  (sh "npm" "install")
+  (compile-cljs/-main "compile-prod.cljs.edn")
+  (triangulum.packaging/build-uberjar m))


### PR DESCRIPTION
* Bump Clojure core to support a change in tools deps.
* Update Triangulum dep so that it looks for manifest on the classpath.
* Allow building an uberjar from the class path via a deps alias to build an uberjar that passes through to Triangulum.
* Allow starting the server through the uberjar at the command line via cli.

Example of building an uberjar:

clj -X:build-uberjar

Example of using that jar, assuming its alongside it's config.edn, to start the server:

java -jar pyr.jar server start

NOTE this commit doesn't contain the build_db logic, that will follow shortly.

## Purpose
To support the building of an uberjar

## Related Issues
Related to, but doesn't quite close PYR1-1084, PYR1-1083

## Submission Checklist some of these are still a TODO
- [ ] Included Jira issue in the PR title - it doesn't link to just one ticket unfortantly. 
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)
- [ ] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
No modules impacted

#### Role
Not role-specific

#### Steps

With that branch checked out, build a jar:

#+begin_src shell
clj -X:uberjar
#+end_src

To test the jar it's best to move it out of the directory, so that any file system functions won't fool you into thinking the jar works. Just make sure you move your config.edn as well:

#+begin_src shell
java -jar pyregence-2025.04.14-8130d0a8-standalone.jar server start
#+end_src


#### Desired Outcome

The server starts

## Screenshots
no screenshots needed.
