### PR TITLE
bugfix: add scrollbar for privacy-policy and terms-of-use pages

### DIFF
--- a/src/cljs/pyregence/pages/privacy_policy.cljs
+++ b/src/cljs/pyregence/pages/privacy_policy.cljs
@@ -6,6 +6,8 @@
   [:div {:style {:align-items    "center"
                  :display        "flex"
                  :flex-direction "column"
+                 :height         "75vh"
+                 :overflow-y     "auto"
                  :margin-top     "2.5rem"
                  :width          "100%"}}
    [:div {:style {:margin "1rem"

--- a/src/cljs/pyregence/pages/terms_of_use.cljs
+++ b/src/cljs/pyregence/pages/terms_of_use.cljs
@@ -5,10 +5,12 @@
   [_]
   [:div {:style {:align-items    "center"
                  :display        "flex"
+                 :height         "75vh"
+                 :overflow-y     "auto"
                  :flex-direction "column"
                  :margin-top     "2.5rem"
                  :width          "100%"}}
-   [:div {:style {:margin "1rem" :width  "75%"}}
+   [:div {:style {:margin "1rem" :width "75%"}}
     [:div
      [:h2 "TERMS OF USE"]
      [:p "Last Updated: December 2, 2025"]


### PR DESCRIPTION
Visit http://local.pyrecast.org:8080/terms-of-use and http://local.pyrecast.org:8080/privacy-policy pages; use dev-tools (F12 in your browser) to try new layouts; see scrollbar appears (and also footer appears!)