### PR TITLE
PYR1-908/Hide Isochrones layer if it's dependent-type has changed

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -133,6 +133,8 @@
                                                         underlay         (get-in @!/capabilities [@!/*forecast :underlays id])
                                                         update-underlay? (seq (set/intersection changed-keys (set (:dependent-inputs underlay))))]
                                                     (when update-underlay?
+                                                      (when (filter-set "isochrones")
+                                                        (mb/set-multiple-layers-visibility! #"isochrones" false))
                                                       (toggle-underlay! (:filter-set underlay)
                                                                         (:dependent-inputs underlay)
                                                                         (:geoserver-key underlay)

--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -132,8 +132,6 @@
                                                         changed-keys     (u-data/get-changed-keys old-param-map new-param-map)
                                                         underlay         (get-in @!/capabilities [@!/*forecast :underlays id])
                                                         update-underlay? (seq (set/intersection changed-keys (set (:dependent-inputs underlay))))]
-                                                    (when (filter-set "isochrones")
-                                                      (mb/set-multiple-layers-visibility! #"isochrones" false))
                                                     (when update-underlay?
                                                       (toggle-underlay! (:filter-set underlay)
                                                                         (:dependent-inputs underlay)


### PR DESCRIPTION
## Purpose
Hide Isochrones layer if it's dependent-type has changed.

## Related Issues
Closes PYR1-908

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

#### Steps

  0. Checkout git commit 253befd81e6200fc3a418042ec944816f3a6b686
  1. Go to [PyreCast.org|http://PyreCast.org] and select Active Fires from the tab options
  2. Select an active fire from the Fire Name dropdown (I suggest AZ Pim Bryce as some others are missing)
  3. Check the Modeled perimeter box from the Optional Layers panel
  4. Select a different option from the Output dropdown
  5. The Modeled perimeter that appeared in step 3 will disappear
  6. Uncheck the Modeled perimeter box
  7. Recheck the Modeled perimeter box and the layer should reappear
  
  Now, check out the latest on this branch, repeat steps 1-7, and see that in step 5, it never disappears, which is the desired behavior.


