### PR TITLE
PYR1-1462 fixup sig3 ignition-time display on match drop dashboard

### DIFF
--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -106,9 +106,14 @@
                                 updated-at
                                 dps-request
                                 job-log]}]
-  (let [{:keys [common-args]} (:script-args dps-request)
-        ;; WORKAROUND for sig3 requests
-        common-args           (or common-args dps-request)]
+  (let [        ;; WORKAROUND for sig3 requests
+        lon           (or (:lon dps-request)
+                          (get-in dps-request [:pyrc_simulation_span :pyrc_simspan_center_lon]))
+        lat           (or (:lat dps-request)
+                          (get-in dps-request [:pyrc_simulation_span :pyrc_simspan_center_lat]))
+        ignition-time (or (:ignition-time dps-request)
+                          (some-> (get-in dps-request [:pyrc_ignition :pyrc_ignition_epoch_s])
+                                  (u-time/epoch-s->utc-date)))]
     [:tr
      [:td match-job-id] ; "Job ID"
      [:td {:width "10%"} (when-not (nil? display-name) display-name)] ; "Fire Name"
@@ -125,15 +130,14 @@
                      :overflow      "auto"}}
        (when-not (nil? message) message)]]
      [:td {:width "10%"} ; "Lon, Lat"
-      (if-let [lon-lat (some->> (select-keys common-args [:lon :lat])
-                                (vals)
+      (if-let [lon-lat (some->> [lon lat]
                                 (map #(-> % (str) (subs 0 6)))
                                 (string/join ", "))]
         lon-lat
         "N/A")]
      [:td ; "Ignition Time (UTC)"
-      (if (some? common-args)
-        (subs (:ignition-time common-args) 0 16)
+      (if (seq ignition-time)
+        (subs ignition-time 0 16)
         "N/A")]
      [:td (fmt-datetime created-at)] ; "Time Started (UTC)"
      [:td (fmt-datetime updated-at)] ; "Last Updated (UTC)"

--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -106,12 +106,13 @@
                                 updated-at
                                 dps-request
                                 job-log]}]
-  (let [;; WORKAROUND for sig3 requests
-        lon           (or (:lon dps-request)
+  (let [common-args   (get-in dps-request [:script-args :common-args])
+        ;; WORKAROUND for sig3 requests
+        lon           (or (:lon common-args)
                           (get-in dps-request [:pyrc_simulation_span :pyrc_simspan_center_lon]))
-        lat           (or (:lat dps-request)
+        lat           (or (:lat common-args)
                           (get-in dps-request [:pyrc_simulation_span :pyrc_simspan_center_lat]))
-        ignition-time (or (:ignition-time dps-request)
+        ignition-time (or (:ignition-time common-args)
                           (some-> (get-in dps-request [:pyrc_ignition :pyrc_ignition_epoch_s])
                                   (u-time/epoch-s->utc-date)))]
     [:tr

--- a/src/cljs/pyregence/pages/dashboard.cljs
+++ b/src/cljs/pyregence/pages/dashboard.cljs
@@ -106,7 +106,7 @@
                                 updated-at
                                 dps-request
                                 job-log]}]
-  (let [        ;; WORKAROUND for sig3 requests
+  (let [;; WORKAROUND for sig3 requests
         lon           (or (:lon dps-request)
                           (get-in dps-request [:pyrc_simulation_span :pyrc_simspan_center_lon]))
         lat           (or (:lat dps-request)

--- a/src/cljs/pyregence/utils/time_utils.cljs
+++ b/src/cljs/pyregence/utils/time_utils.cljs
@@ -93,6 +93,17 @@
       (.toISOString)
       (iso-string->local-datetime-string)))
 
+(defn epoch-s->utc-date
+  "Converts epoch seconds into a UTC string of the form 'YYYY-MM-DD HH:MM UTC'."
+  [epoch-s]
+  (let [js-date (js/Date. (* epoch-s 1000))
+        year    (.getUTCFullYear js-date)
+        month   (pad-zero (+ 1 (.getUTCMonth js-date)))
+        day     (pad-zero (.getUTCDate js-date))
+        hours   (pad-zero (.getUTCHours js-date))
+        minutes (pad-zero (.getUTCMinutes js-date))]
+    (str year "-" month "-" day " " hours ":" minutes " UTC")))
+
 (defn ms->hhmmss
   "Converts milliseconds into 'hours:minutes:seconds'."
   [ms]


### PR DESCRIPTION
PYR1-1462 Fixup sig3 ignition-time display on Match Drop dashboard

## Purpose
The Match Drop dashboard expects `ignition-time` as a `"YYYY-MM-DD HH:MM UTC"` string and slices it with `subs` for display. For sig3-style requests, the `dps-request` only exposes `:pyrc_ignition/:pyrc_ignition_epoch_s` (a number), so the fallback produced a numeric value that broke the "Ignition Time (UTC)" column.

This PR adds `epoch-s->utc-date` in `time-utils` — the inverse of the server-side `utc-date->epoch-s` used in `match_drop.clj` — and uses it in `match-drop-item` to coerce the sig3 epoch-seconds back into the same string shape, so the column renders consistently for both request formats.

## Related Issues
Closes PYR1-1462

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Match Drop > Dashboard

#### Role
User (with Match Drop access)

#### Steps
1. Log in as a user that has Match Drop access and at least one sig3-style match drop (i.e. a `dps-request` shaped with `:pyrc_ignition/:pyrc_ignition_epoch_s` rather than a top-level `:ignition-time`).
2. Navigate to `/dashboard`.
3. Inspect the "Ignition Time (UTC)" column for that row.
4. Also confirm a legacy match drop (one with a top-level `:ignition-time` string on `dps-request`) still displays correctly.

#### Desired Outcome
- For sig3 match drops, "Ignition Time (UTC)" shows the ignition time in `YYYY-MM-DD HH:MM` form (first 16 chars of `YYYY-MM-DD HH:MM UTC`) instead of a raw epoch-second number or `"N/A"`.
- For legacy match drops, the column is unchanged.
- No errors in the JS console (previously `subs` would have thrown on the numeric value).

---

## Screenshots
<!-- Add a screen shot when UI changes are included -->
