### PR TITLE
WIP: PYR1-1119 Fix bug where Match Drops weren't able to be initiated.

### DIFF
--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -589,8 +589,8 @@
     2       (do
               (log-str (str "Geoserver workspace is " geoserver-workspace))
               ;; NOTE: set-capabilities! isn't handled by the GeoSync action hook since GeoSync is running in CLI mode in the GeoSync microservice (action hooks only work in server mode).
-              (set-capabilities! {"geoserver-key"  "match-drop"
-                                  "workspace-name" geoserver-workspace})
+              (set-capabilities! nil {"geoserver-key"  "match-drop"
+                                      "workspace-name" geoserver-workspace})
               (log-str (str "Match Drop layers successfully added to Pyrecast! "
                             "Match Drop job #" match-job-id " is complete."))
               (update-match-job! {:match-job-id match-job-id
@@ -604,8 +604,8 @@
             ;; TODO in the future we should make sure that the front-end is updated as soon as the workspace is removed.
             ;; we will need to do something similar to the refresh-fire-names! fn in match_drop_tool.cljs, but only call
             ;; it once this section of the code is hit.
-            (remove-workspace! {"geoserver-key"  "match-drop"
-                                "workspace-name" geoserver-workspace}))
+            (remove-workspace! nil {"geoserver-key"  "match-drop"
+                                    "workspace-name" geoserver-workspace}))
 
     :else (update-match-drop-on-error! match-job-id
                                        {:job-id  job-id


### PR DESCRIPTION
## Purpose
Fixes a bug introduced in #934 where the `match-drop/initiate-md!` function didn't correctly pass along the `user-id` parameter, which lead to errors of the following type, which prevent Match Drops from initiating:
```
"ERROR: null value in column \"user_rid\" of relation \"match_jobs\" violates not-null constraint\n  Detail: Failing row contains (203, null, 2025-07-31 14:18:48.712312, 2025-07-31 14:18:48.712312, 2, null, , f, f, null, null, null, null, null, null, null).\n  Where: SQL function \"initialize_match_job\" statement 1"
```

## Related Issues
Closes PYR1-1119

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. Toolbars > Camera Tool) -->
<!-- The current list of all Modules is: -->
<!-- Layers, Side Panel, Point Info, Toolbars, Match Drop, Misc., Mobile -->

#### Role
<!-- Admin, User, or Visitor -->

#### Steps
<!-- All steps needed to test this PR -->
1.

#### Desired Outcome

