### PR TITLE
PYR1-1103/use-goes-19-data.

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -192,7 +192,7 @@
                           (merge-fn (split-isochrones-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)
-                              (re-matches #"fire-detections.*:(goes16-rgb|fire-history|conus-buildings|us-transmission-lines|.*boundaries).*" full-name))
+                              (re-matches #"fire-detections.*:(goes19-rgb|fire-history|conus-buildings|us-transmission-lines|.*boundaries).*" full-name))
                           (merge-fn (split-fire-detections full-name))
 
                           (str/starts-with? full-name "fuels")

--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -211,7 +211,7 @@
           " - Hot spots detected by the Moderate Resolution Imaging Spectroradiometer sensor on the Suomi NPP and NOAA-20 satellites."
           [:br]
           [:br]
-          [:strong "Live satellite (GOES-16)"]
+          [:strong "Live satellite (GOES-19)"]
           " - Real time imagery from the GOES East satellite."]
          [:div {:style {:margin-top 10}}
           [:hr]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -57,9 +57,9 @@
                              :z-index       101
                              :filter-set    #{"fire-detections" "modis-timestamped"}
                              :geoserver-key :shasta}
-   :goes-imagery            {:opt-label     "Live satellite (GOES-16)"
+   :goes-imagery            {:opt-label     "Live satellite (GOES-19)"
                              :z-index       100
-                             :filter-set    #{"fire-detections" "goes16-rgb"}
+                             :filter-set    #{"fire-detections" "goes19-rgb"}
                              :geoserver-key :shasta}))
 
 (def near-term-forecast-options


### PR DESCRIPTION
## Purpose
To show the goes-19 live satellite data instead of goes-16.

## Related Issues
Closes PYR1-1103

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing Steps

Visit the site and click the Optional Layer goes-19, and see the satellite image!

Sadly, at the time this PR was made, this isn't quite working and I'm not sure. I suspect it's because 
I'm not correctly mocking the goes-19 folder on sashta. Here is the goes-19 folder i created for testing (yes it should be removed!)


```org
#+begin_src sh :dir /ssh:dverlee@shasta|sudo:root@shasta:/srv/gis/fire_detections/goes-19 :results raw
ls -l
#+end_src

#+RESULTS:
total 52864
-rwxr-xr-x 1 elmfire domain users 4915463 Jun 19 02:16 goes19-rgb_20250619_004617.tif
-rwxr-xr-x 1 elmfire domain users 4696840 Jun 19 02:16 goes19-rgb_20250619_005117.tif
-rwxr-xr-x 1 elmfire domain users 4489510 Jun 19 02:16 goes19-rgb_20250619_005617.tif
-rwxr-xr-x 1 elmfire domain users 4072430 Jun 19 02:16 goes19-rgb_20250619_010617.tif
-rwxr-xr-x 1 elmfire domain users 3874440 Jun 19 02:16 goes19-rgb_20250619_011117.tif
-rwxr-xr-x 1 elmfire domain users 3691040 Jun 19 02:16 goes19-rgb_20250619_011617.tif
-rwxr-xr-x 1 elmfire domain users 3521594 Jun 19 02:16 goes19-rgb_20250619_012117.tif
-rwxr-xr-x 1 elmfire domain users 3354027 Jun 19 02:16 goes19-rgb_20250619_012617.tif
-rwxr-xr-x 1 elmfire domain users 3189967 Jun 19 02:16 goes19-rgb_20250619_013117.tif
-rwxr-xr-x 1 elmfire domain users 3035216 Jun 19 02:16 goes19-rgb_20250619_013617.tif
-rwxr-xr-x 1 elmfire domain users 2892246 Jun 19 02:16 goes19-rgb_20250619_014117.tif
-rwxr-xr-x 1 elmfire domain users 2753816 Jun 19 02:16 goes19-rgb_20250619_014617.tif
-rwxr-xr-x 1 elmfire domain users 2628506 Jun 19 02:16 goes19-rgb_20250619_015117.tif
-rwxr-xr-x 1 elmfire domain users 2507095 Jun 19 02:17 goes19-rgb_20250619_015617.tif
-rwxr-xr-x 1 elmfire domain users 2283740 Jun 19 02:17 goes19-rgb_20250619_020617.tif
-rwxr-xr-x 1 elmfire domain users       0 Jun 19 02:22 goes19-rgb_20250619_021117.tif
-rwxr-xr-x 1 elmfire domain users 2188618 Jun 19 02:16 goes19-rgb.tif
```

And here is what the goes-16 file looks like for reference:

```org

#+begin_src sh :dir /ssh:dverlee@shasta|sudo:root@shasta:/srv/gis/fire_detections/goes-16 :results raw
ls -l
#+end_src

#+RESULTS:
total 54916
-rwxr-xr-x 1 elmfire domain users 4915463 Jun 19 00:54 goes16-rgb_20250619_004617.tif
-rwxr-xr-x 1 elmfire domain users 4696840 Jun 19 00:59 goes16-rgb_20250619_005117.tif
-rwxr-xr-x 1 elmfire domain users 4489510 Jun 19 01:09 goes16-rgb_20250619_005617.tif
-rwxr-xr-x 1 elmfire domain users 4072430 Jun 19 01:14 goes16-rgb_20250619_010617.tif
-rwxr-xr-x 1 elmfire domain users 3874440 Jun 19 01:19 goes16-rgb_20250619_011117.tif
-rwxr-xr-x 1 elmfire domain users 3691040 Jun 19 01:24 goes16-rgb_20250619_011617.tif
-rwxr-xr-x 1 elmfire domain users 3521594 Jun 19 01:30 goes16-rgb_20250619_012117.tif
-rwxr-xr-x 1 elmfire domain users 3354027 Jun 19 01:34 goes16-rgb_20250619_012617.tif
-rwxr-xr-x 1 elmfire domain users 3189967 Jun 19 01:39 goes16-rgb_20250619_013117.tif
-rwxr-xr-x 1 elmfire domain users 3035216 Jun 19 01:44 goes16-rgb_20250619_013617.tif
-rwxr-xr-x 1 elmfire domain users 2892246 Jun 19 01:49 goes16-rgb_20250619_014117.tif
-rwxr-xr-x 1 elmfire domain users 2753816 Jun 19 01:54 goes16-rgb_20250619_014617.tif
-rwxr-xr-x 1 elmfire domain users 2628506 Jun 19 02:00 goes16-rgb_20250619_015117.tif
-rwxr-xr-x 1 elmfire domain users 2507095 Jun 19 02:10 goes16-rgb_20250619_015617.tif
-rwxr-xr-x 1 elmfire domain users 2283740 Jun 19 02:14 goes16-rgb_20250619_020617.tif
-rwxr-xr-x 1 elmfire domain users 2188618 Jun 19 02:20 goes16-rgb_20250619_021117.tif
-rwxr-xr-x 1 elmfire domain users 2097557 Jun 19 02:24 goes16-rgb_20250619_021617.tif
lrwxrwxrwx 1 elmfire domain users      30 Jun 19 02:24 goes16-rgb.tif -> goes16-rgb_20250619_021617.tif
```

What I did was a cp -r, a rename and a `ln -s goes19-rgb.tif goes19-rgb_20250619_021617.tif`

What I'm seeing is that goes19-rgb_20250619_021117.tif has 0 bits and my symlink didn't go through. And i'm currently unsure why. If were confident the code is right, and the mocked goes-19 data is wrong, I'll blow this folder away and send the email to chris to send that data to 19. I'll probably do that anyway.