### PR TITLE
Clarify the usage of dependencies and update README.

### DIFF
--- a/README.org
+++ b/README.org
@@ -347,6 +347,12 @@ To build a JAR run:
 clj -X:build-uberjar
 #+end_src
 
+Or if you have Guix installed, run:
+
+#+begin_src sh
+./pyregence-shell.sh -- clojure -X:build-uberjar
+#+end_src
+
 This will produce a uberJAR located at  target/pyregence-<date>-<commit>-standalone.jar which depends only
 on a config.edn, java and psql. The JAR's cli actions are available through ~java -jar~:
 

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,11 +1,11 @@
 (use-modules ((gnu packages) #:select (specifications->manifest)))
 
-(specifications->manifest
- (list "clojure-tools@1.11" ;; to build and run clojure.
-       "openjdk@21:jdk"     ;; to build and to run clojure.
-       "node@22"            ;; to build and run clojurescript.
-       "git"                ;; to build the jar we use git information.
-       "nss-certs"          ;; to build we need certs.
-       "bash"               ;; for sh (TODO double check this is needed...).
-       "coreutils"          ;; to build the jar it needs mkdir.
+(specifications->manifest   ;; build jar | run jar | run clojure
+ (list "clojure-tools@1.11" ;; T         | F       | T
+       "openjdk@21:jdk"     ;; T         | T       | T
+       "node@22"            ;; T         | F       | F
+       "git"                ;; T         | F       | F
+       "nss-certs"          ;; T         | F       | F
+       "bash"               ;; T (sh)    | F       | F
+       "coreutils"          ;; T (mdkir) | F       | F
        ))


### PR DESCRIPTION
# Clarify usage of system dependencies.

This commit just clarifies how the system dependencies are used and mentions the option to use Guix to build the jar.
