### PR TITLE
PYR1-1128 Add Fire Factor 2024 (v4) fuels to the Fuels tab

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -87,18 +87,18 @@
                                                                      :units           ""
                                                                      :convert         #(str (u-misc/direction %) " (" % "°)")
                                                                      :reverse-legend? false
-                                                                     :disabled-for    #{:cecs :cfo :fire-factor-2022 :fire-factor-2023 :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
+                                                                     :disabled-for    #{:cecs :cfo :fire-factor-2022 :fire-factor-2023 :fire-factor-2024 :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
                                                             :slp    {:opt-label       "Slope (degrees)"
                                                                      :filter          "slp"
                                                                      :units           "\u00B0"
                                                                      :reverse-legend? true
-                                                                     :disabled-for    #{:cecs :cfo :fire-factor-2022 :fire-factor-2023 :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
+                                                                     :disabled-for    #{:cecs :cfo :fire-factor-2022 :fire-factor-2023 :fire-factor-2024 :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
                                                             :dem    {:opt-label       "Elevation (ft)"
                                                                      :filter          "dem"
                                                                      :units           "ft"
                                                                      :convert         #(u-num/to-precision 1 (* % 3.28084))
                                                                      :reverse-legend? true
-                                                                     :disabled-for    #{:cecs :cfo :fire-factor-2022 :fire-factor-2023 :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
+                                                                     :disabled-for    #{:cecs :cfo :fire-factor-2022 :fire-factor-2023 :fire-factor-2024 :landfire-1.0.5 :landfire-1.3.0 :landfire-1.4.0 :landfire-2.0.0 :landfire-2.1.0 :landfire-2.3.0 :landfire-2.4.0 :landfire-2.4.0-2.3.0}}
                                                             :cc     {:opt-label       "Canopy Cover (%)"
                                                                      :filter          "cc"
                                                                      :units           "%"
@@ -207,6 +207,9 @@
                                                                                    :filter    "ca-2022-fuelscape"}
                                                             :ca-fuelscapes-2021   {:opt-label "2021 CA fuelscape"
                                                                                    :filter    "ca-2021-fuelscape"}
+                                                            :fire-factor-2024     {:opt-label    "Fire Factor 2024"
+                                                                                   :filter       "fire-factor-2024"
+                                                                                   :disabled-for #{:asp :slp :dem}}
                                                             :fire-factor-2023     {:opt-label    "Fire Factor 2023"
                                                                                    :filter       "fire-factor-2023"
                                                                                    :disabled-for #{:asp :slp :dem}}


### PR DESCRIPTION
## Purpose

Same as #926, but for 2024: add a new fuels source: fire-factor-2024

## Related Issues
Closes PYR1-1128

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new D1B table)

## Testing
#### Module Impacted
Fuel layers

#### Role
All

#### Steps
1. Click `fuels` tab
2. Select "Fire Factor 2024" Source
3. Check the layer works on the map
4. Select other `Layer`, like "Canopy Cover (%)" for example
5. Do step `3.`

#### Desired Outcome
New layer works

## Screenshots

See #926, should be similar.

## More details

See [here](https://sig-gis.atlassian.net/browse/PYR1-1128?focusedCommentId=18243)
