### PR TITLE
Use namespaced keyword

### DIFF
--- a/src/clj/pyregence/weather_stations.clj
+++ b/src/clj/pyregence/weather_stations.clj
@@ -32,7 +32,7 @@
         (catch Exception ex (log (ex-data ex) :truncate? false)))
       (Thread/sleep (* 1000 ;; 1s
                        60   ;; 1m
-                       (get-config :pyregence.weather-stations/get-observation-stations-every-n-minutes)))
+                       (get-config ::get-observation-stations-every-n-minutes)))
       (recur))))
 
 (defn- select-relevent-properties


### PR DESCRIPTION
## Purpose
Use name-spaced keyword `::get-observation-stations-every-n-minutes` in current namespace.

