### PR TITLE
PYR1-1523 Auto-switch disabled outputs when ignition pattern changes

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -577,6 +577,27 @@
     (when auto-zoom?
       (mb/zoom-to-extent! (get-current-layer-extent) (current-layer) max-zoom))))
 
+(defn- auto-switch-disabled-params!
+  "When a param changes, other params' selected options may become disabled.
+   Detects this and switches them to the first non-disabled option."
+  []
+  (let [params          (get-forecast-opt :params)
+        current-vals    (get @!/*params @!/*forecast)
+        selected-set    (->> current-vals (vals) (filter keyword?) (set))]
+    (doseq [[param-key {:keys [options]}] params
+            :let [selected-option (get current-vals param-key)
+                  {:keys [disabled-for]} (get options selected-option)]
+            :when (and (set? disabled-for)
+                       (seq (set/intersection disabled-for selected-set)))
+            :let [first-enabled (->> options
+                                     (remove (fn [[_ {:keys [disabled-for hidden?]}]]
+                                               (or hidden?
+                                                   (and (set? disabled-for)
+                                                        (seq (set/intersection disabled-for selected-set))))))
+                                     (ffirst))]
+            :when first-enabled]
+      (swap! !/*params assoc-in [@!/*forecast param-key] first-enabled))))
+
 (defn- select-param!
   "The function called whenever an input dropdown is changed on the collapsible panel.
    Resets the proper state atoms with the new, selected inputs from the UI."
@@ -597,6 +618,7 @@
       (reset! !/*layer-idx 0)
       (swap! !/*params assoc-in (cons @!/*forecast [:burn-pct]) :50)
       (reset! !/animate? false))
+    (auto-switch-disabled-params!)
     (change-type! (not (#{:burn-pct :model-init} main-key)) ;; TODO: Make this a config
                   (get-current-layer-key :clear-point?)
                   (get-current-option-key main-key val :auto-zoom?)


### PR DESCRIPTION
## Purpose
When selecting a planning ignition pattern (e.g. "Missoula Electric overhead lines Planning") on the Risk tab, the Output dropdown stayed on an incompatible `fire-risk-forecast` output instead of switching
to a `fire-risk-planning` output. This caused "There are no layers available for the selected parameters" errors because no GeoServer layer matches the combined filter-set.

Added `auto-switch-disabled-params!` which runs after every param change — if any sibling param's currently selected option becomes disabled, it auto-switches to the first non-disabled option. Works
bidirectionally (forecast → planning and planning → forecast).

## Related Issues
Closes PYR1-1523

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Layers > Risk tab > Ignition Pattern / Output dropdowns

#### Role
Admin, User

#### Steps
1. Log in and go to the Risk tab
2. Select any planning ignition pattern (e.g. "Missoula Electric overhead lines Planning")
3. Observe the Output dropdown

#### Desired Outcome
The Output dropdown should auto-switch to the first compatible planning output (e.g. "Fire area percentile") instead of staying on a grayed-out forecast output and showing "There are no layers available for
the selected parameters."

---

#### Steps (reverse direction)
1. While a planning pattern is selected, note the Output is a planning output
2. Switch the Ignition Pattern back to "All-cause fires"

#### Desired Outcome
The Output dropdown should auto-switch back to the first compatible forecast output (e.g. "Relative burn probability").
