### PR TITLE
PYR1-1472 Upgrade protocol-buffers-schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/quickselect": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "webpack-cli": "^5.1.4"
   },
   "overrides": {
-    "vega": "^6.2.0"
+    "vega": "^6.2.0",
+    "protocol-buffers-schema": "^3.6.1"
   }
 }


### PR DESCRIPTION
## Purpose

Fixes Dependabot alert (CVE-2026-5758, prototype pollution in `protocol-buffers-schema < 3.6.1`).

Pulled in transitively via `mapbox-gl -> pbf -> resolve-protobuf-schema`. Added an npm override to force resolution to `^3.6.1`.

- `package.json`: +1 override entry
- `package-lock.json`: `protocol-buffers-schema` 3.6.0 → 3.6.1

`npm audit` reports 0 vulnerabilities.


## Related Issues
Closes [PYR1-1472](https://sig-gis.atlassian.net/browse/PYR1-1472)




[PYR1-1472]: https://sig-gis.atlassian.net/browse/PYR1-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ