### PR TITLE
Move set-capabilities timeout from 2.5 minutes to 5 minutes

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -284,7 +284,7 @@
                         (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password)))]
     (if-not (contains? (get-config :triangulum.views/client-keys :geoserver) geoserver-key)
       (log-str "Failed to load capabilities. The GeoServer URL passed in was not found in config.edn.")
-      (let [timeout-ms    (* 2.5 60 1000) ; 2.5 minutes
+      (let [timeout-ms    (* 5 60 1000) ; 5 minutes
             future-result (future
                             (try
                               (let [stdout?       (= 0 (count @layers))


### PR DESCRIPTION
## Purpose
Updates the timeout in `set-capabilities` from 2.5 to 5 minutes so that the initial capabilities calls to our GCP GeoServers don't time out (see below what was happening):

```
04/30 14:54:44 150.0 seconds timeout occurred while loading capabilities for https://geoserver-usw1.pyrecast.org/geoserver01
04/30 14:54:45 270 layers from https://geoserver-usw1.pyrecast.org/geoserver02 added to http://local.pyrecast.org:8080.
04/30 14:54:49 150.0 seconds timeout occurred while loading capabilities for https://geoserver-usw1.pyrecast.org/geoserver01
04/30 14:54:50 270 layers from https://geoserver-usw1.pyrecast.org/geoserver02 added to http://local.pyrecast.org:8080.
04/30 14:55:22 955 layers from https://geoserver-usw1.pyrecast.org/geoserver03 added to http://local.pyrecast.org:8080.
04/30 14:55:22 955 layers from https://geoserver-usw1.pyrecast.org/geoserver03 added to http://local.pyrecast.org:8080.
04/30 14:57:52 150.0 seconds timeout occurred while loading capabilities for https://geoserver-utility.pyrecast.org/geoserver
04/30 14:57:52 150.0 seconds timeout occurred while loading capabilities for https://geoserver-utility.pyrecast.org/geoserver
04/30 14:57:54 3528 layers from https://climate.pyregence.org/geoserver added to http://local.pyrecast.org:8080.
04/30 14:57:54 3528 layers from https://climate.pyregence.org/geoserver added to http://local.pyrecast.org:8080.
```