### PR TITLE
PYR1-1127/add fire risk predicted fire size combined percentile when admin

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -193,12 +193,13 @@
                           (re-matches #"([a-z|-]+_[a-z0-9|-]+_)\d{8}_\d{2}:([A-Za-z0-9|-]+\d*_)+\d{8}_\d{6}" full-name)
                           (merge-fn (split-risk-weather-psps-layer-name full-name))
 
-                          (and (re-matches #"[a-z|-]+_[a-z|-]+[a-z|\d|-]*_\d{8}_\d{6}:([a-z|-]+_){2}\d{2}_[a-z|-]+" full-name)
+                          (and (re-matches #"[a-z|-]+_[a-z|-]+[a-z|\d|-]*_\d{8}_\d{6}:([a-z|-]+_){2}(\d{2}|combined)_[a-z|-]+" full-name)
                                (or (get-config :triangulum.views/client-keys :features :match-drop) (not (str/includes? full-name "match-drop"))))
                           (merge-fn (split-fire-spread-forecast-layer-name full-name))
 
                           (and (str/includes? full-name "isochrones")
-                               (re-matches #"([a-z|-]+_)[a-z|-]+[a-z|\d|-]*_\d{8}_\d{6}:([a-z|-]+_){2}\d{2}_isochrones_[a-z|\d|-]*_\d{8}_\d{6}_\d{2}" full-name))
+                               (re-matches #"([a-z|-]+_)[a-z|-]+[a-z|\d|-]*_\d{8}_\d{6}:([a-z|-]+_){2}(\d{2}|combined)_isochrones_[a-z|\d|-]*_\d{8}_\d{6}_(\d{2}|combined)" full-name))
+
                           (merge-fn (split-isochrones-layer-name full-name))
 
                           (or (re-matches #"fire-detections.*_\d{8}_\d{6}" full-name)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -735,7 +735,15 @@
           psps-orgs-list-chan             (u-async/call-clj-async! "get-psps-organizations")
           match-drop-access-chan          (u-async/call-clj-async! "get-user-match-drop-access")
           fire-names                      (edn/read-string (:body (<! fire-names-chan)))
-          active-fire-count               (count (:active-fires fire-names))]
+          active-fire-count               (count (:active-fires fire-names))
+          options-config                  (cond-> options-config admin?
+                                                  (assoc-in [:active-fire
+                                                             :params
+                                                             :burn-pct
+                                                             :options
+                                                             :combined]
+                                                            {:opt-label "Combined"
+                                                             :filter    "combined"}))]
       (reset! !/match-drop-access? (:success (<! match-drop-access-chan)))
       (reset! !/active-fire-count active-fire-count)
       (reset! !/user-orgs-list (edn/read-string (:body (<! user-orgs-list-chan))))


### PR DESCRIPTION
As the title says, the goal is to add the fire-risk predicted fire size combined percentile when the user is an admin. So, login as a Super Admin, visit the fire risk tab, click predicted fire size then combined. This should show you the combined view on a successful matchdrop run. 