### PR TITLE
 PYR1-1462 bugfix match drop in pyrecast state syncing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -60,8 +60,9 @@
            :server           {:main-opts  ["-m" "triangulum.server"]}
            :systemd          {:main-opts  ["-m" "triangulum.systemd"]}
            :test             {:extra-paths ["test"]
-                              :main-opts   ["-e" "(require,'[clojure.test,:refer,[run-tests]],'[pyregence.match-drop-test])"
-                                            "-e" "(let,[{:keys,[fail,error]},(run-tests,'pyregence.match-drop-test)],(System/exit,(if,(zero?,(+,fail,error)),0,1)))"]}
+                              :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                              :main-opts   ["-m" "cognitect.test-runner"]
+                              :exec-fn     cognitect.test-runner.api/test}
            :rct-test         {:exec-fn    com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
                               :exec-args  {:dirs #{"src"}}}
            :clj-watson       {:replace-deps

--- a/deps.edn
+++ b/deps.edn
@@ -59,6 +59,9 @@
                               :main-opts  ["-m" "rebel-readline.main"]}
            :server           {:main-opts  ["-m" "triangulum.server"]}
            :systemd          {:main-opts  ["-m" "triangulum.systemd"]}
+           :test             {:extra-paths ["test"]
+                              :main-opts   ["-e" "(require,'[clojure.test,:refer,[run-tests]],'[pyregence.match-drop-test])"
+                                            "-e" "(let,[{:keys,[fail,error]},(run-tests,'pyregence.match-drop-test)],(System/exit,(if,(zero?,(+,fail,error)),0,1)))"]}
            :rct-test         {:exec-fn    com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
                               :exec-args  {:dirs #{"src"}}}
            :clj-watson       {:replace-deps

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -483,16 +483,15 @@
                 (concat [[order step "success" (prettify result) match-job-id]]))))
           @state))
 
-(def ^:private poll-interval-ms  (* 10 1000))
-(def ^:private poll-timeout-ms   (* 36000 1000))
-
 (defn- poll-with-retries!
   "Polls in a future with retry-on-error and timeout. `poll-fn` is called each
    iteration and should return false when polling is complete, true to continue.
    `on-error` is called with the exception. `on-timeout` is called when the
    deadline is exceeded."
   [poll-fn on-error on-timeout]
-  (let [end-time (+ (System/currentTimeMillis) poll-timeout-ms)]
+  (let [poll-interval-ms (* 10 1000)
+        poll-timeout-ms  (* 36000 1000)
+        end-time         (+ (System/currentTimeMillis) poll-timeout-ms)]
     (future
       (loop []
         (let [continue? (try
@@ -510,40 +509,40 @@
 (defn- start-polling-results!
   [sig3-endpoint job-id match-job-id]
   (let [state (atom {"mdrop-dps"          {"pending" false "success" false "failure" false "order" 1}
-                      "mdrop-gridfire"     {"pending" false "success" false "failure" false "order" 2}
-                      "mdrop-elmfire"      {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
-                      "mdrop-pyretechnics" {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
-                      "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
+                     "mdrop-gridfire"     {"pending" false "success" false "failure" false "order" 2}
+                     "mdrop-elmfire"      {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
+                     "mdrop-pyretechnics" {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
+                     "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
     (poll-with-retries!
-      (fn poll-and-record-transitions []
-        (let [job-state     (poll-job! sig3-endpoint job-id)
-              transitions   (calculate-transitions state job-state match-job-id)
-              job-succeded? (= (get job-state "status") "success")
-              job-failed?   (= (get job-state "status") "failure")
-              job-done?     (or job-succeded? job-failed?)]
-          (doseq [[_ step status result match-job-id] (sort-by first transitions)]
-            (update-match-job! (cond-> {:match-job-id   match-job-id
-                                        :message        (case status
-                                                          "pending" (str "Step " step " STARTED")
-                                                          "failure" (str "Step " step " FAILED.\nResult:\n" result)
-                                                          "success" (str "Step " step " DONE.\nResult:\n" result))}
-                                 (and (= step "mdrop-elmfire") (= "success" status))
-                                 (assoc :elmfire-done? true)
-                                 (and (= step "mdrop-gridfire") (= "success" status))
-                                 (assoc :gridfire-done? true))))
-          (doseq [[_ step status] transitions]
-            (swap! state assoc-in [step status] true))
-          (if job-done?
-            (do (update-match-job! {:match-job-id match-job-id
-                                    :md-status    (if job-succeded? 0 1)})
-                false)
-            true)))
-      (fn log-poll-error [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-      (fn mark-timed-out []
-        (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
-        (update-match-job! {:match-job-id match-job-id
-                            :md-status    1
-                            :message      (str "Match Drop #" match-job-id " timed out.")})))))
+     (fn poll-and-record-transitions []
+       (let [job-state     (poll-job! sig3-endpoint job-id)
+             transitions   (calculate-transitions state job-state match-job-id)
+             job-succeded? (= (get job-state "status") "success")
+             job-failed?   (= (get job-state "status") "failure")
+             job-done?     (or job-succeded? job-failed?)]
+         (doseq [[_ step status result match-job-id] (sort-by first transitions)]
+           (update-match-job! (cond-> {:match-job-id   match-job-id
+                                       :message        (case status
+                                                         "pending" (str "Step " step " STARTED")
+                                                         "failure" (str "Step " step " FAILED.\nResult:\n" result)
+                                                         "success" (str "Step " step " DONE.\nResult:\n" result))}
+                                (and (= step "mdrop-elmfire") (= "success" status))
+                                (assoc :elmfire-done? true)
+                                (and (= step "mdrop-gridfire") (= "success" status))
+                                (assoc :gridfire-done? true))))
+         (doseq [[_ step status] transitions]
+           (swap! state assoc-in [step status] true))
+         (if job-done?
+           (do (update-match-job! {:match-job-id match-job-id
+                                   :md-status    (if job-succeded? 0 1)})
+               false)
+           true)))
+     (fn log-poll-error [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+     (fn mark-timed-out []
+       (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
+       (update-match-job! {:match-job-id match-job-id
+                           :md-status    1
+                           :message      (str "Match Drop #" match-job-id " timed out.")})))))
 
 (defn- create-match-job-using-kubernetes!
   [{:keys [user-id display-name] :as params} sig3-endpoint]
@@ -664,21 +663,21 @@
    sig3-endpoint
    match-job-id]
   (poll-with-retries!
-    (fn poll-and-delete-when-done []
-      (let [job-state     (poll-job! sig3-endpoint job-id)
-            status        (get job-state "status")
-            job-succeded? (= status "success")
-            job-failed?   (= status "failure")
-            job-done?     (or job-succeded? job-failed?)]
-        (if job-done?
-          (do (if job-succeded?
-                (do (log-str "Deleting Match Job #" match-job-id " from the database.")
-                    (call-sql "delete_match_job" match-job-id))
-                (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
-              false)
-          true)))
-    (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-    (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))))
+   (fn poll-and-delete-when-done []
+     (let [job-state     (poll-job! sig3-endpoint job-id)
+           status        (get job-state "status")
+           job-succeded? (= status "success")
+           job-failed?   (= status "failure")
+           job-done?     (or job-succeded? job-failed?)]
+       (if job-done?
+         (do (if job-succeded?
+               (do (log-str "Deleting Match Job #" match-job-id " from the database.")
+                   (call-sql "delete_match_job" match-job-id))
+               (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
+             false)
+         true)))
+   (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+   (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))))
 
 (defn- delete-match-drop-using-kubernetes! [sig3-endpoint match-job-id]
   (let [{:keys [dps-request geoserver-workspace]} (get-match-job-from-match-job-id! match-job-id)

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -520,7 +520,7 @@
                       "mdrop-pyretechnics" {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
                       "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
     (poll-with-retries!
-      (fn []
+      (fn poll-and-record-transitions []
         (let [job-state     (poll-job! sig3-endpoint job-id)
               transitions   (calculate-transitions state job-state match-job-id)
               job-succeded? (= (get job-state "status") "success")
@@ -543,8 +543,8 @@
                                     :md-status    (if job-succeded? 0 1)})
                 false)
             true)))
-      (fn [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-      (fn []
+      (fn log-poll-error [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+      (fn mark-timed-out []
         (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
         (update-match-job! {:match-job-id match-job-id
                             :md-status    1
@@ -674,7 +674,7 @@
       :or   {interval-in-seconds 10
              timeout-in-seconds  36000}}]
   (poll-with-retries!
-    (fn []
+    (fn poll-and-delete-when-done []
       (let [job-state     (poll-job! sig3-endpoint job-id)
             status        (get job-state "status")
             job-succeded? (= status "success")
@@ -687,8 +687,8 @@
                 (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
               false)
           true)))
-    (fn [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-    (fn [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))
+    (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+    (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))
     :interval-in-seconds interval-in-seconds
     :timeout-in-seconds  timeout-in-seconds))
 

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -537,8 +537,8 @@
                                                 :md-status    (if job-succeded? 0 1)})
                             false)
                         true)))
-      :on-error   (fn log-poll-error [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-      :on-timeout (fn mark-timed-out []
+      :on-error   (fn [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+      :on-timeout (fn []
                     (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
                     (update-match-job! {:match-job-id match-job-id
                                         :md-status    1
@@ -676,8 +676,8 @@
                             (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
                           false)
                       true)))
-    :on-error   (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-    :on-timeout (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))}))
+    :on-error   (fn [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+    :on-timeout (fn [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))}))
 
 (defn- delete-match-drop-using-kubernetes! [sig3-endpoint match-job-id]
   (let [{:keys [dps-request geoserver-workspace]} (get-match-job-from-match-job-id! match-job-id)

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -490,32 +490,41 @@
                         "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
     (future
       (loop []
-        (let [job-state     (poll-job! sig3-endpoint job-id)
-              transitions   (calculate-transitions state job-state match-job-id)
-              job-succeded? (= (get job-state "status") "success")
-              job-failed?   (= (get job-state "status") "failure")
-              job-done?     (or job-succeded? job-failed?)]
-          (doseq [[_ step status result match-job-id] (sort-by first transitions)]
-            (update-match-job! (cond-> {:match-job-id   match-job-id
-                                        :message        (case status
-                                                          "pending" (str "Step " step " STARTED")
-                                                          "failure" (str "Step " step " FAILED.\nResult:\n" result)
-                                                          "success" (str "Step " step " DONE.\nResult:\n" result))}
-                                 (and (= step "mdrop-elmfire") (= "success" status))
-                                 (assoc :elmfire-done? true)
-                                 (and (= step "mdrop-gridfire") (= "success" status))
-                                 (assoc :gridfire-done? true))))
-          (doseq [[_ step status] transitions]
-            (swap! state assoc-in [step status] true))
-          (if job-done?
-            (do (update-match-job! {:match-job-id match-job-id
-                                    :md-status    (if job-succeded? 0 1)})
-                job-state)
-            (do
-              (Thread/sleep (* interval-in-seconds 1000))
-              (if (< (System/currentTimeMillis) end-time)
-                (recur)
-                (println "Timeout while waiting for job" job-id "results. Stopping progress recording.")))))))))
+        (let [continue?
+              (try
+                (let [job-state     (poll-job! sig3-endpoint job-id)
+                      transitions   (calculate-transitions state job-state match-job-id)
+                      job-succeded? (= (get job-state "status") "success")
+                      job-failed?   (= (get job-state "status") "failure")
+                      job-done?     (or job-succeded? job-failed?)]
+                  (doseq [[_ step status result match-job-id] (sort-by first transitions)]
+                    (update-match-job! (cond-> {:match-job-id   match-job-id
+                                                :message        (case status
+                                                                  "pending" (str "Step " step " STARTED")
+                                                                  "failure" (str "Step " step " FAILED.\nResult:\n" result)
+                                                                  "success" (str "Step " step " DONE.\nResult:\n" result))}
+                                         (and (= step "mdrop-elmfire") (= "success" status))
+                                         (assoc :elmfire-done? true)
+                                         (and (= step "mdrop-gridfire") (= "success" status))
+                                         (assoc :gridfire-done? true))))
+                  (doseq [[_ step status] transitions]
+                    (swap! state assoc-in [step status] true))
+                  (if job-done?
+                    (do (update-match-job! {:match-job-id match-job-id
+                                            :md-status    (if job-succeded? 0 1)})
+                        false)
+                    true))
+                (catch Exception e
+                  (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e))
+                  true))]
+          (when continue?
+            (Thread/sleep (* interval-in-seconds 1000))
+            (if (< (System/currentTimeMillis) end-time)
+              (recur)
+              (do (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
+                  (update-match-job! {:match-job-id match-job-id
+                                      :md-status    1
+                                      :message      (str "Match Drop #" match-job-id " timed out.")})))))))))
 
 (defn- create-match-job-using-kubernetes!
   [{:keys [user-id display-name] :as params} sig3-endpoint]

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -488,7 +488,7 @@
    iteration and should return false when polling is complete, true to continue.
    `on-error` is called with the exception. `on-timeout` is called when the
    deadline is exceeded."
-  [poll-fn on-error on-timeout]
+  [{:keys [poll-fn on-error on-timeout]}]
   (let [poll-interval-ms (* 10 1000)
         poll-timeout-ms  (* 36000 1000)
         end-time         (+ (System/currentTimeMillis) poll-timeout-ms)]
@@ -514,35 +514,35 @@
                      "mdrop-pyretechnics" {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
                      "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
     (poll-with-retries!
-     (fn poll-and-record-transitions []
-       (let [job-state     (poll-job! sig3-endpoint job-id)
-             transitions   (calculate-transitions state job-state match-job-id)
-             job-succeded? (= (get job-state "status") "success")
-             job-failed?   (= (get job-state "status") "failure")
-             job-done?     (or job-succeded? job-failed?)]
-         (doseq [[_ step status result match-job-id] (sort-by first transitions)]
-           (update-match-job! (cond-> {:match-job-id   match-job-id
-                                       :message        (case status
-                                                         "pending" (str "Step " step " STARTED")
-                                                         "failure" (str "Step " step " FAILED.\nResult:\n" result)
-                                                         "success" (str "Step " step " DONE.\nResult:\n" result))}
-                                (and (= step "mdrop-elmfire") (= "success" status))
-                                (assoc :elmfire-done? true)
-                                (and (= step "mdrop-gridfire") (= "success" status))
-                                (assoc :gridfire-done? true))))
-         (doseq [[_ step status] transitions]
-           (swap! state assoc-in [step status] true))
-         (if job-done?
-           (do (update-match-job! {:match-job-id match-job-id
-                                   :md-status    (if job-succeded? 0 1)})
-               false)
-           true)))
-     (fn log-poll-error [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-     (fn mark-timed-out []
-       (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
-       (update-match-job! {:match-job-id match-job-id
-                           :md-status    1
-                           :message      (str "Match Drop #" match-job-id " timed out.")})))))
+     {:poll-fn    (fn poll-and-record-transitions []
+                    (let [job-state     (poll-job! sig3-endpoint job-id)
+                          transitions   (calculate-transitions state job-state match-job-id)
+                          job-succeded? (= (get job-state "status") "success")
+                          job-failed?   (= (get job-state "status") "failure")
+                          job-done?     (or job-succeded? job-failed?)]
+                      (doseq [[_ step status result match-job-id] (sort-by first transitions)]
+                        (update-match-job! (cond-> {:match-job-id   match-job-id
+                                                    :message        (case status
+                                                                      "pending" (str "Step " step " STARTED")
+                                                                      "failure" (str "Step " step " FAILED.\nResult:\n" result)
+                                                                      "success" (str "Step " step " DONE.\nResult:\n" result))}
+                                             (and (= step "mdrop-elmfire") (= "success" status))
+                                             (assoc :elmfire-done? true)
+                                             (and (= step "mdrop-gridfire") (= "success" status))
+                                             (assoc :gridfire-done? true))))
+                      (doseq [[_ step status] transitions]
+                        (swap! state assoc-in [step status] true))
+                      (if job-done?
+                        (do (update-match-job! {:match-job-id match-job-id
+                                                :md-status    (if job-succeded? 0 1)})
+                            false)
+                        true)))
+      :on-error   (fn log-poll-error [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+      :on-timeout (fn mark-timed-out []
+                    (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
+                    (update-match-job! {:match-job-id match-job-id
+                                        :md-status    1
+                                        :message      (str "Match Drop #" match-job-id " timed out.")}))})))
 
 (defn- create-match-job-using-kubernetes!
   [{:keys [user-id display-name] :as params} sig3-endpoint]
@@ -663,21 +663,21 @@
    sig3-endpoint
    match-job-id]
   (poll-with-retries!
-   (fn poll-and-delete-when-done []
-     (let [job-state     (poll-job! sig3-endpoint job-id)
-           status        (get job-state "status")
-           job-succeded? (= status "success")
-           job-failed?   (= status "failure")
-           job-done?     (or job-succeded? job-failed?)]
-       (if job-done?
-         (do (if job-succeded?
-               (do (log-str "Deleting Match Job #" match-job-id " from the database.")
-                   (call-sql "delete_match_job" match-job-id))
-               (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
-             false)
-         true)))
-   (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-   (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))))
+   {:poll-fn    (fn poll-and-delete-when-done []
+                  (let [job-state     (poll-job! sig3-endpoint job-id)
+                        status        (get job-state "status")
+                        job-succeded? (= status "success")
+                        job-failed?   (= status "failure")
+                        job-done?     (or job-succeded? job-failed?)]
+                    (if job-done?
+                      (do (if job-succeded?
+                            (do (log-str "Deleting Match Job #" match-job-id " from the database.")
+                                (call-sql "delete_match_job" match-job-id))
+                            (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
+                          false)
+                      true)))
+    :on-error   (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+    :on-timeout (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))}))
 
 (defn- delete-match-drop-using-kubernetes! [sig3-endpoint match-job-id]
   (let [{:keys [dps-request geoserver-workspace]} (get-match-job-from-match-job-id! match-job-id)

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -659,21 +659,28 @@
   (let [end-time (+ (System/currentTimeMillis) (* timeout-in-seconds 1000))]
     (future
       (loop []
-        (let [job-state     (poll-job! sig3-endpoint job-id)
-              status        (get job-state "status")
-              job-succeded? (= status "success")
-              job-failed?   (= status "failure")
-              job-done?     (or job-succeded? job-failed?)]
-          (if job-done?
-            (if job-succeded?
-              (do (log-str "Deleting Match Job #" match-job-id " from the database.")
-                  (call-sql "delete_match_job" match-job-id))
-              (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
-            (do
-              (Thread/sleep (* interval-in-seconds 1000))
-              (if (< (System/currentTimeMillis) end-time)
-                (recur)
-                (println "Timeout while waiting for job" job-id "results. Aborting.")))))))))
+        (let [continue?
+              (try
+                (let [job-state     (poll-job! sig3-endpoint job-id)
+                      status        (get job-state "status")
+                      job-succeded? (= status "success")
+                      job-failed?   (= status "failure")
+                      job-done?     (or job-succeded? job-failed?)]
+                  (if job-done?
+                    (do (if job-succeded?
+                          (do (log-str "Deleting Match Job #" match-job-id " from the database.")
+                              (call-sql "delete_match_job" match-job-id))
+                          (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
+                        false)
+                    true))
+                (catch Exception e
+                  (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e))
+                  true))]
+          (when continue?
+            (Thread/sleep (* interval-in-seconds 1000))
+            (if (< (System/currentTimeMillis) end-time)
+              (recur)
+              (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))))))))
 
 (defn- delete-match-drop-using-kubernetes! [sig3-endpoint match-job-id]
   (let [{:keys [dps-request geoserver-workspace]} (get-match-job-from-match-job-id! match-job-id)

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -449,9 +449,14 @@
 
 (defn- poll-job!
   [sig3-endpoint job-id]
-  (let [response (client/get (format "%s/api/poll/%s" sig3-endpoint job-id)
-                             {:headers {"sig-auth" (get-md-config :sig3-auth)}})]
-    (json/read-str (:body response))))
+  (let [{:keys [status body]} (client/get (format "%s/api/poll/%s" sig3-endpoint job-id)
+                                          {:headers          {"sig-auth" (get-md-config :sig3-auth)}
+                                           :socket-timeout   30000
+                                           :conn-timeout     30000
+                                           :throw-exceptions false})]
+    (when-not (= 200 status)
+      (throw (ex-info (format "poll-job! returned status %d" status) {:status status :body body})))
+    (json/read-str body)))
 
 (defn- prettify
   [edn]

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -463,24 +463,27 @@
   (with-out-str (pp/pprint edn)))
 
 (defn calculate-transitions
-  "Return a vector of state changes when compared with the current job-state
-   `order` is for sorting: control order of events
-   `step` is the step name in the match-drop network in sig3"
+  "Return a vector of state changes when compared with the current job-state.
+   `order` is for sorting: control order of events.
+   `step` is the step name in the match-drop network in sig3.
+   When a step skips the pending phase (e.g. polling interval > step duration),
+   a synthetic pending transition is emitted so STARTED always precedes DONE/FAILED."
   [state job-state match-job-id]
-  (mapcat (fn build-vector-of-transitions [[step {:strs [order pending success failure]}]]
+  (mapcat (fn build-transitions [[step {:strs [order pending success failure]}]]
             (let [{:strs [result job-status]} (get-in job-state ["steps" step])
-                  {:strs [message]}         result] ;; error-msg
-              (cond-> []
-                (and (false? pending) (= job-status "pending"))
-                (concat [[order step "pending" {}  match-job-id]])
-                (and (false? pending) (false? failure) (= job-status "failure"))
-                (concat [[order step "pending" {} match-job-id]])
-                (and (false? failure) (= job-status "failure"))
-                (concat [[order step "failure" message match-job-id]])
-                (and (false? pending) (false? success) (= job-status "success"))
-                (concat [[order step "pending" {} match-job-id]])
-                (and (false? success) (= job-status "success"))
-                (concat [[order step "success" (prettify result) match-job-id]]))))
+                  {:strs [message]}           result
+                  missed-pending?             (and (false? pending) (#{"success" "failure"} job-status))
+                  pending-transition          [order step "pending" {} match-job-id]]
+              (case job-status
+                "pending" (when (false? pending)
+                            [pending-transition])
+                "failure" (cond-> []
+                            missed-pending?    (conj pending-transition)
+                            (false? failure)   (conj [order step "failure" message match-job-id]))
+                "success" (cond-> []
+                            missed-pending?    (conj pending-transition)
+                            (false? success)   (conj [order step "success" (prettify result) match-job-id]))
+                nil)))
           @state))
 
 (defn- poll-with-retries!

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -473,8 +473,12 @@
               (cond-> []
                 (and (false? pending) (= job-status "pending"))
                 (concat [[order step "pending" {}  match-job-id]])
+                (and (false? pending) (false? failure) (= job-status "failure"))
+                (concat [[order step "pending" {} match-job-id]])
                 (and (false? failure) (= job-status "failure"))
                 (concat [[order step "failure" message match-job-id]])
+                (and (false? pending) (false? success) (= job-status "success"))
+                (concat [[order step "pending" {} match-job-id]])
                 (and (false? success) (= job-status "success"))
                 (concat [[order step "success" (prettify result) match-job-id]]))))
           @state))

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -483,16 +483,16 @@
                 (concat [[order step "success" (prettify result) match-job-id]]))))
           @state))
 
+(def ^:private poll-interval-ms  (* 10 1000))
+(def ^:private poll-timeout-ms   (* 36000 1000))
+
 (defn- poll-with-retries!
   "Polls in a future with retry-on-error and timeout. `poll-fn` is called each
    iteration and should return false when polling is complete, true to continue.
    `on-error` is called with the exception. `on-timeout` is called when the
    deadline is exceeded."
-  [poll-fn on-error on-timeout
-   & {:keys [interval-in-seconds timeout-in-seconds]
-      :or   {interval-in-seconds 10
-             timeout-in-seconds  36000}}]
-  (let [end-time (+ (System/currentTimeMillis) (* timeout-in-seconds 1000))]
+  [poll-fn on-error on-timeout]
+  (let [end-time (+ (System/currentTimeMillis) poll-timeout-ms)]
     (future
       (loop []
         (let [continue? (try
@@ -501,19 +501,14 @@
                             (on-error e)
                             true))]
           (when continue?
-            (Thread/sleep (* interval-in-seconds 1000))
+            (Thread/sleep poll-interval-ms)
             (if (< (System/currentTimeMillis) end-time)
               (recur)
               (on-timeout))))))))
 
 ;; https://mikerowecode.com/2013/02/clojure-polling-function.html
 (defn- start-polling-results!
-  [sig3-endpoint
-   job-id
-   match-job-id
-   & {:keys [interval-in-seconds timeout-in-seconds]
-      :or   {interval-in-seconds 10
-             timeout-in-seconds  36000}}]
+  [sig3-endpoint job-id match-job-id]
   (let [state (atom {"mdrop-dps"          {"pending" false "success" false "failure" false "order" 1}
                       "mdrop-gridfire"     {"pending" false "success" false "failure" false "order" 2}
                       "mdrop-elmfire"      {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
@@ -548,9 +543,7 @@
         (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
         (update-match-job! {:match-job-id match-job-id
                             :md-status    1
-                            :message      (str "Match Drop #" match-job-id " timed out.")}))
-      :interval-in-seconds interval-in-seconds
-      :timeout-in-seconds  timeout-in-seconds)))
+                            :message      (str "Match Drop #" match-job-id " timed out.")})))))
 
 (defn- create-match-job-using-kubernetes!
   [{:keys [user-id display-name] :as params} sig3-endpoint]
@@ -669,10 +662,7 @@
 (defn- poll-delete-match-drop-results-then-remove-from-db!
   [{:keys [job-id]}
    sig3-endpoint
-   match-job-id
-   & {:keys [interval-in-seconds timeout-in-seconds]
-      :or   {interval-in-seconds 10
-             timeout-in-seconds  36000}}]
+   match-job-id]
   (poll-with-retries!
     (fn poll-and-delete-when-done []
       (let [job-state     (poll-job! sig3-endpoint job-id)
@@ -688,9 +678,7 @@
               false)
           true)))
     (fn log-delete-poll-error [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
-    (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))
-    :interval-in-seconds interval-in-seconds
-    :timeout-in-seconds  timeout-in-seconds))
+    (fn log-delete-timeout [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))))
 
 (defn- delete-match-drop-using-kubernetes! [sig3-endpoint match-job-id]
   (let [{:keys [dps-request geoserver-workspace]} (get-match-job-from-match-job-id! match-job-id)

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -483,6 +483,29 @@
                 (concat [[order step "success" (prettify result) match-job-id]]))))
           @state))
 
+(defn- poll-with-retries!
+  "Polls in a future with retry-on-error and timeout. `poll-fn` is called each
+   iteration and should return false when polling is complete, true to continue.
+   `on-error` is called with the exception. `on-timeout` is called when the
+   deadline is exceeded."
+  [poll-fn on-error on-timeout
+   & {:keys [interval-in-seconds timeout-in-seconds]
+      :or   {interval-in-seconds 10
+             timeout-in-seconds  36000}}]
+  (let [end-time (+ (System/currentTimeMillis) (* timeout-in-seconds 1000))]
+    (future
+      (loop []
+        (let [continue? (try
+                          (poll-fn)
+                          (catch Exception e
+                            (on-error e)
+                            true))]
+          (when continue?
+            (Thread/sleep (* interval-in-seconds 1000))
+            (if (< (System/currentTimeMillis) end-time)
+              (recur)
+              (on-timeout))))))))
+
 ;; https://mikerowecode.com/2013/02/clojure-polling-function.html
 (defn- start-polling-results!
   [sig3-endpoint
@@ -491,49 +514,43 @@
    & {:keys [interval-in-seconds timeout-in-seconds]
       :or   {interval-in-seconds 10
              timeout-in-seconds  36000}}]
-  (let [end-time (+ (System/currentTimeMillis) (* timeout-in-seconds 1000))
-        state    (atom {"mdrop-dps"          {"pending" false "success" false "failure" false "order" 1}
-                        "mdrop-gridfire"     {"pending" false "success" false "failure" false "order" 2}
-                        "mdrop-elmfire"      {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
-                        "mdrop-pyretechnics" {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
-                        "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
-    (future
-      (loop []
-        (let [continue?
-              (try
-                (let [job-state     (poll-job! sig3-endpoint job-id)
-                      transitions   (calculate-transitions state job-state match-job-id)
-                      job-succeded? (= (get job-state "status") "success")
-                      job-failed?   (= (get job-state "status") "failure")
-                      job-done?     (or job-succeded? job-failed?)]
-                  (doseq [[_ step status result match-job-id] (sort-by first transitions)]
-                    (update-match-job! (cond-> {:match-job-id   match-job-id
-                                                :message        (case status
-                                                                  "pending" (str "Step " step " STARTED")
-                                                                  "failure" (str "Step " step " FAILED.\nResult:\n" result)
-                                                                  "success" (str "Step " step " DONE.\nResult:\n" result))}
-                                         (and (= step "mdrop-elmfire") (= "success" status))
-                                         (assoc :elmfire-done? true)
-                                         (and (= step "mdrop-gridfire") (= "success" status))
-                                         (assoc :gridfire-done? true))))
-                  (doseq [[_ step status] transitions]
-                    (swap! state assoc-in [step status] true))
-                  (if job-done?
-                    (do (update-match-job! {:match-job-id match-job-id
-                                            :md-status    (if job-succeded? 0 1)})
-                        false)
-                    true))
-                (catch Exception e
-                  (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e))
-                  true))]
-          (when continue?
-            (Thread/sleep (* interval-in-seconds 1000))
-            (if (< (System/currentTimeMillis) end-time)
-              (recur)
-              (do (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
-                  (update-match-job! {:match-job-id match-job-id
-                                      :md-status    1
-                                      :message      (str "Match Drop #" match-job-id " timed out.")})))))))))
+  (let [state (atom {"mdrop-dps"          {"pending" false "success" false "failure" false "order" 1}
+                      "mdrop-gridfire"     {"pending" false "success" false "failure" false "order" 2}
+                      "mdrop-elmfire"      {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
+                      "mdrop-pyretechnics" {"pending" false "success" false "failure" false "order" 2} ;; `2` is not a typo: the models run in parallel
+                      "mdrop-geosync"      {"pending" false "success" false "failure" false "order" 3}})]
+    (poll-with-retries!
+      (fn []
+        (let [job-state     (poll-job! sig3-endpoint job-id)
+              transitions   (calculate-transitions state job-state match-job-id)
+              job-succeded? (= (get job-state "status") "success")
+              job-failed?   (= (get job-state "status") "failure")
+              job-done?     (or job-succeded? job-failed?)]
+          (doseq [[_ step status result match-job-id] (sort-by first transitions)]
+            (update-match-job! (cond-> {:match-job-id   match-job-id
+                                        :message        (case status
+                                                          "pending" (str "Step " step " STARTED")
+                                                          "failure" (str "Step " step " FAILED.\nResult:\n" result)
+                                                          "success" (str "Step " step " DONE.\nResult:\n" result))}
+                                 (and (= step "mdrop-elmfire") (= "success" status))
+                                 (assoc :elmfire-done? true)
+                                 (and (= step "mdrop-gridfire") (= "success" status))
+                                 (assoc :gridfire-done? true))))
+          (doseq [[_ step status] transitions]
+            (swap! state assoc-in [step status] true))
+          (if job-done?
+            (do (update-match-job! {:match-job-id match-job-id
+                                    :md-status    (if job-succeded? 0 1)})
+                false)
+            true)))
+      (fn [e] (log-str "ERROR polling match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+      (fn []
+        (log-str "Timeout while waiting for job " job-id " results. Stopping progress recording.")
+        (update-match-job! {:match-job-id match-job-id
+                            :md-status    1
+                            :message      (str "Match Drop #" match-job-id " timed out.")}))
+      :interval-in-seconds interval-in-seconds
+      :timeout-in-seconds  timeout-in-seconds)))
 
 (defn- create-match-job-using-kubernetes!
   [{:keys [user-id display-name] :as params} sig3-endpoint]
@@ -656,31 +673,24 @@
    & {:keys [interval-in-seconds timeout-in-seconds]
       :or   {interval-in-seconds 10
              timeout-in-seconds  36000}}]
-  (let [end-time (+ (System/currentTimeMillis) (* timeout-in-seconds 1000))]
-    (future
-      (loop []
-        (let [continue?
-              (try
-                (let [job-state     (poll-job! sig3-endpoint job-id)
-                      status        (get job-state "status")
-                      job-succeded? (= status "success")
-                      job-failed?   (= status "failure")
-                      job-done?     (or job-succeded? job-failed?)]
-                  (if job-done?
-                    (do (if job-succeded?
-                          (do (log-str "Deleting Match Job #" match-job-id " from the database.")
-                              (call-sql "delete_match_job" match-job-id))
-                          (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
-                        false)
-                    true))
-                (catch Exception e
-                  (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e))
-                  true))]
-          (when continue?
-            (Thread/sleep (* interval-in-seconds 1000))
-            (if (< (System/currentTimeMillis) end-time)
-              (recur)
-              (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))))))))
+  (poll-with-retries!
+    (fn []
+      (let [job-state     (poll-job! sig3-endpoint job-id)
+            status        (get job-state "status")
+            job-succeded? (= status "success")
+            job-failed?   (= status "failure")
+            job-done?     (or job-succeded? job-failed?)]
+        (if job-done?
+          (do (if job-succeded?
+                (do (log-str "Deleting Match Job #" match-job-id " from the database.")
+                    (call-sql "delete_match_job" match-job-id))
+                (log-str "ERROR deleting match-drop '" match-job-id "'\n" job-state))
+              false)
+          true)))
+    (fn [e] (log-str "ERROR polling delete match-drop job-id=" job-id " match-job-id=" match-job-id ": " (.getMessage e)))
+    (fn [] (log-str "Timeout while waiting for delete job " job-id " results. Aborting."))
+    :interval-in-seconds interval-in-seconds
+    :timeout-in-seconds  timeout-in-seconds))
 
 (defn- delete-match-drop-using-kubernetes! [sig3-endpoint match-job-id]
   (let [{:keys [dps-request geoserver-workspace]} (get-match-job-from-match-job-id! match-job-id)

--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -210,7 +210,7 @@
       ;; user doesn't have match drop access
       [no-access]
       ;; user has match-drop access
-      [:div {:style ($/root)}
+      [:div {:style ($/combine ($/root) {:height "100vh"})}
        ;; TODO make this bigger to reflect the long logs we have
        [message-box-modal]
        [:div {:style ($/combine $/flex-col {:padding "2rem"})}

--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -56,7 +56,7 @@
 (defn- show-job-log-modal! [match-job-id job-log]
   (set-message-box-content!
    {:title (str "Match Drop #" match-job-id)
-    :body  [:div {:style {:max-height "500px"
+    :body  [:div {:style {:height     "50vh"
                           :overflow-y "auto"
                           :width      "75vw"}}
             [:pre {:style {:line-height   1.0

--- a/test/pyregence/match_drop_test.clj
+++ b/test/pyregence/match_drop_test.clj
@@ -1,0 +1,70 @@
+(ns pyregence.match-drop-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [pyregence.match-drop :refer [calculate-transitions]]))
+
+(def match-job-id 42)
+
+(defn- make-state
+  "Build a state atom with one step, overriding defaults with `overrides`."
+  [step-name overrides]
+  (atom {step-name (merge {"pending" false "success" false "failure" false "order" 1}
+                          overrides)}))
+
+(deftest calculate-transitions-pending
+  (testing "emits pending transition when job-status is pending"
+    (let [state     (make-state "mdrop-dps" {})
+          job-state {"steps" {"mdrop-dps" {"job-status" "pending" "result" {}}}}
+          result    (calculate-transitions state job-state match-job-id)]
+      (is (= 1 (count result)))
+      (is (= [1 "mdrop-dps" "pending" {} match-job-id] (first result))))))
+
+(deftest calculate-transitions-success
+  (testing "emits success transition when job-status is success and pending already seen"
+    (let [state     (make-state "mdrop-dps" {"pending" true})
+          job-state {"steps" {"mdrop-dps" {"job-status" "success" "result" {"some" "data"}}}}
+          result    (calculate-transitions state job-state match-job-id)]
+      (is (= 1 (count result)))
+      (is (= "success" (nth (first result) 2))))))
+
+(deftest calculate-transitions-failure
+  (testing "emits failure transition when job-status is failure and pending already seen"
+    (let [state     (make-state "mdrop-dps" {"pending" true})
+          job-state {"steps" {"mdrop-dps" {"job-status" "failure" "result" {"message" "boom"}}}}
+          result    (calculate-transitions state job-state match-job-id)]
+      (is (= 1 (count result)))
+      (is (= "failure" (nth (first result) 2)))
+      (is (= "boom" (nth (first result) 3))))))
+
+(deftest calculate-transitions-skipped-pending-success
+  (testing "synthesizes pending transition when step jumps directly to success"
+    (let [state     (make-state "mdrop-dps" {})
+          job-state {"steps" {"mdrop-dps" {"job-status" "success" "result" {"some" "data"}}}}
+          result    (calculate-transitions state job-state match-job-id)
+          statuses  (mapv #(nth % 2) result)]
+      (is (= 2 (count result)) "should emit both pending and success transitions")
+      (is (= ["pending" "success"] statuses)))))
+
+(deftest calculate-transitions-skipped-pending-failure
+  (testing "synthesizes pending transition when step jumps directly to failure"
+    (let [state     (make-state "mdrop-dps" {})
+          job-state {"steps" {"mdrop-dps" {"job-status" "failure" "result" {"message" "err"}}}}
+          result    (calculate-transitions state job-state match-job-id)
+          statuses  (mapv #(nth % 2) result)]
+      (is (= 2 (count result)) "should emit both pending and failure transitions")
+      (is (= ["pending" "failure"] statuses)))))
+
+(deftest calculate-transitions-no-duplicate-pending
+  (testing "does not duplicate pending when pending already seen and step succeeds"
+    (let [state     (make-state "mdrop-dps" {"pending" true})
+          job-state {"steps" {"mdrop-dps" {"job-status" "success" "result" {"some" "data"}}}}
+          result    (calculate-transitions state job-state match-job-id)
+          statuses  (mapv #(nth % 2) result)]
+      (is (= ["success"] statuses)))))
+
+(deftest calculate-transitions-no-change
+  (testing "returns empty when step has not started"
+    (let [state     (make-state "mdrop-dps" {})
+          job-state {"steps" {}}
+          result    (calculate-transitions state job-state match-job-id)]
+      (is (empty? result)))))


### PR DESCRIPTION
## Purpose

Fix match-drop polling silently dying on errors, leaving jobs permanently stuck "in progress".

- Wrap both polling loops in try/catch so transient exceptions (network blips, DB hiccups, bad JSON) are logged and retried instead of silently killing the future.
- Add 30s socket/connection timeouts to `poll-job!` to prevent the polling thread from hanging indefinitely on unresponsive sig3.
- Fix the timeout branch to mark the match job as failed (`md-status=1`) with a user-visible message instead of just printing to stdout and orphaning the job.
- Detect missed STARTED edges in `calculate-transitions` — when a step completes between two polls (skipping the `pending` phase), a synthetic STARTED transition is now emitted so the recorded history is always consistent.
- Extract `poll-with-retries!` to deduplicate the shared retry/timeout/error-handling loop used by both `start-polling-results!` and `poll-delete-match-drop-results-then-remove-from-db!`.
- Add unit tests for `calculate-transitions` (7 tests, 13 assertions).

## Related Issues
Closes PYR1-1462

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Match Drop

#### Role
Admin or User with match-drop access

#### Steps
1. Trigger a match drop and tail the server log. Confirm STARTED/DONE messages arrive for every step.
2. Point `sig3-endpoint` at an unreachable host. Confirm the polling future logs errors and keeps retrying instead of dying silently.
3. Set `poll-timeout-ms` to a small value. Confirm `match_jobs.md_status` is set to 1 (failed) with a timeout message, not left at 2 (in progress).
4. Run unit tests with `clojure -M:test` and confirm 7 tests pass with 0 failures.

#### Desired Outcome
- Polling never dies silently; transient errors are logged and retried.
- Timed-out jobs are marked as failed with a user-visible message.
- Every step shows a STARTED message before DONE/FAILED, even when polling is slower than the step.

---

## Screenshots
N/A (backend-only changes)
