### PR TITLE
PYR1-1114  Make 2FA validation token expiry duration configurable through config.edn

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -101,23 +101,24 @@
                               :triangulum.worker/stop  pyregence.jobs/stop-match-drop-server!}]
 
  ;;; Pyrecast
- :pyregence.cameras/alert-west-api-key       "<api-key>"
- :pyregence.capabilities/psps                {:geoserver-admin-username "admin"
-                                              :geoserver-admin-password "password"}
- :pyregence.match-drop/match-drop            {:app-name       "Pyrecast Match Drop Server"
-                                              :app-host       "localhost"
-                                              :app-port       31337
-                                              :dps-name       "Data Provisioning Server"
-                                              :dps-host       "sierra.pyregence.org"
-                                              :dps-port       31337
-                                              :elmfire-name   "ELMFIRE"
-                                              :elmfire-host   "sierra.pyregence.org"
-                                              :elmfire-port   31338
-                                              :gridfire-name  "GridFire"
-                                              :gridfire-host  "sierra.pyregence.org"
-                                              :gridfire-port  31339
-                                              :geosync-name   "GeoSync"
-                                              :geosync-host   "sierra.pyregence.org"
-                                              :geosync-port   31340
-                                              :max-queue-size 5
-                                              :md-prefix      "<prod | dev | local>"}}
+ :pyregence.email/verification-token-expiry-minutes 15
+ :pyregence.cameras/alert-west-api-key              "<api-key>"
+ :pyregence.capabilities/psps                       {:geoserver-admin-username "admin"
+                                                     :geoserver-admin-password "password"}
+ :pyregence.match-drop/match-drop                   {:app-name       "Pyrecast Match Drop Server"
+                                                     :app-host       "localhost"
+                                                     :app-port       31337
+                                                     :dps-name       "Data Provisioning Server"
+                                                     :dps-host       "sierra.pyregence.org"
+                                                     :dps-port       31337
+                                                     :elmfire-name   "ELMFIRE"
+                                                     :elmfire-host   "sierra.pyregence.org"
+                                                     :elmfire-port   31338
+                                                     :gridfire-name  "GridFire"
+                                                     :gridfire-host  "sierra.pyregence.org"
+                                                     :gridfire-port  31339
+                                                     :geosync-name   "GeoSync"
+                                                     :geosync-host   "sierra.pyregence.org"
+                                                     :geosync-port   31340
+                                                     :max-queue-size 5
+                                                     :md-prefix      "<prod | dev | local>"}}

--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -103,7 +103,7 @@
     :new-user   (send-verification-email! email
                                           "Pyregence New User"
                                           get-new-user-message)
-    :2fa        (mock-send-2fa-code email) ; For testing without email: (mock-send-2fa-code email)
+    :2fa        (send-2fa-code email) ; For testing without email: (mock-send-2fa-code email)
     :match-drop (send-match-drop-email! email
                                         "Match Drop Finished Running"
                                         get-match-drop-message

--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -55,9 +55,9 @@
 (defn send-2fa-code
   "Sends a time-limited 2FA code to the user's email"
   [email]
-  (let [token         (generate-numeric-token)
-        expiry-mins   15 ;; Default to 15 minutes
-        expiry-ms      (* expiry-mins 60 1000) ;; Convert to milliseconds
+  (let [expiry-mins   (or (get-config ::verification-token-expiry-minutes) 15)
+        token         (generate-numeric-token)
+        expiry-ms     (* expiry-mins 60 1000) ;; Convert minutes to milliseconds
         current-time  (System/currentTimeMillis)
         expiration    (java.sql.Timestamp. (+ current-time expiry-ms))
         body          (get-2fa-message nil email token expiry-mins)
@@ -76,9 +76,9 @@
 (defn mock-send-2fa-code
   "For testing only: generates a 2FA code and stores it, but doesn't send an email"
   [email]
-  (let [token         (generate-numeric-token)
-        expiry-mins   15 ;; Default to 15 minutes
-        expiry-ms     (* expiry-mins 60 1000) ;; Convert to milliseconds
+  (let [expiry-mins   (or (get-config ::verification-token-expiry-minutes) 15)
+        token         (generate-numeric-token)
+        expiry-ms     (* expiry-mins 60 1000) ;; Convert minutes to milliseconds
         current-time  (System/currentTimeMillis)
         expiration    (java.sql.Timestamp. (+ current-time expiry-ms))
         body          (get-2fa-message nil email token expiry-mins)]
@@ -87,6 +87,7 @@
     (println "TESTING MODE: NO EMAIL SENT")
     (println "2FA CODE for" email ":" token)
     (println "Expires at:" expiration)
+    (println "Code will expire in" expiry-mins "minutes (from config)")
     (println "Email body would be:")
     (println body)
     (println "=====================================")
@@ -102,7 +103,7 @@
     :new-user   (send-verification-email! email
                                           "Pyregence New User"
                                           get-new-user-message)
-    :2fa        (send-2fa-code email) ; For testing without email: (mock-send-2fa-code email)
+    :2fa        (mock-send-2fa-code email) ; For testing without email: (mock-send-2fa-code email)
     :match-drop (send-match-drop-email! email
                                         "Match Drop Finished Running"
                                         get-match-drop-message


### PR DESCRIPTION
## Purpose

2FA token expiry is now configurable (defaults to 15 minutes) - set `:pyregence.email/verification-token-expiry-minutes` in config.edn

## Related Issues
Closes [PYR1-1114](https://sig-gis.atlassian.net/browse/PYR1-1114)

Note: there will be another optional PR in dev-docs to add the new key in `config.edn` (we can always fall back on the 15-minute default without any changes). 

[PYR1-1114]: https://sig-gis.atlassian.net/browse/PYR1-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ