### PR TITLE
PYR1-1476 simplify match-drop request builder

### DIFF
--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -292,7 +292,6 @@
      :fuel-version         "2.4.0"
      :wx-type              wx-type
      :ignition-radius      300
-     :run-hours            72
      :model-time           model-time ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
      :wx-start-time        (u/round-down-to-nearest-hour model-time)
      :fire-name            (str "md-" match-job-id)

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -276,22 +276,6 @@
 ;; Create Match Job Functions
 ;;==============================================================================
 
-(defn- params->match-drop-args [match-job-id
-                                {:keys [ignition-time lat lon wx-type]}
-                                {:keys [sig3-env]}]
-  (let [model-time (u/convert-date-string ignition-time)] ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
-    {:ignition-time        ignition-time
-     :lat                  lat
-     :lon                  lon
-     :num-ensemble-members 200
-     :fuel-source          "landfire"
-     :fuel-version         "2.4.0"
-     :wx-type              wx-type
-     :wx-start-time        (u/round-down-to-nearest-hour model-time)
-     :fire-name            (str "md-" match-job-id)
-     :geoserver-workspace  (str "match-drop-forecast_md-" match-job-id "_" model-time)
-     :env                  sig3-env}))
-
 (defn- create-match-job-using-runway!
   [{:keys [display-name user-id ignition-time lat lon wx-type] :as params}]
   {:pre [(integer? user-id)]}
@@ -405,28 +389,31 @@
        1000)))
 
 (defn- match-drop-args->body
-  [{:keys [fire-name lon lat wx-start-time ignition-time fuel-source wx-type fuel-version num-ensemble-members geoserver-workspace env]}]
-  {:network   :match-drop
-   :arguments {:env                  env
-               :pyrc_fire_name       fire-name
-               :geoserver-workspace  geoserver-workspace
-               :pyrc_simulation_span {:pyrc_simspan_center_lon    lon
-                                      :pyrc_simspan_center_lat    lat
-                                      :pyrc_simspan_start_epoch_s (utc-date->epoch-s wx-start-time)}
-               :pyrc_ignition        {:pyrc_ignition_lon     lon
-                                      :pyrc_ignition_lat     lat
-                                      :pyrc_ignition_epoch_s (utc-date->epoch-s ignition-time)}
-               :pyrc_inputs          {:pyrc_fuel_source  fuel-source
-                                      :pyrc_wx_type      wx-type
-                                      :pyrc_fuel_version fuel-version}
-               :pyrc_sim_params      {:pyrc_sim_num_ensemble_members num-ensemble-members}}})
+  [match-job-id
+   {:keys [ignition-time lat lon wx-type]}
+   {:keys [sig3-env]}]
+  (let [model-time    (u/convert-date-string ignition-time) ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
+        wx-start-time (u/round-down-to-nearest-hour model-time)]
+    {:network   :match-drop
+     :arguments {:env                  sig3-env
+                 :pyrc_fire_name       (str "md-" match-job-id)
+                 :geoserver-workspace  (str "match-drop-forecast_md-" match-job-id "_" model-time)
+                 :pyrc_simulation_span {:pyrc_simspan_center_lon    lon
+                                        :pyrc_simspan_center_lat    lat
+                                        :pyrc_simspan_start_epoch_s (utc-date->epoch-s wx-start-time)}
+                 :pyrc_ignition        {:pyrc_ignition_lon     lon
+                                        :pyrc_ignition_lat     lat
+                                        :pyrc_ignition_epoch_s (utc-date->epoch-s ignition-time)}
+                 :pyrc_inputs          {:pyrc_fuel_source  "landfire"
+                                        :pyrc_wx_type      wx-type
+                                        :pyrc_fuel_version "2.4.0"}
+                 :pyrc_sim_params      {:pyrc_sim_num_ensemble_members 200}}}))
 
 (defn- submit-match-drop-job!
   "Requests a match-drop job from kubernetes"
   [params sig3-endpoint match-job-id]
   (let [match-drop-config                  (get-md-configs [:sig3-env])
-        match-drop-inputs                  (params->match-drop-args match-job-id params match-drop-config)
-        request                            (match-drop-args->body match-drop-inputs)
+        request                            (match-drop-args->body match-job-id params match-drop-config)
         api-url                            (format "%s/api/submit-job" sig3-endpoint)
         http-request                       {:body         (json/write-str request)
                                             :headers      {"sig-auth" (get-md-config :sig3-auth)}
@@ -435,7 +422,7 @@
         _                                  (println "POST" api-url request)
         {:keys [body status] :as response} (client/post api-url http-request)]
     (if (= 200 status)
-      {:match-drop-inputs match-drop-inputs
+      {:match-drop-inputs (:arguments request)
        :job-id            (:job-id (json/read-str body :key-fn keyword))}
       (throw (ex-info (format "match-drop request failed with status %d" status)
                       {:request http-request :response response})))))

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -393,11 +393,12 @@
    {:keys [ignition-time lat lon wx-type]}
    {:keys [sig3-env]}]
   (let [model-time    (u/convert-date-string ignition-time) ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
-        wx-start-time (u/round-down-to-nearest-hour model-time)]
+        wx-start-time (u/round-down-to-nearest-hour model-time)
+        fire-name     (str "md-" match-job-id)]
     {:network   :match-drop
      :arguments {:env                  sig3-env
-                 :pyrc_fire_name       (str "md-" match-job-id)
-                 :geoserver-workspace  (str "match-drop-forecast_md-" match-job-id "_" model-time)
+                 :pyrc_fire_name       fire-name
+                 :geoserver-workspace  (str "match-drop-forecast_" fire-name "_" model-time)
                  :pyrc_simulation_span {:pyrc_simspan_center_lon    lon
                                         :pyrc_simspan_center_lat    lat
                                         :pyrc_simspan_start_epoch_s (utc-date->epoch-s wx-start-time)}

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -280,19 +280,13 @@
                                 {:keys [ignition-time lat lon wx-type]}
                                 {:keys [sig3-env]}]
   (let [model-time (u/convert-date-string ignition-time)] ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
-    {:west-buffer          12
-     :ignition-time        ignition-time
-     :east-buffer          12
-     :south-buffer         12
+    {:ignition-time        ignition-time
      :lat                  lat
      :lon                  lon
-     :north-buffer         12
      :num-ensemble-members 200
      :fuel-source          "landfire"
      :fuel-version         "2.4.0"
      :wx-type              wx-type
-     :ignition-radius      300
-     :model-time           model-time ; e.g. Turns "2022-12-01 18:00 UTC" into "20221201_180000"
      :wx-start-time        (u/round-down-to-nearest-hour model-time)
      :fire-name            (str "md-" match-job-id)
      :geoserver-workspace  (str "match-drop-forecast_md-" match-job-id "_" model-time)


### PR DESCRIPTION
## Purpose

Refactor of `match-drop.clj`'s sig3 request builder — no behavior change to the HTTP body sent to `/api/submit-job`.

- **Drop dead locals from `params->match-drop-args`.** `:run-hours`, `:west-buffer`, `:east-buffer`, `:south-buffer`, `:north-buffer`, and `:ignition-radius` were set here but never destructured by `match-drop-args->body`, so they never reached the sig3 payload — they only survived as noise in the `match_jobs :dps-request` audit blob. sig3's `match-drop.edn` already defaults all six to identical values, so plumbing them through would be redundant.
- **Inline `params->match-drop-args` into `match-drop-args->body`.** The two-step pipeline built a flat intermediate map only to immediately destructure it again; collapsing into one function removes the indirection. The constants `"landfire"`, `"2.4.0"`, and `200` that used to round-trip through the intermediate now sit at the leaves where they're used. `submit-match-drop-job!` returns `:match-drop-inputs` as `(:arguments request)`, so `create-match-job-using-kubernetes!` still destructures `:geoserver-workspace` from it and still stores the blob as the DB audit.
- **Bind the `"md-<id>"` prefix once.** It was duplicated between `:pyrc_fire_name` and `:geoserver-workspace`; a `fire-name` let-binding keeps the two strings from drifting.

The HTTP body is byte-identical before and after. The only observable change is the shape of the `:dps-request` audit blob in `match_jobs`: it now mirrors the sig3 `:arguments` payload (nested `pyrc_*` keys) rather than the flat intermediate. Downstream code only reads `:geoserver-workspace` off that blob, which is preserved at the top level.

## Related Issues
Closes PYR1-1476

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Match Drop

#### Role
User

#### Steps
1. Open Pyrecast against an environment that has `:sig3-endpoint` configured.
2. Initiate a Match Drop from the UI (forecast weather, any valid ignition location/time).
3. Watch the new `match_jobs` row through the DB or the UI status until all four sig3 steps (`mdrop-dps`, `mdrop-elmfire`, `mdrop-pyretechnics`, `mdrop-geosync`) report success.
4. Inspect the `match_jobs.dps_request` JSON for the new row.

#### Desired Outcome
- The Match Drop completes end-to-end exactly as on `main` (no change in runtime, cube contents, or produced layers).
- `match_jobs.dps_request` now contains the nested sig3 `:arguments` shape (`:pyrc_fire_name`, `:pyrc_simulation_span`, `:pyrc_ignition`, `:pyrc_inputs`, `:pyrc_sim_params`, top-level `:geoserver-workspace` and `:env`) rather than the previous flat `:fire-name`/`:lat`/`:lon`/... shape.

---

## Screenshots
N/A — no UI changes.
