### PR TITLE
PYR1-1111/Add guix functionality to help with development and deployment. 

### DIFF
--- a/channels.scm
+++ b/channels.scm
@@ -1,0 +1,11 @@
+(list (channel
+        (name 'guix)
+        (url "https://git.savannah.gnu.org/git/guix.git")
+        (branch "master")
+        (commit
+          "799d930bf740a66792240eb27d98823f041b1335")
+        (introduction
+          (make-channel-introduction
+            "9edb3f66fd807b096b48283debdcddccfea34bad"
+            (openpgp-fingerprint
+              "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA")))))

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,0 +1,11 @@
+(use-modules ((gnu packages) #:select (specifications->manifest)))
+
+(specifications->manifest
+ (list "clojure-tools@1.11" ;; to build and run clojure
+       "openjdk@21:jdk" ;; to build, to run clojure
+       "node@22"        ;; to build and run clojurescript
+       "git"       ;; source control 
+       "nss-certs" ;; for build certs
+       "bash"      ;; for sh (only for dev?)
+       "coreutils" ;; for mkdir which is used in build
+       ))

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,11 +1,11 @@
 (use-modules ((gnu packages) #:select (specifications->manifest)))
 
 (specifications->manifest
- (list "clojure-tools@1.11" ;; to build and run clojure
-       "openjdk@21:jdk" ;; to build, to run clojure
-       "node@22"        ;; to build and run clojurescript
-       "git"       ;; source control
-       "nss-certs" ;; for build certs
-       "bash"      ;; for sh (only for dev?)
-       "coreutils" ;; for mkdir which is used in build
+ (list "clojure-tools@1.11" ;; to build and run clojure.
+       "openjdk@21:jdk"     ;; to build and to run clojure.
+       "node@22"            ;; to build and run clojurescript.
+       "git"                ;; to build the jar we use git information.
+       "nss-certs"          ;; to build we need certs.
+       "bash"               ;; for sh (TODO double check this is needed...).
+       "coreutils"          ;; to build the jar it needs mkdir.
        ))

--- a/manifest.scm
+++ b/manifest.scm
@@ -4,7 +4,7 @@
  (list "clojure-tools@1.11" ;; to build and run clojure
        "openjdk@21:jdk" ;; to build, to run clojure
        "node@22"        ;; to build and run clojurescript
-       "git"       ;; source control 
+       "git"       ;; source control
        "nss-certs" ;; for build certs
        "bash"      ;; for sh (only for dev?)
        "coreutils" ;; for mkdir which is used in build

--- a/pyregence-shell.sh
+++ b/pyregence-shell.sh
@@ -2,13 +2,10 @@
 # Run to enter a container that contains all pyregences dependences (e.g java)
 
 guix time-machine \
-  --channels=channels.scm \
-  -- shell \
-  --manifest=manifest.scm \
-  --container \
-  --network \
-  -S /usr/bin/env=bin/env \
-  -- bash -c '
-  export PS1="🔥 \w \$ "
-  exec bash
-  '
+     --channels=channels.scm \
+     -- shell \
+     --manifest=manifest.scm \
+     --container \
+     --network \
+     -S /usr/bin/env=bin/env \
+     -- "$@"

--- a/pyregence-shell.sh
+++ b/pyregence-shell.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# Run to enter a container that contains all pyregences dependences (e.g java)
+# Run to enter a shell that contains all pyregences dependences (e.g java)
+# Notes
+# + symlink to env because webpack looks for node there.
+# + share m2 and gitlabs for clojure deps caching.
 
 guix time-machine \
-     --channels=channels.scm \
-     -- shell \
-     --manifest=manifest.scm \
-     --container \
-     --network \
-     -S /usr/bin/env=bin/env \
-     -- "$@"
+         --channels=channels.scm \
+         -- shell \
+         --manifest=manifest.scm \
+         --container \
+         --network \
+         --symlink="/usr/bin/env=bin/env" \
+         --share=$HOME/.m2 \
+         --share=$HOME/.gitlibs \
+         "$@"

--- a/pyregence-shell.sh
+++ b/pyregence-shell.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Run to enter a container that contains all pyregences dependences (e.g java)
+
+guix time-machine \
+  --channels=channels.scm \
+  -- shell \
+  --manifest=manifest.scm \
+  --container \
+  --network \
+  -S /usr/bin/env=bin/env \
+  -- bash -c '
+  export PS1="🔥 \w \$ "
+  exec bash
+  '


### PR DESCRIPTION

This commit fulfills part of [PYR1-1111](https://sig-gis.atlassian.net/browse/PYR1-1111) by adding Guix functionality that can help with development, but mainly focuses on deployment. Specifically, the part of the deployment that's involved with building the uberjar can now be done in a shared isolated (process and filesystem) environment through [guix](https://guix.gnu.org/).

So, assuming Guix is installed on the machine you want to build the jar, and you have cloned this repo, building the jar looks like what you would see on the pyrecast [jenkins build configuration:](http://jenkins.sig-gis.com/view/PyreCast/job/Pyregence%20Dev%20GCP/configure), mainly calling what's in the new pyregence-shell.sh file, plus passing a command to build the jar, in total, this single long one-line bash command:

```
guix time-machine \
         --channels=channels.scm \
         -- shell \
         --manifest=manifest.scm \
         --container \
         --network \
         --symlink="/usr/bin/env=bin/env" \
         --share=$HOME/.m2 \
         --share=$HOME/.gitlibs \
         -- clj -x:build-uberjar
```

This command is a call to [guix time-machine](https://guix.gnu.org/manual/en/html_node/Invoking-guix-time_002dmachine.html), which, in this context, helps us create that isolated env in which to build the jar (or to run the server through nrepl!). It does this by taking as arguments the two other files (outside pyregence-shell.sh) that are in this commit. The channels.scm, which tells guix where to look for the packages (e.g clojure) in the manifest.scm.



