### PR TITLE
PYR1-1181 Only allow logged in users to see the weather stations

### DIFF
--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -132,7 +132,7 @@
                                                   :auth-action :block}
    ;; Weather Station API
    [:post "/clj/get-weather-stations"]           {:handler (clj-handler weather-stations/get-weather-stations)
-                                                  :auth-type   :token
+                                                  :auth-type   #{:member :token}
                                                   :auth-action :block}
 
    [:post "/clj/get-current-image"]              {:handler (clj-handler cameras/get-current-image)

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -132,16 +132,17 @@
                    (reset! !/show-weather-station? false)
                    (gtag-tool-clicked @!/show-camera? "camera"))
               @!/show-camera?])
-           [:weather-station
-            "Show weather stations"
-            #(do
-               (reset! !/show-info? false)
-               (reset! !/show-measure-tool? false)
-               (reset! !/show-match-drop? false)
-               (reset! !/show-camera? false)
-               (swap! !/show-weather-station? not)
-               (gtag-tool-clicked @!/show-weather-station? "weather-station"))
-            @!/show-weather-station?]
+           (when (number? user-id)
+            [:weather-station
+             "Show weather stations"
+             #(do
+                (reset! !/show-info? false)
+                (reset! !/show-measure-tool? false)
+                (reset! !/show-match-drop? false)
+                (reset! !/show-camera? false)
+                (swap! !/show-weather-station? not)
+                (gtag-tool-clicked @!/show-weather-station? "weather-station"))
+             @!/show-weather-station?])
            (when-not (get-any-level-key :disable-flag?)
              [:flag
               (str (hs-str @!/show-red-flag?) " red flag warnings")

--- a/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
@@ -71,7 +71,7 @@
    [:a {:href   "https://api.weather.gov/"
         :ref    "noreferrer noopener"
         :target "_blank"}
-    "National Weather Service (NWS) API."]
+    "National Weather Service (NWS) API"]
    "."])
 
 (defn- not-found


### PR DESCRIPTION
## Purpose
Only allow logged in users to see the weather stations

## Related Issues
Closes PYR1-1181

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

