### PR TITLE
DRAFT! dsilva-explore-tiering-match-drop-issue

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -1,5 +1,6 @@
 (ns pyregence.authentication
   (:require [pyregence.email            :as email]
+            [pyregence.handlers         :as handlers]
             [pyregence.marketplace      :as marketplace]
             [pyregence.totp             :as totp]
             [pyregence.utils            :refer [nil-on-error]]
@@ -20,15 +21,18 @@
    This is the single source of truth for session structure."
   [user-data]
   (when user-data
-    (data-response "" {:session (merge {:match-drop-access?    (:match_drop_access user-data)
-                                        :user-email            (:user_email user-data)
-                                        :user-id               (:user_id user-data)
-                                        :user-name             (:user_name user-data)
-                                        :user-role             (:user_role user-data)
-                                        :organization-id       (:organization_rid user-data)
-                                        :org-membership-status (:org_membership_status user-data)
-                                        :subscription-tier     (:subscription_tier user-data)}
-                                       (get-config :app :client-keys))})))
+    (let [base    {:match-drop-access?    (:match_drop_access user-data)
+                   :user-email            (:user_email user-data)
+                   :user-id               (:user_id user-data)
+                   :user-name             (:user_name user-data)
+                   :user-role             (:user_role user-data)
+                   :organization-id       (:organization_rid user-data)
+                   :org-membership-status (:org_membership_status user-data)
+                   :subscription-tier     (:subscription_tier user-data)}
+          ;; Derive effective Match Drop access from role + tier so tier2+ org
+          ;; members don't need the per-user flag toggled manually.
+          session (assoc base :match-drop-access? (handlers/match-drop-access? base))]
+      (data-response "" {:session (merge session (get-config :app :client-keys))}))))
 
 (defn- parse-user-settings
   "Safely parses user settings from EDN string, returning empty map on error."
@@ -829,16 +833,22 @@
        data-response))
 
 (defn get-all-users
-  "Returns a vector of all users in the DB."
+  "Returns a vector of all users in the DB. `match-drop-access` reflects the
+   effective (derived) access, so admins see the same state the user experiences."
   [_]
   (->> (call-sql "get_all_users")
        (mapv (fn [{:keys [user_uid email name settings match_drop_access email_verified
-                          last_login_date user_role org_membership_status organization_name]}]
+                          last_login_date user_role org_membership_status organization_name
+                          subscription_tier]}]
                {:user-id               user_uid
                 :email                 email
                 :name                  name
                 :settings              settings
-                :match-drop-access     match_drop_access
+                :match-drop-access     (handlers/match-drop-access?
+                                        {:match-drop-access?    match_drop_access
+                                         :user-role             user_role
+                                         :subscription-tier     subscription_tier
+                                         :org-membership-status org_membership_status})
                 :email-verified        email_verified
                 :last-login-date       last_login_date
                 :user-role             user_role

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -318,7 +318,8 @@ CREATE OR REPLACE FUNCTION get_all_users()
   last_login_date       timestamptz,
   user_role             user_role,
   org_membership_status org_membership_status,
-  organization_name     text
+  organization_name     text,
+  subscription_tier     subscription_tier
  ) AS $$
     SELECT
       u.user_uid,
@@ -330,7 +331,8 @@ CREATE OR REPLACE FUNCTION get_all_users()
       u.last_login_date,
       u.user_role,
       u.org_membership_status,
-      o.org_name
+      o.org_name,
+      o.subscription_tier
     FROM users u
     LEFT JOIN organizations o
       ON u.organization_rid = o.organization_uid


### PR DESCRIPTION
  src/clj/pyregence/handlers.clj — New match-drop-access? helper. Derives effective access from the session-shaped map: honors the per-user :match-drop-access? flag as an override, then
  auto-grants to super admins, account managers, and accepted org members on tier2_pro+.

  src/clj/pyregence/authentication.clj
  - Added [pyregence.handlers :as handlers] require (no circular dep — handlers.clj imports nothing from pyregence.*).
  - create-session-from-user-data now stamps the session's :match-drop-access? with the derived value. Because every downstream consumer (route-authenticator at handlers.clj:90, handler bodies at match_drop.clj:565,586, capabilities at capabilities.clj:332, the frontend atom via get-user-match-drop-access) just reads that flag, they all pick up the new semantics for free — no site-by-site edits.
  - get-all-users now computes derived access per row, so the Admin tab "Match Drop?" column shows the same state the user actually experiences. Required adding subscription_tier to the SQL output.

  src/sql/functions/user_functions.sql — get_all_users returns subscription_tier alongside the other org fields it already joins.

  What this means for SRP

  Once the migration runs and the app is redeployed:
  - Any SRP user whose org is tier2_pro+ and whose membership is accepted gets Match Drop immediately on next login — no admin toggle needed.
  - Super admins and account managers get it unconditionally.
  - The per-user DB flag still works as a forced-on override for edge cases (e.g., granting a tier1 user special access).

  What's not covered (flag for review)

  - If SRP's org is still on tier1_*, the patch won't help — the PO should confirm their subscription tier is set to tier2_pro in the organizations table.
  - The admin UI toggle (update_user_match_drop_access) only writes the raw column. For tier2+ org members it'll appear to "do nothing" because derived access stays true. If admins need a per-user revoke path, that's a follow-up.
  - No new test file was added; this repo's auth tests should be extended to cover the hierarchy.
  - SQL change requires a deploy that re-runs the function definition — coordinate with whoever handles migrations.

  Verify locally

  1. Re-apply user_functions.sql against a local DB.
  2. Log in as a tier2 org member whose match_drop_access = false — the dashboard Match Drop button should appear, and /clj/get-user-match-drop-access should 200.
  3. Log in as a tier1 org member — gate should still block.
  4. Open Admin tab, search SRP — "Match Drop?" column should show green checks for accepted members once their org is on tier2+.

## Purpose
<!-- Description of what has been added/changed -->

## Related Issues
Closes PYR1-###

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)
- [ ] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. Toolbars > Camera Tool) -->
<!-- The current list of all Modules is: -->
<!-- Layers, Side Panel, Point Info, Toolbars, Match Drop, Misc., Mobile -->

#### Role
<!-- Admin, User, or Visitor -->

#### Steps
<!-- All steps needed to test this PR -->
1.

#### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots
<!-- Add a screen shot when UI changes are included -->
