### PR TITLE
Fix update users status

### DIFF
--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -471,12 +471,19 @@ BEGIN
                               END,
       user_role             = CASE
                                 WHEN _status IN ('pending', 'accepted')
-                                THEN 'organization_member'::user_role
+                                THEN
+                                  CASE
+                                    WHEN user_role IN ('organization_admin', 'organization_member')
+                                    THEN user_role
+                                    ELSE 'organization_member'::user_role
+                                END
                                 ELSE 'member'::user_role
                               END
   WHERE email = ANY(_users_to_be_updated);
 END;
 $$ LANGUAGE plpgsql;
+
+
 
 CREATE OR REPLACE FUNCTION delete_users(_user_email text, _users_to_be_removed text[])
 RETURNS boolean

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -483,8 +483,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-
-
 CREATE OR REPLACE FUNCTION delete_users(_user_email text, _users_to_be_removed text[])
 RETURNS boolean
 LANGUAGE plpgsql


### PR DESCRIPTION
Now updating an organization member's (or admin) status will correctly keep their existing role.

To test this, update an organization admin's status on the account settings page and notice that it doesn't incorrectly change them to an organization member (which would happen before this PR)