### PR TITLE
PRY1-1184 fix alignment of tip to tool for camera and WS.

### DIFF
--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -273,16 +273,20 @@
             tool-tip-text]]))})))
 
 (defn tool-tip-wrapper
-  "Adds a tooltip given the desired text (or Hiccup), direction of the tooltip, and the element."
-  [tool-tip-text arrow-position sibling]
-  (r/with-let [show?        (r/atom false)
-               sibling-ref  (r/atom nil)]
-    [:div {:on-mouse-over  #(do (reset! show? true))
-           :on-touch-end   #(go (<! (timeout 1500)) (reset! show? false))
-           :on-mouse-leave #(reset! show? false)}
-     [sibling-wrapper sibling sibling-ref]
-     (when @sibling-ref
-       [tool-tip {:tool-tip-text  tool-tip-text
-                  :sibling-ref    @sibling-ref
-                  :arrow-position arrow-position
-                  :show?          @show?}])]))
+  "Adds a tooltip given the desired text (or Hiccup), direction of the tooltip, and the element.
+   Can optional take a parent to position of the child (see PYR1-1190)."
+  ([tool-tip-text arrow-position child parent]
+   [parent
+    [tool-tip-wrapper tool-tip-text arrow-position child]])
+  ([tool-tip-text arrow-position sibling]
+   (r/with-let [show?        (r/atom false)
+                sibling-ref  (r/atom nil)]
+     [:div {:on-mouse-over  #(do (reset! show? true))
+            :on-touch-end   #(go (<! (timeout 1500)) (reset! show? false))
+            :on-mouse-leave #(reset! show? false)}
+      [sibling-wrapper sibling sibling-ref]
+      (when @sibling-ref
+        [tool-tip {:tool-tip-text  tool-tip-text
+                   :sibling-ref    @sibling-ref
+                   :arrow-position arrow-position
+                   :show?          @show?}])])))

--- a/src/cljs/pyregence/components/common.cljs
+++ b/src/cljs/pyregence/components/common.cljs
@@ -273,8 +273,7 @@
             tool-tip-text]]))})))
 
 (defn tool-tip-wrapper
-  "Adds a tooltip given the desired text (or Hiccup), direction of the tooltip, and the element.
-   Can optional take a parent to position of the child (see PYR1-1190)."
+  "Adds a tooltip given the desired text (or Hiccup), direction of the tooltip, and the element. Can optionally take a parent to position the child (see PYR1-1190)."
   ([tool-tip-text arrow-position child parent]
    [parent
     [tool-tip-wrapper tool-tip-text arrow-position child]])

--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -114,15 +114,15 @@
        [:div {:style {:height "32px"
                       :width  "32px"}}
         [svg/return]]]])
+   [:div {:style {:bottom   "1.25rem"
+                  :position "absolute"
+                  :right    "1rem"}}]
    [tool-tip-wrapper
     "Zoom Map to Camera"
-    :right
+    :top
     [:button {:class    (<class $/p-themed-button)
               :on-click zoom-camera
-              :style    {:bottom   "1.25rem"
-                         :padding  "2px"
-                         :position "absolute"
-                         :right    "1rem"}}
+              :style    {:padding  "2px"}}
      [:div {:style {:height "32px"
                     :width  "32px"}}
       [svg/binoculars]]]]

--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -104,7 +104,7 @@
    (when @!/terrain?
      [tool-tip-wrapper
       "Zoom Out to 2D"
-      :left
+      :top
       [:button {:class    (<class $/p-themed-button)
                 :on-click reset-view
                 :style    {:padding  "2px"}}

--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -107,13 +107,15 @@
       :left
       [:button {:class    (<class $/p-themed-button)
                 :on-click reset-view
-                :style    {:bottom   "1.25rem"
-                           :padding  "2px"
-                           :position "absolute"
-                           :left     "1rem"}}
+                :style    {:padding  "2px"}}
        [:div {:style {:height "32px"
                       :width  "32px"}}
-        [svg/return]]]])
+        [svg/return]]]
+      (fn [child]
+        [:div {:style {:bottom   "1.25rem"
+                       :position "absolute"
+                       :left     "1rem"}}
+         child])])
    [tool-tip-wrapper
     "Zoom Map to Camera"
     :top
@@ -124,8 +126,8 @@
                     :width  "32px"}}
       [svg/binoculars]]]
     (fn [child] [:div {:style {:bottom   "1.25rem"
-                               :position "absolute"
-                               :right    "1rem"}}
+                              :position "absolute"
+                              :right    "1rem"}}
                  child])]
    [:img {:src   @image-src
           :style {:height "auto" :width "100%"}}]])

--- a/src/cljs/pyregence/components/map_controls/camera_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/camera_tool.cljs
@@ -114,9 +114,6 @@
        [:div {:style {:height "32px"
                       :width  "32px"}}
         [svg/return]]]])
-   [:div {:style {:bottom   "1.25rem"
-                  :position "absolute"
-                  :right    "1rem"}}]
    [tool-tip-wrapper
     "Zoom Map to Camera"
     :top
@@ -125,7 +122,11 @@
               :style    {:padding  "2px"}}
      [:div {:style {:height "32px"
                     :width  "32px"}}
-      [svg/binoculars]]]]
+      [svg/binoculars]]]
+    (fn [child] [:div {:style {:bottom   "1.25rem"
+                               :position "absolute"
+                               :right    "1rem"}}
+                 child])]
    [:img {:src   @image-src
           :style {:height "auto" :width "100%"}}]])
 

--- a/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
@@ -153,18 +153,18 @@
        [:div {:style {:height "32px"
                       :width  "32px"}}
         [svg/return]]]])
-   [tool-tip-wrapper
-    "Zoom Map to Weather Station"
-    :right
-    [:button {:class    (<class $/p-themed-button)
-              :on-click zoom-weather-station
-              :style    {:bottom   "1.25rem"
-                         :padding  "2px"
-                         :position "absolute"
-                         :right    "1rem"}}
-     [:div {:style {:height "32px"
-                    :width  "32px"}}
-      [svg/binoculars]]]]])
+   [:div {:style {:bottom   "1.25rem"
+                  :position "absolute"
+                  :right    "1rem"}}
+    [tool-tip-wrapper
+     "Zoom Map to Weather Station"
+     :right
+     [:button {:class    (<class $/p-themed-button)
+               :on-click zoom-weather-station
+               :style    {:padding  "2px"}}
+      [:div {:style {:height "32px"
+                     :width  "32px"}}
+       [svg/binoculars]]]]]])
 
 (defn- loading-all-stations []
   [:div {:style {:padding "1.2em"}}

--- a/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
@@ -153,18 +153,21 @@
        [:div {:style {:height "32px"
                       :width  "32px"}}
         [svg/return]]]])
-   [:div {:style {:bottom   "1.25rem"
-                  :position "absolute"
-                  :right    "1rem"}}
-    [tool-tip-wrapper
-     "Zoom Map to Weather Station"
-     :right
-     [:button {:class    (<class $/p-themed-button)
-               :on-click zoom-weather-station
-               :style    {:padding  "2px"}}
-      [:div {:style {:height "32px"
-                     :width  "32px"}}
-       [svg/binoculars]]]]]])
+
+   [tool-tip-wrapper
+    "Zoom Map to Weather Station"
+    :right
+    [:button {:class    (<class $/p-themed-button)
+              :on-click zoom-weather-station
+              :style    {:padding  "2px"}}
+     [:div {:style {:height "32px"
+                    :width  "32px"}}
+      [svg/binoculars]]]
+    (fn [child]
+      [:div {:style {:bottom   "1.25rem"
+                     :position "absolute"
+                     :right    "1rem"}}
+       child])]])
 
 (defn- loading-all-stations []
   [:div {:style {:padding "1.2em"}}

--- a/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
@@ -143,13 +143,10 @@
    (when @!/terrain?
      [tool-tip-wrapper
       "Zoom Out to 2D"
-      :left
+      :top
       [:button {:class    (<class $/p-themed-button)
                 :on-click reset-view
-                :style    {:bottom   "1.25rem"
-                           :padding  "2px"
-                           :position "absolute"
-                           :left     "1rem"}}
+                :style    {:padding  "2px"}}
        [:div {:style {:height "32px"
                       :width  "32px"}}
         [svg/return]]]
@@ -161,7 +158,7 @@
 
    [tool-tip-wrapper
     "Zoom Map to Weather Station"
-    :right
+    :top
     [:button {:class    (<class $/p-themed-button)
               :on-click zoom-weather-station
               :style    {:padding  "2px"}}

--- a/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
+++ b/src/cljs/pyregence/components/map_controls/weather_station_observation_latest_tool.cljs
@@ -152,7 +152,12 @@
                            :left     "1rem"}}
        [:div {:style {:height "32px"
                       :width  "32px"}}
-        [svg/return]]]])
+        [svg/return]]]
+      (fn [child]
+        [:div {:style {:bottom   "1.25rem"
+                       :position "absolute"
+                       :left     "1rem"}}
+         child])])
 
    [tool-tip-wrapper
     "Zoom Map to Weather Station"


### PR DESCRIPTION
## Purpose
This branch's purpose is to fix the alignment of the camera and weather station tips to their tools.

## Related Issues
Closes PYR1-1184

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g., updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing

For each tool: weather-station and camera, hover over binoculars (zoom-in) and expect to see the tip closely aligned just under the tip, now click the tool and do the same for the zoom-out icon. Also, check the other tool tips and notice how they haven't changed!

<img width="845" height="614" alt="Screenshot from 2025-09-03 16-40-04" src="https://github.com/user-attachments/assets/0b82d1a0-8930-4295-9ff9-25c5b7ee894f" />
<img width="845" height="614" alt="Screenshot from 2025-09-03 16-40-00" src="https://github.com/user-attachments/assets/0f23c854-c33d-4131-a075-aa4502cc229e" />
