### PR TITLE
PYR1-1101 Add two-factor authentication UI

### DIFF
--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -47,7 +47,7 @@
   "Generate message for 2FA verification"
   [_ email token expiry-mins]
   (str "Hi " email ",\n\n"
-       "  Please use the following verification code to complete your Pyregence login:\n\n"
+       "  Please use the following verification code:\n\n"
        "  " token "\n\n"
        "  This code will expire in " expiry-mins " minutes.\n\n"
        "  - Pyregence Technical Support"))

--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -15,6 +15,9 @@
    [:get "/admin"]                               {:handler (render-page "/admin")
                                                   :auth-type :admin
                                                   :auth-action :redirect}
+   [:get "/backup-codes"]                        {:handler (render-page "/backup-codes")
+                                                  :auth-type :user
+                                                  :auth-action :redirect}
    [:get "/dashboard"]                           {:handler (render-page "/dashboard")
                                                   :auth-type :user
                                                   :auth-action :redirect}
@@ -26,6 +29,12 @@
    [:get "/privacy-policy"]                      {:handler (render-page "/privacy-policy")}
    [:get "/register"]                            {:handler (render-page "/register")}
    [:get "/reset-password"]                      {:handler (render-page "/reset-password")}
+   [:get "/settings"]                            {:handler (render-page "/settings")
+                                                  :auth-type :user
+                                                  :auth-action :redirect}
+   [:get "/totp-setup"]                          {:handler (render-page "/totp-setup")
+                                                  :auth-type :user
+                                                  :auth-action :redirect}
    [:get "/terms-of-use"]                        {:handler (render-page "/terms-of-use")}
    [:get "/verify-2fa"]                          {:handler (render-page "/verify-2fa")}
    [:get "/verify-email"]                        {:handler (render-page "/verify-email")}
@@ -61,7 +70,10 @@
    [:post "/clj/regenerate-backup-codes"]        {:handler (clj-handler authentication/regenerate-backup-codes)
                                                   :auth-type :user
                                                   :auth-action :block}
-   [:post "/clj/remove-totp"]                    {:handler (clj-handler authentication/remove-totp)
+   [:post "/clj/enable-email-2fa"]               {:handler (clj-handler authentication/enable-email-2fa)
+                                                  :auth-type :user
+                                                  :auth-action :block}
+   [:post "/clj/disable-2fa"]                    {:handler (clj-handler authentication/disable-2fa)
                                                   :auth-type :user
                                                   :auth-action :block}
 

--- a/src/cljs/pyregence/client.cljs
+++ b/src/cljs/pyregence/client.cljs
@@ -5,6 +5,7 @@
             [reagent.dom                        :refer [render]]
             [pyregence.components.page-layout   :refer [wrap-page]]
             [pyregence.pages.admin              :as admin]
+            [pyregence.pages.backup-codes       :as backup-codes]
             [pyregence.pages.dashboard          :as dashboard]
             [pyregence.pages.help               :as help]
             [pyregence.pages.login              :as login]
@@ -13,7 +14,9 @@
             [pyregence.pages.privacy-policy     :as privacy]
             [pyregence.pages.register           :as register]
             [pyregence.pages.reset-password     :as reset-password]
+            [pyregence.pages.settings           :as settings]
             [pyregence.pages.terms-of-use       :as terms]
+            [pyregence.pages.totp-setup         :as totp-setup]
             [pyregence.pages.verify-2fa         :as verify-2fa]
             [pyregence.pages.verify-email       :as verify-email]
             [pyregence.state                    :as !]
@@ -26,6 +29,7 @@
   "All root-components for URIs that should have just a header."
   {"/"                   #(ntf/root-component (merge % {:forecast-type :near-term}))
    "/admin"              admin/root-component
+   "/backup-codes"       backup-codes/root-component
    "/dashboard"          dashboard/root-component
    "/forecast"           #(ntf/root-component (merge % {:forecast-type :near-term}))
    "/login"              login/root-component
@@ -33,6 +37,8 @@
    "/near-term-forecast" #(ntf/root-component (merge % {:forecast-type :near-term}))
    "/register"           register/root-component
    "/reset-password"     reset-password/root-component
+   "/settings"           settings/root-component
+   "/totp-setup"         totp-setup/root-component
    "/verify-2fa"         verify-2fa/root-component
    "/verify-email"       verify-email/root-component})
 

--- a/src/cljs/pyregence/components/login_menu.cljs
+++ b/src/cljs/pyregence/components/login_menu.cljs
@@ -21,7 +21,10 @@
                 :aria-label "Visit the admin page"
                 :href       "/admin"}
             [svg/admin-user :height "25px"]]])
-        [:label {:style    {:cursor "pointer" :margin ".16rem .2rem 0 0"}
+        [:label {:style    {:cursor "pointer" :margin-right "1rem"}
+                 :on-click #(u-browser/jump-to-url! "/settings")}
+         "2FA Settings"]
+        [:label {:style    {:cursor "pointer"}
                  :on-click (fn []
                              (go (<! (u-async/call-clj-async! "log-out"))
                                  (-> js/window .-location .reload)))}

--- a/src/cljs/pyregence/components/two_fa.cljs
+++ b/src/cljs/pyregence/components/two_fa.cljs
@@ -1,0 +1,71 @@
+(ns pyregence.components.two-fa
+  "Shared components for two-factor authentication UI"
+  (:require [herb.core        :refer [<class]]
+            [pyregence.styles :as $]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def code-length             6)
+(def code-validation-pattern #"^[A-Za-z0-9]{0,8}$")
+(def totp-code-pattern       #"^\d{6}$")
+(def backup-code-pattern     #"^[A-Za-z0-9]{8}$")
+
+(defn valid-code?
+  "Validates TOTP (6-digit) or backup (8-char) codes"
+  [code]
+  (or (re-matches totp-code-pattern code)
+      (re-matches backup-code-pattern code)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Components
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn code-box [code & [used?]]
+  [:div {:style (merge {:background-color "white"
+                        :border           (str "1px solid " ($/color-picker :light-gray))
+                        :border-radius    "4px"
+                        :color            "#333"
+                        :font-family      "monospace"
+                        :font-size        "0.9rem"
+                        :padding          "8px 4px"
+                        :text-align       "center"}
+                       (when used? {:opacity "0.5"}))}
+   code])
+
+(defn backup-codes-grid [codes]
+  [:div {:style {:border        (str "1px solid " ($/color-picker :light-gray))
+                 :border-radius "8px"
+                 :margin-bottom "1.5rem"
+                 :padding       "1.5rem"}}
+   [:div {:style {:display               "grid"
+                  :gap                   "10px"
+                  :grid-template-columns "repeat(5, 1fr)"}}
+    (for [backup-code codes]
+      ^{:key (:code backup-code)}
+      [code-box (:code backup-code) (:used? backup-code)])]])
+
+(defn code-input
+  "Code input field. Options: :on-submit :auto-focus? :placeholder"
+  [code-atom & [{:keys [on-submit auto-focus? placeholder]
+                 :or   {placeholder "Enter code"}}]]
+  [:input {:auto-focus  auto-focus?
+           :class       (<class $/p-bordered-input)
+           :maxLength   "8"
+           :on-change   #(when-let [new-val (.-value (.-target %))]
+                           (when (re-matches code-validation-pattern new-val)
+                             (reset! code-atom new-val)))
+           :on-key-down (when on-submit
+                          (fn [e]
+                            (when (= (.-key e) "Enter")
+                              (.preventDefault e)
+                              (on-submit))))
+           :placeholder placeholder
+           :style       {:font-size      "0.9rem"
+                         :height         "2.2rem"
+                         :letter-spacing "0.1em"
+                         :text-align     "center"
+                         :width          "160px"}
+           :type        "text"
+           :value       @code-atom}])

--- a/src/cljs/pyregence/pages/backup_codes.cljs
+++ b/src/cljs/pyregence/pages/backup_codes.cljs
@@ -1,0 +1,189 @@
+(ns pyregence.pages.backup-codes
+  (:require [clojure.core.async             :refer [go <!]]
+            [cljs.reader                    :as reader]
+            [clojure.string                 :as str]
+            [herb.core                      :refer [<class]]
+            [pyregence.components.messaging :refer [toast-message!]]
+            [pyregence.components.two-fa    :as two-fa]
+            [pyregence.styles               :as $]
+            [pyregence.utils.async-utils    :as u-async]
+            [pyregence.utils.browser-utils  :as u-browser]
+            [reagent.core                   :as r]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce state (r/atom {:backup-codes  []       ;; Current codes
+                        :code          ""       ;; Verification code
+                        :loading       true     ;; Loading state
+                        :regenerating? false    ;; Regeneration dialog
+                        :verifying?    false})) ;; Verification mode
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; API Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- fetch-backup-codes! []
+  (go
+    (let [response (<! (u-async/call-clj-async! "get-backup-codes"))]
+      (if (and (:success response) (:body response))
+        (let [parsed-body (reader/read-string (:body response))
+              codes (:backup-codes parsed-body)]
+          (swap! state assoc
+                 :backup-codes codes
+                 :loading false))
+        (do
+          (toast-message! "Failed to load backup codes")
+          (swap! state assoc :loading false))))))
+
+(defn- submit-regeneration! []
+  (go
+    (let [code (:code @state)]
+      (when (two-fa/valid-code? code)
+        (let [response (<! (u-async/call-clj-async! "regenerate-backup-codes" code))
+              body (when (:success response)
+                     (reader/read-string (:body response)))
+              new-codes (:backup-codes body)]
+          (swap! state assoc :code "")
+          (cond
+            (seq new-codes)
+            (do (swap! state assoc
+                       :backup-codes new-codes
+                       :regenerating? false
+                       :verifying? false)
+                (toast-message! "New backup codes generated!"))
+
+            (:success response)
+            (do (toast-message! "Failed to regenerate backup codes")
+                (fetch-backup-codes!))
+
+            :else
+            (toast-message! "Invalid code")))))))
+
+(defn- regenerate-backup-codes! []
+  (cond
+    (:verifying? @state)
+    nil
+
+    (:regenerating? @state)
+    (swap! state assoc :verifying? true :code "")
+
+    :else
+    (swap! state assoc :regenerating? true)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; UI Components
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- code-field
+  "A verification code input field bound to a state map."
+  [state-map & [opts]]
+  (let [code (r/cursor state-map [:code])]
+    [two-fa/code-input code opts]))
+
+(defn- codes [backup-codes on-regenerate]
+  [:div
+   [:p {:style {:margin-bottom "1.5rem"}}
+    "Save these backup codes in a safe place. Each code can only be used once."]
+
+   [two-fa/backup-codes-grid backup-codes]
+
+   [:div {:style {:display "flex"
+                  :gap     "10px"}}
+    [:input {:class    (<class $/p-form-button)
+             :on-click #(u-browser/download-backup-codes! (map :code backup-codes))
+             :type     "button"
+             :value    "DOWNLOAD"}]
+    [:input {:class    (<class $/p-form-button)
+             :on-click #(do
+                          (if (u-browser/copy-to-clipboard! (str/join "\n" (map :code backup-codes)))
+                            (toast-message! "Copied to clipboard")
+                            (toast-message! "Failed to copy")))
+             :type     "button"
+             :value    "COPY"}]
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-regenerate
+             :type     "button"
+             :value    "REGENERATE"}]]])
+
+(defn- confirmation [on-confirm on-cancel]
+  [:div
+   [:p {:style {:margin-bottom "1rem"}}
+    "This will invalidate your current backup codes. Continue?"]
+   [:div {:style {:display "flex"
+                  :gap     "10px"}}
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-confirm
+             :type     "button"
+             :value    "YES, REGENERATE"}]
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-cancel
+             :type     "button"
+             :value    "CANCEL"}]]])
+
+(defn- verification [{:keys [code]} on-submit on-cancel]
+  [:div
+   [:p {:style {:margin-bottom "1rem"}}
+    "Enter your TOTP code or a backup code:"]
+   [:div {:style {:margin-bottom "1rem"}}
+    [code-field state {:on-submit   on-submit
+                       :auto-focus? true
+                       :placeholder "Enter code"}]]
+   [:div {:style {:display "flex"
+                  :gap     "10px"}}
+    [:input {:class    (<class $/p-form-button)
+             :disabled (not (two-fa/valid-code? code))
+             :on-click on-submit
+             :style    (when-not (two-fa/valid-code? code)
+                         {:cursor  "not-allowed"
+                          :opacity "0.6"})
+             :type     "button"
+             :value    "CONFIRM"}]
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-cancel
+             :type     "button"
+             :value    "CANCEL"}]]])
+
+(defn root-component
+  "Root component for backup codes management."
+  []
+  (r/create-class
+   {:component-did-mount fetch-backup-codes!
+    :reagent-render
+    (fn []
+      (let [{:keys [loading backup-codes regenerating? verifying?]} @state]
+        [:div {:style {:display         "flex"
+                       :justify-content "center"
+                       :margin          "5rem"}}
+         [:div {:style ($/combine ($/action-box)
+                                  {:max-width "600px"
+                                   :min-width "500px"})}
+          [:div {:style ($/action-header)}
+           [:label "Backup Codes"]]
+          [:div {:style {:overflow "auto"
+                         :padding  "1.5rem"}}
+           (cond
+             loading
+             [:p "Loading..."]
+
+             (empty? backup-codes)
+             [:div
+              [:p {:style {:margin-bottom "1rem"}}
+               "No backup codes available. Generate new codes to secure your account."]
+              [:input {:class    (<class $/p-form-button)
+                       :on-click regenerate-backup-codes!
+                       :type     "button"
+                       :value    "GENERATE BACKUP CODES"}]]
+
+             :else
+             [:div
+              (cond
+                verifying?
+                [verification @state submit-regeneration! #(swap! state assoc :verifying? false :code "")]
+
+                regenerating?
+                [confirmation regenerate-backup-codes! #(swap! state assoc :regenerating? false)]
+
+                :else
+                [codes backup-codes regenerate-backup-codes!])])]]]))}))

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -30,7 +30,7 @@
         (let [resp-data (edn/read-string (:body response))]
           (if (:require-2fa resp-data)
             ;; 2FA is required, redirect to 2FA verification page
-            (u-browser/jump-to-url! (str "/verify-2fa?email=" (:email resp-data)))
+            (u-browser/jump-to-url! (str "/verify-2fa?email=" (:email resp-data) "&method=" (:method resp-data)))
             ;; Normal login success
             (let [url (:redirect-from (u-browser/get-session-storage) "/forecast")]
               (u-browser/clear-session-storage!)

--- a/src/cljs/pyregence/pages/settings.cljs
+++ b/src/cljs/pyregence/pages/settings.cljs
@@ -1,0 +1,419 @@
+(ns pyregence.pages.settings
+  (:require [clojure.core.async             :refer [go <!]]
+            [clojure.string                 :as str]
+            [cljs.reader                    :as reader]
+            [herb.core                      :refer [<class]]
+            [pyregence.components.messaging :refer [toast-message!]]
+            [pyregence.components.two-fa    :as two-fa]
+            [pyregence.styles               :as $]
+            [pyregence.utils.async-utils    :as u-async]
+            [reagent.core                   :as r]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce state (r/atom {:code       ""       ;; Verification code
+                        :disabling? false    ;; Disabling 2FA
+                        :loading    true     ;; Loading state
+                        :switching? false    ;; Switching methods
+                        :user       nil      ;; User data
+                        :verifying? false})) ;; Viewing codes
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helper Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- parse-user-settings [settings]
+  (cond
+    (nil? settings) {}
+    (map? settings) settings
+    (string? settings)
+    (try
+      (reader/read-string settings)
+      (catch :default e
+        (js/console.error "Failed to parse settings:" settings e)
+        {}))
+    :else {}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; API Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- fetch-user-settings! []
+  (go
+    (let [response (<! (u-async/call-clj-async! "get-current-user-settings"))]
+      (if (and (:success response) (:body response))
+        (let [parsed-body (reader/read-string (:body response))]
+          (swap! state assoc :loading false :user parsed-body))
+        (swap! state assoc :loading false)))))
+
+(defn- handle-enable-email-2fa! []
+  (go
+    (let [code (:code @state)
+          settings (parse-user-settings (:settings (:user @state)))
+          two-factor (:two-factor settings)
+          email (:email (:user @state))]
+      (cond
+        (= two-factor :totp)
+        (cond
+          (not (:switching? @state))
+          (swap! state assoc :switching? true :code "")
+
+          (and (:switching? @state) (seq code))
+          (let [disable-response (<! (u-async/call-clj-async! "disable-2fa" code))]
+            (if (:success disable-response)
+              (do
+                (<! (fetch-user-settings!))
+                (if (:success (<! (u-async/call-clj-async! "send-email" email :2fa)))
+                  (do
+                    (toast-message! "TOTP disabled. Check your email for verification code")
+                    (swap! state assoc :code ""))
+                  (do
+                    (toast-message! "Failed to send verification email")
+                    (swap! state assoc :switching? false :code ""))))
+              (do
+                (toast-message! "Invalid verification code")
+                (swap! state assoc :code "")))))
+
+        :else
+        (cond
+          (not (:switching? @state))
+          (if (:success (<! (u-async/call-clj-async! "send-email" email :2fa)))
+            (do
+              (toast-message! "Verification code sent to your email")
+              (swap! state assoc :switching? true :code ""))
+            (toast-message! "Failed to send verification code"))
+
+          (and (:switching? @state)
+               (two-fa/valid-code? code))
+          (let [enable-response (<! (u-async/call-clj-async! "enable-email-2fa" code))]
+            (if (:success enable-response)
+              (do
+                (toast-message! "Email 2FA enabled successfully")
+                (swap! state assoc :switching? false :code "")
+                (fetch-user-settings!))
+              (do
+                (toast-message! "Invalid verification code")
+                (swap! state assoc :code "")))))))))
+
+(defn- handle-switch-to-totp! []
+  (go
+    (let [code (:code @state)
+          email (:email (:user @state))]
+      (cond
+        ;; Send verification email
+        (not (:switching? @state))
+        (if (:success (<! (u-async/call-clj-async! "send-email" email :2fa)))
+          (do
+            (toast-message! "Verification code sent to your email")
+            (swap! state assoc :switching? true :code ""))
+          (toast-message! "Failed to send verification code"))
+
+        ;; Verify code
+        (and (:switching? @state)
+             (re-matches two-fa/totp-code-pattern code))
+        (let [verify-response (<! (u-async/call-clj-async! "verify-2fa" email code))]
+          (if (:success verify-response)
+            ;; Redirect to TOTP setup
+            (do
+              (swap! state assoc :switching? false :code "")
+              (set! (.-location js/window) "/totp-setup"))
+            (do
+              (toast-message! "Invalid verification code")
+              (swap! state assoc :code ""))))))))
+
+(defn- handle-disable-2fa! []
+  (go
+    (let [code (:code @state)
+          settings (parse-user-settings (:settings (:user @state)))
+          two-factor (:two-factor settings)
+          email (:email (:user @state))]
+      (cond
+        ;; Send email code
+        (and (= two-factor :email) (not (:disabling? @state)))
+        (if (:success (<! (u-async/call-clj-async! "send-email" email :2fa)))
+          (do
+            (toast-message! "Verification code sent to your email")
+            (swap! state assoc :disabling? true :code ""))
+          (toast-message! "Failed to send verification code"))
+
+        (and (= two-factor :totp) (not (:disabling? @state)))
+        (swap! state assoc :disabling? true :code "")
+
+        ;; Disable 2FA
+        (and (:disabling? @state) (seq code))
+        (let [response (<! (u-async/call-clj-async! "disable-2fa" code))]
+          (if (:success response)
+            (do
+              (toast-message! "2FA disabled successfully")
+              (swap! state assoc :disabling? false :code "")
+              (fetch-user-settings!))
+            (do
+              (toast-message! "Invalid verification code")
+              (swap! state assoc :code ""))))))))
+
+(defn- verify-and-view-codes! []
+  (go
+    (let [code (:code @state)
+          user-email (:email (:user @state))]
+      (if (two-fa/valid-code? code)
+        ;; Verify code
+        (let [response (<! (u-async/call-clj-async! "verify-2fa" user-email code))]
+          (if (:success response)
+            ;; Redirect to backup codes
+            (do
+              (swap! state assoc :verifying? false :code "")
+              (set! (.-location js/window) "/backup-codes"))
+            (do
+              (toast-message! "Invalid code. Please try again.")
+              (swap! state assoc :code ""))))
+        (toast-message! "Please enter a valid code")))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; UI Components
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- code-field [state-map & [opts]]
+  (let [code (r/cursor state-map [:code])]
+    [two-fa/code-input code opts]))
+
+(defn- code-verification-dialog [title field-options on-confirm on-cancel code-valid?]
+  [:div
+   [:p {:style {:margin-bottom "1rem"}} title]
+   (when (str/includes? title "authenticator code")
+     [:p {:style {:color         "#666"
+                  :font-size     "0.9rem"
+                  :margin-bottom "1rem"}}
+      "You can also use one of your backup codes."])
+   [:div {:style {:margin-bottom "1rem"}}
+    [code-field state field-options]]
+   [:div {:style {:display "flex"
+                  :gap     "10px"}}
+    [:input (cond-> {:class    (<class $/p-form-button)
+                     :on-click on-confirm
+                     :type     "button"
+                     :value    (if (str/includes? title "view backup codes")
+                                 "VERIFY"
+                                 "CONFIRM")}
+              (not code-valid?)
+              (assoc :disabled true
+                     :style    {:cursor  "not-allowed"
+                                :opacity "0.6"}))]
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-cancel
+             :type     "button"
+             :value    "CANCEL"}]]])
+
+(defn- totp-method-controls [on-view-codes on-switch on-disable]
+  [:div {:style {:display         "flex"
+                 :gap             "10px"
+                 :justify-content "space-between"}}
+   [:div {:style {:display "flex"
+                  :gap     "10px"}}
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-view-codes
+             :type     "button"
+             :value    "VIEW BACKUP CODES"}]
+    [:input {:class    (<class $/p-form-button)
+             :on-click on-switch
+             :type     "button"
+             :value    "SWITCH TO EMAIL 2FA"}]]
+   [:input {:class    (<class $/p-form-button)
+            :on-click on-disable
+            :style    {:border-color ($/color-picker :red)}
+            :type     "button"
+            :value    "DISABLE 2FA"}]])
+
+(defn- authenticator [{:keys [verifying? disabling? switching? code]}
+                      on-view-codes on-switch-to-email on-disable]
+  [:div
+   [:p {:style {:margin-bottom "1rem"}}
+    "Two-factor authentication is enabled using an authenticator app."]
+   (cond
+     verifying?
+     [code-verification-dialog
+      "Enter your authenticator code or a backup code to view backup codes:"
+      {:on-submit on-view-codes :auto-focus? true}
+      on-view-codes
+      #(swap! state assoc :verifying? false :code "")
+      (two-fa/valid-code? code)]
+
+     disabling?
+     [code-verification-dialog
+      "Enter your authenticator code to disable 2FA:"
+      {:on-submit on-disable :auto-focus? true :placeholder "Enter code"}
+      on-disable
+      #(swap! state assoc :disabling? false :code "")
+      (two-fa/valid-code? code)]
+
+     switching?
+     [code-verification-dialog
+      "Enter your authenticator code to switch to email 2FA:"
+      {:on-submit on-switch-to-email :auto-focus? true}
+      on-switch-to-email
+      #(swap! state assoc :switching? false :code "")
+      (two-fa/valid-code? code)]
+
+     :else
+     [totp-method-controls
+      #(swap! state assoc :verifying? true)
+      on-switch-to-email
+      on-disable])])
+
+(defn- email [{:keys [disabling? switching? code]}
+              on-switch-to-totp on-disable]
+  [:div
+   [:p {:style {:margin-bottom "1rem"}}
+    "Two-factor authentication is enabled using email verification."]
+   (cond
+     disabling?
+     [:div
+      [:p {:style {:margin-bottom "1rem"}}
+       "Enter the verification code sent to your email:"]
+      [:div {:style {:margin-bottom "1rem"}}
+       [code-field state {:on-submit   on-disable
+                          :auto-focus? true}]]
+      [:div {:style {:display "flex"
+                     :gap     "10px"}}
+       [:input {:class    (<class $/p-form-button)
+                :disabled (not (two-fa/valid-code? code))
+                :on-click on-disable
+                :style    (when-not (two-fa/valid-code? code)
+                            {:cursor  "not-allowed"
+                             :opacity "0.6"})
+                :type     "button"
+                :value    "CONFIRM"}]
+       [:input {:class    (<class $/p-form-button)
+                :on-click #(swap! state assoc :disabling? false :code "")
+                :type     "button"
+                :value    "CANCEL"}]]]
+
+     switching?
+     [:div
+      [:p {:style {:margin-bottom "1rem"}}
+       "Enter the verification code to switch to authenticator:"]
+      [:div {:style {:margin-bottom "1rem"}}
+       [code-field state {:on-submit on-switch-to-totp
+                          :auto-focus? true}]]
+      [:div {:style {:display "flex"
+                     :gap     "10px"}}
+       [:input {:class    (<class $/p-form-button)
+                :disabled (not (two-fa/valid-code? code))
+                :on-click on-switch-to-totp
+                :style    (when-not (two-fa/valid-code? code)
+                            {:cursor  "not-allowed"
+                             :opacity "0.6"})
+                :type     "button"
+                :value    "CONFIRM"}]
+       [:input {:class    (<class $/p-form-button)
+                :on-click #(swap! state assoc :switching? false :code "")
+                :type     "button"
+                :value    "CANCEL"}]]]
+
+     :else
+     [:div {:style {:display         "flex"
+                    :gap             "10px"
+                    :justify-content "space-between"}}
+      [:input {:class    (<class $/p-form-button)
+               :on-click on-switch-to-totp
+               :type     "button"
+               :value    "SWITCH TO AUTHENTICATOR"}]
+      [:input {:class    (<class $/p-form-button)
+               :on-click on-disable
+               :style    {:border-color ($/color-picker :red)}
+               :type     "button"
+               :value    "DISABLE 2FA"}]])])
+
+(defn- method-choice [{:keys [switching? code]}
+                      on-enable-email]
+  [:div
+   (if switching?
+     [:div
+      [:p {:style {:margin-bottom "1rem"}}
+       "Enter the verification code sent to your email:"]
+      [:div {:style {:margin-bottom "1rem"}}
+       [code-field state {:on-submit   on-enable-email
+                          :auto-focus? true}]]
+      [:div {:style {:display "flex"
+                     :gap     "10px"}}
+       [:input {:class    (<class $/p-form-button)
+                :disabled (not (two-fa/valid-code? code))
+                :on-click on-enable-email
+                :style    (when-not (two-fa/valid-code? code)
+                            {:cursor  "not-allowed"
+                             :opacity "0.6"})
+                :type     "button"
+                :value    "VERIFY"}]
+       [:input {:class    (<class $/p-form-button)
+                :on-click #(swap! state assoc :switching? false :code "")
+                :type     "button"
+                :value    "CANCEL"}]]]
+     [:div
+      [:p {:style {:margin-bottom "1rem"}}
+       "Enable two-factor authentication to secure your account."]
+      [:p {:style {:font-weight   "500"
+                   :margin-bottom "1rem"}}
+       "Choose one method:"]
+      [:div {:style {:display        "flex"
+                     :flex-direction "column"
+                     :gap            "20px"}}
+       [:div
+        [:input {:class    (<class $/p-form-button)
+                 :on-click #(set! (.-location js/window) "/totp-setup")
+                 :style    {:margin-bottom "0.5rem"}
+                 :type     "button"
+                 :value    "AUTHENTICATOR APP"}]
+        [:p {:style {:color         "#666"
+                     :font-size     "0.9rem"
+                     :margin        "0"
+                     :margin-bottom "0.3rem"}}
+         "Use an authenticator app (Recommended)"]
+        [:p {:style {:color     "#666"
+                     :font-size "0.85rem"
+                     :margin    "0"}}
+         "Install Google Authenticator, Microsoft Authenticator, or Authy from your app store"]]
+       [:div
+        [:input {:class    (<class $/p-form-button)
+                 :on-click on-enable-email
+                 :style    {:margin-bottom "0.5rem"}
+                 :type     "button"
+                 :value    "EMAIL VERIFICATION"}]
+        [:p {:style {:color     "#666"
+                     :font-size "0.9rem"
+                     :margin    "0"}}
+         "Receive codes via email"]]]])])
+
+(defn root-component
+  "Root component for 2FA settings page."
+  []
+  (r/create-class
+   {:component-did-mount fetch-user-settings!
+    :reagent-render
+    (fn []
+      (let [{:keys [loading user]} @state
+            settings (parse-user-settings (:settings user))
+            two-factor (:two-factor settings)]
+        [:div {:style {:display         "flex"
+                       :justify-content "center"
+                       :margin          "5rem"}}
+         [:div {:style ($/combine ($/action-box)
+                                  {:max-width "600px"
+                                   :min-width "500px"})}
+          [:div {:style ($/action-header)}
+           [:label "2FA"]]
+          [:div {:style {:overflow "auto"
+                         :padding  "1.5rem"}}
+           (cond
+             loading
+             [:div {:style {:text-align "center"}}
+              [:p "Loading..."]]
+
+             (= two-factor :totp)
+             [authenticator @state verify-and-view-codes! handle-enable-email-2fa! handle-disable-2fa!]
+
+             (= two-factor :email)
+             [email @state handle-switch-to-totp! handle-disable-2fa!]
+
+             :else
+             [method-choice @state handle-enable-email-2fa!])]]]))}))

--- a/src/cljs/pyregence/pages/totp_setup.cljs
+++ b/src/cljs/pyregence/pages/totp_setup.cljs
@@ -1,0 +1,197 @@
+(ns pyregence.pages.totp-setup
+  (:require [clojure.core.async             :refer [go <!]]
+            [cljs.reader                    :as reader]
+            [clojure.string                 :as str]
+            [herb.core                      :refer [<class]]
+            [pyregence.components.messaging :refer [toast-message!]]
+            [pyregence.components.two-fa    :as two-fa]
+            [pyregence.styles               :as $]
+            [pyregence.utils.async-utils    :as u-async]
+            [pyregence.utils.browser-utils  :as u-browser]
+            [reagent.core                   :as r]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def ^:private redirect-delay-ms 1500)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; State
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defonce state
+  ^{:doc "Component state for TOTP setup process"}
+  (r/atom {:backup-codes []       ;; Generated codes
+           :code         ""       ;; Verification code
+           :loading      true     ;; Loading state
+           :qr-uri       nil      ;; QR code URI
+           :setup-key    nil      ;; Manual entry key
+           :show-key?    false})) ;; Show manual option
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helper Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- generate-qr-url [uri]
+  (str "https://api.qrserver.com/v1/create-qr-code/?size=200x200&data="
+       (js/encodeURIComponent uri)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; API Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- start-totp-setup! []
+  (go
+    (let [response (<! (u-async/call-clj-async! "begin-totp-setup"))]
+      (if (and (:success response) (:body response))
+        (let [data (reader/read-string (:body response))
+              {:keys [qr-uri secret backup-codes]} data]
+          (swap! state merge
+                 {:backup-codes (vec backup-codes)
+                  :loading      false
+                  :qr-uri       qr-uri
+                  :setup-key    secret}))
+        (do
+          (toast-message! "Failed to start 2FA setup")
+          (swap! state assoc :loading false))))))
+
+(defn- complete-totp-setup! []
+  (go
+    (let [code (:code @state)]
+      (if (re-matches two-fa/totp-code-pattern code)
+        (let [response (<! (u-async/call-clj-async! "complete-totp-setup" code))]
+          (if (:success response)
+            (do
+              (toast-message! "2FA setup complete!")
+              (js/setTimeout #(set! (.-location js/window) "/settings") redirect-delay-ms))
+            (toast-message! "Invalid code. Please try again.")))
+        (toast-message! "Please enter a 6-digit code")))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; UI Components
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- code-field
+  "A verification code input field bound to a state map."
+  [state-map & [opts]]
+  (let [code (r/cursor state-map [:code])]
+    [two-fa/code-input code opts]))
+
+(defn- step
+  "UI component for displaying a numbered step with title and content."
+  [step-number title content]
+  [:div {:style {:margin-bottom "1.5rem"}}
+   [:p {:style {:font-weight   "500"
+                :margin-bottom "1rem"}}
+    (str step-number ". " title)]
+   content])
+
+(defn- enrollment [{:keys [qr-uri setup-key show-key?]} on-toggle-key]
+  [:div
+   (when qr-uri
+     [:div {:style {:border        (str "1px solid " ($/color-picker :light-gray))
+                    :border-radius "4px"
+                    :margin-bottom "1rem"
+                    :padding       "2rem 1rem"
+                    :text-align    "center"}}
+      [:img {:alt   "QR Code"
+             :src   (generate-qr-url qr-uri)
+             :style {:background-color "white"
+                     :border           (str "1px solid " ($/color-picker :light-gray))
+                     :padding          "10px"}}]])
+
+   [:div {:style {:margin-top "1rem"}}
+    [:a {:href     "#"
+         :on-click (fn [e]
+                     (.preventDefault e)
+                     (on-toggle-key))
+         :style    {:color           "inherit"
+                    :cursor          "pointer"
+                    :font-size       "0.9rem"
+                    :text-decoration "none"}}
+     (str (if show-key? "▲" "▼") " Unable to scan? Use setup key instead")]
+    (when show-key?
+      [:div {:style {:margin-top "1rem"}}
+       [:p {:style {:font-size     "0.9rem"
+                    :margin-bottom "0.75rem"}}
+        "Enter this key in your authenticator app:"]
+       [:div {:style {:align-items "center"
+                      :display     "flex"
+                      :gap         "10px"}}
+        [two-fa/code-box setup-key]
+        [:input {:class    (<class $/p-form-button)
+                 :on-click #(do
+                              (if (u-browser/copy-to-clipboard! setup-key)
+                                (toast-message! "Copied to clipboard")
+                                (toast-message! "Failed to copy")))
+                 :type     "button"
+                 :value    "COPY"}]]])]])
+
+(defn- codes [backup-codes]
+  (when (seq backup-codes)
+    [:div
+     [two-fa/backup-codes-grid backup-codes]
+     [:div {:style {:display "flex"
+                    :gap     "10px"}}
+      [:input {:class    (<class $/p-form-button)
+               :on-click #(u-browser/download-backup-codes! (map :code backup-codes))
+               :type     "button"
+               :value    "DOWNLOAD"}]
+      [:input {:class    (<class $/p-form-button)
+               :on-click #(do
+                            (if (u-browser/copy-to-clipboard! (str/join "\n" (map :code backup-codes)))
+                              (toast-message! "Copied to clipboard")
+                              (toast-message! "Failed to copy")))
+               :type     "button"
+               :value    "COPY"}]]]))
+
+(defn- verification [state-atom on-submit]
+  (let [{:keys [code]} @state-atom]
+    [:div
+     [:div {:style {:margin-bottom "1rem"}}
+      [code-field state-atom {:on-submit on-submit
+                              :placeholder "Enter 6-digit code"}]]
+
+     [:div {:style {:margin-top "1rem"
+                    :text-align "right"}}
+      [:input {:class    (<class $/p-form-button)
+               :disabled (not= two-fa/code-length (count code))
+               :on-click on-submit
+               :style    (when (not= two-fa/code-length (count code))
+                           {:cursor  "not-allowed"
+                            :opacity "0.6"})
+               :type     "button"
+               :value    "CONTINUE"}]]]))
+
+(defn root-component
+  "Root component for TOTP setup process."
+  []
+  (r/create-class
+   {:component-did-mount start-totp-setup!
+    :reagent-render
+    (fn []
+      (let [{:keys [loading backup-codes]} @state]
+        [:div {:style {:display         "flex"
+                       :justify-content "center"
+                       :margin          "5rem"}}
+         [:div {:style ($/combine ($/action-box)
+                                  {:max-width "600px"
+                                   :min-width "500px"})}
+          [:div {:style ($/action-header)}
+           [:label "2FA"]]
+          [:div {:style {:overflow "auto"
+                         :padding  "1.5rem"}}
+           (if loading
+             [:div {:style {:padding    "2rem"
+                            :text-align "center"}}
+              [:p "Loading..."]]
+             [:div
+              [step 1 "Scan QR code with your authenticator app"
+               [enrollment @state #(swap! state update :show-key? not)]]
+
+              [step 2 "Save your backup codes"
+               [codes backup-codes]]
+
+              [step 3 "Verify your device"
+               [verification state complete-totp-setup!]]])]]]))}))

--- a/src/cljs/pyregence/pages/verify_2fa.cljs
+++ b/src/cljs/pyregence/pages/verify_2fa.cljs
@@ -11,9 +11,10 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defonce pending?           (r/atom false))
-(defonce email              (r/atom ""))
-(defonce verification-code  (r/atom ""))
+(defonce pending?          (r/atom false))   ;; Loading state
+(defonce email             (r/atom ""))      ;; User email
+(defonce verification-code (r/atom ""))      ;; Code input
+(defonce method            (r/atom "email")) ;; 'email' or 'totp'
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; API Calls
@@ -26,7 +27,7 @@
                          [(when (empty? @verification-code)
                             "Please enter the verification code.")])]
 
-      (if (pos? (count errors))
+      (if (seq errors)
         (do (toast-message! errors)
             (reset! pending? false))
         (if (:success (<! (u-async/call-clj-async! "verify-2fa" @email @verification-code)))
@@ -40,12 +41,35 @@
 ;; UI Components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn- prompt [{:keys [auth-method user-email]} on-resend-email]
+  (if (= auth-method "totp")
+    [:<>
+     [:p {:style {:margin-bottom "0.5rem"}}
+      "Enter the 6-digit code from your authenticator app."]
+     [:p {:style {:color       "#666"
+                  :font-size   "0.9rem"
+                  :margin-top  "0.5rem"}}
+      "You can also use one of your 8-character backup codes."]]
+    [:<>
+     [:p {:style {:margin-bottom "0.5rem"}}
+      [:span
+       "Enter the verification code sent to "
+       [:span {:style {:font-weight "bold"}} user-email]
+       "."]]
+     [:a {:href     "#"
+          :on-click on-resend-email
+          :style    {:color      ($/color-picker :link-color)
+                     :font-size  "0.9rem"
+                     :margin-top "0.5rem"}}
+      "Resend verification code"]]))
+
 (defn root-component
   "The root component for the /verify-2fa page.
    Displays the 2FA verification form."
   [params]
   (reset! email (or (:email params) ""))
-  ;; If email is missing, redirect to login page
+  (reset! method (or (:method params) "email"))
+  ;; Redirect if no email
   (when (empty? @email)
     (u-browser/jump-to-url! "/login"))
   (fn [_]
@@ -57,18 +81,12 @@
        "Verify"
        [["Verification Code" verification-code "text" "verification-code"]]
        verify-2fa!]]
-     [:div {:style {:display "flex"
+     [:div {:style {:align-items    "center"
+                    :display        "flex"
                     :flex-direction "column"
-                    :align-items "center"
-                    :margin-top "1rem"}}
-      [:p {:style {:margin-bottom "0.5rem"}}
-       (str "Enter the verification code sent to ")
-       [:span {:style {:font-weight "bold"}} @email]
-       "."]
-      [:a {:href "#"
-           :style {:color ($/color-picker :link-color)}
-           :on-click #(go
-                        (if (:success (<! (u-async/call-clj-async! "send-email" @email :2fa)))
-                          (toast-message! "A new verification code has been sent to your email.")
-                          (toast-message! "Failed to send verification code. Please try again.")))}
-       "Resend verification code"]]]))
+                    :margin-top     "1rem"}}
+      [prompt {:auth-method @method :user-email @email}
+       #(go
+          (if (:success (<! (u-async/call-clj-async! "send-email" @email :2fa)))
+            (toast-message! "A new verification code has been sent to your email.")
+            (toast-message! "Failed to send verification code. Please try again.")))]]]))

--- a/src/cljs/pyregence/utils/browser_utils.cljs
+++ b/src/cljs/pyregence/utils/browser_utils.cljs
@@ -74,3 +74,29 @@
    (if window-name
      (.open js/window url window-name)
      (jump-to-url! url))))
+
+(defn copy-to-clipboard!
+  "Copies text to the system clipboard. Returns true if successful, false otherwise."
+  [text]
+  (let [textarea (.createElement js/document "textarea")]
+    (set! (.-value textarea) text)
+    (.appendChild js/document.body textarea)
+    (.select textarea)
+    (let [success (.execCommand js/document "copy")]
+      (.removeChild js/document.body textarea)
+      success)))
+
+(defn download-backup-codes!
+  "Downloads backup codes as a text file"
+  [codes]
+  (let [content (str "Pyregence 2FA Backup Codes\n"
+                     "Generated: " (.toLocaleDateString (js/Date.)) "\n\n"
+                     (str/join "\n" codes) "\n\n"
+                     "Keep these codes safe. Each can only be used once.")
+        blob (js/Blob. #js [content] #js {:type "text/plain"})
+        url (.createObjectURL js/URL blob)
+        a (.createElement js/document "a")]
+    (set! (.-href a) url)
+    (set! (.-download a) "pyregence-backup-codes.txt")
+    (.click a)
+    (.revokeObjectURL js/URL url)))


### PR DESCRIPTION
## Overview

Complete frontend implementation for two-factor authentication (2FA) with support for both authenticator apps (TOTP) and email-based verification.

## What's New

Added four new pages for 2FA management: Settings (`/settings`) serves as the central hub for configuration, TOTP Setup (`/totp-setup`) handles authenticator app setup with QR codes and backup codes, Backup Codes (`/backup-codes`) allows viewing and regenerating recovery codes, and 2FA Verification (`/verify-2fa`) provides login-time verification.

Users can now enable/disable 2FA with proper verification, switch between email and authenticator methods, and manage their backup codes. Used backup codes appear with visual indicators, and users can download or copy their codes for safekeeping.

## Technical Implementation

### Frontend
Created a reusable 2FA components with standardized code input fields used across all flows. Built custom UI components for code verification, ensuring consistent error messages and user feedback throughout. Added backup code download utility and settings navigation link.

### Backend Integration
Email verification is now required when enabling email 2FA for security. All verification endpoints support both 6-digit TOTP codes and 8-character backup codes, ensuring backup codes work anywhere TOTP codes do. Added seamless handling for the various 2FA flows (email/authenticator).

### Testing
Added RCT tests for the new email 2FA verification flow and included test users: `user@pyr.dev` (no 2FA), `totp-2fa@pyr.dev` (authenticator enabled), and `email-2fa@pyr.dev` (email 2FA enabled).

## Screenshots

1. 2FA Settings entry point - New "2FA Settings" link in navigation bar
<img width="1413" height="780" alt="1- settings entry" src="https://github.com/user-attachments/assets/e8334043-1b23-4dc3-89eb-cc85cd8fbeee" />

2. Method selection - Initial setup screen to choose authenticator app or email
<img width="1214" height="728" alt="2-settings" src="https://github.com/user-attachments/assets/c04c298e-86b8-47fc-8c49-952bbeb13a8a" />

3. TOTP setup - QR code scanning, manual key entry, and backup codes display
<img width="1413" height="780" alt="3-2fa totp" src="https://github.com/user-attachments/assets/dbb82632-c8b5-431c-a183-bf9f2fcedeb2" />

4. Email verification - Code entry with success toast notification
<img width="1413" height="780" alt="4-email verification" src="https://github.com/user-attachments/assets/9f3a4a36-0c7a-4075-ad9e-e9f60d9c4c70" />

5. Email 2FA enabled - Management options to switch methods or disable
<img width="1413" height="780" alt="5-email 2fa enabled" src="https://github.com/user-attachments/assets/9a6c21cb-061d-44f4-ae53-68dc9d8df9f2" />

6. Disable email 2FA - Verification dialog requiring email code confirmation
<img width="1413" height="780" alt="6-disable email 2fa" src="https://github.com/user-attachments/assets/f8ba0f44-b6a0-4e87-9c7a-ea3bd6a25762" />

7. Authenticator management - View backup codes, switch to email, or disable
<img width="1413" height="780" alt="7-settings with authenticator enabled" src="https://github.com/user-attachments/assets/091d11e5-b275-4370-97e5-8d773c88aa6d" />

8. View backup codes - Verification accepting authenticator or backup codes
<img width="1413" height="780" alt="8-view backup codes code" src="https://github.com/user-attachments/assets/7fe1407a-b1c0-4eb3-8390-4d198af49999" />

9. Backup codes page - Display 10 codes with download/copy/regenerate options
<img width="1413" height="780" alt="9-backup codes" src="https://github.com/user-attachments/assets/bc92ed5d-becd-4e47-88cf-7de9c30c641a" />

10. Regeneration warning - Confirmation that regenerating invalidates current codes
<img width="1413" height="780" alt="10-backup code regenration confirmation" src="https://github.com/user-attachments/assets/16034293-5329-4ea8-a58f-f990559569b3" />

11. Regeneration verification - Requires TOTP or backup code to proceed
<img width="1413" height="780" alt="11-backup code regeneration verificaiton" src="https://github.com/user-attachments/assets/f3fcd1cd-7797-4424-bd7a-eca72f8dd477" />

12. Switch to email - Verification when switching from authenticator to email
<img width="1413" height="780" alt="12-switching from authenticator to email diaglog code" src="https://github.com/user-attachments/assets/abe1f225-4dbd-4b9f-b1b9-1fff0af261b8" />

13. Login verification - Accepts 6-digit TOTP or 8-character backup codes
<img width="1413" height="780" alt="13-login 2fa verfication screen" src="https://github.com/user-attachments/assets/53e4c66a-8eb0-4d6a-9826-21f203b27e13" />

14. Email login - Email verification with "Resend verification code" link
<img width="1413" height="780" alt="14-login email verfication screen" src="https://github.com/user-attachments/assets/2732bac1-107f-482d-867d-ebfa85bea70c" />
