### PR TITLE
PYR1-1527 pyrecast private geo server capabilities timeout on large layer sets

### DIFF
--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -296,7 +296,9 @@
                               (let [stdout?       (= 0 (count @layers))
                                     geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
                                     new-layers    (process-layers! geoserver-url workspace-name basic-auth)
-                                    message       (str (count new-layers) " layers from " geoserver-url " added to " (get-site-url) ".")]
+                                    message       (str "Added " (count new-layers) " layers from " geoserver-url
+                                                       (when workspace-name (str " (workspace=" workspace-name ")"))
+                                                       " to " (get-site-url) ".")]
                                 (if workspace-name
                                   (do
                                     (remove-workspace! nil {"geoserver-key"  (name geoserver-key)

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -1,6 +1,7 @@
 (ns pyregence.capabilities
   (:require
    [clj-http.client     :as client]
+   [clojure.data.json   :as json]
    [clojure.edn         :as edn]
    [clojure.set         :as set]
    [clojure.string      :as str]
@@ -313,11 +314,38 @@
           (log-str (quot timeout-ms 1000) " seconds timeout occurred while loading capabilities for "
                    (get-config :triangulum.views/client-keys :geoserver geoserver-key)))))))
 
+(defn- list-workspaces
+  "Lists workspace names from a GeoServer instance via the REST API."
+  [geoserver-url basic-auth]
+  (let [url      (-> geoserver-url
+                     (u/end-with "/")
+                     (str "rest/workspaces.json"))
+        response (client/get url (cond-> {:as :text}
+                                   basic-auth (assoc :basic-auth basic-auth)))]
+    (->> (json/read-str (:body response) :key-fn keyword)
+         :workspaces
+         :workspace
+         (mapv :name))))
+
 (defn set-all-capabilities!
-  "Calls set-capabilities! on all GeoServer URLs provided in config.edn."
+  "Calls set-capabilities! on all GeoServer URLs provided in config.edn.
+   For GeoServers that require authentication, loads capabilities per workspace
+   to avoid timeout on large GetCapabilities responses."
   [_]
   (doseq [geoserver-key (keys (get-config :triangulum.views/client-keys :geoserver))]
-    (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))
+    (if (private-layer-geoservers geoserver-key)
+      (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
+            basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
+        (try
+          (let [workspaces (list-workspaces geoserver-url basic-auth)]
+            (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+            (doseq [ws workspaces]
+              (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                      "workspace-name" ws})))
+          (catch Exception e
+            (log-str "Failed to list workspaces for " geoserver-url ", falling back to full GetCapabilities.\n" (ex-message e))
+            (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))))
+      (set-capabilities! nil {"geoserver-key" (name geoserver-key)})))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))
 

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -339,9 +339,11 @@
         (try
           (let [workspaces (list-workspaces geoserver-url basic-auth)]
             (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-            (doseq [ws workspaces]
-              (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                      "workspace-name" ws})))
+            (->> workspaces
+                 (pmap (fn [ws]
+                         (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                                 "workspace-name" ws})))
+                 (doall)))
           (catch Exception e
             (log-str "Failed to list workspaces for " geoserver-url ", falling back to full GetCapabilities.\n" (ex-message e))
             (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))))


### PR DESCRIPTION
## Purpose
  The PSPS GeoServer has many layers, causing the single GetCapabilities request to time out and fail to load layers on startup. This PR loads capabilities per workspace instead of all at once, and parallelizes
  the loading. Falls back to the original behavior if workspace discovery fails.

  ## Related Issues
  Closes PYR1-1527

  ## Submission Checklist
  - [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
  - [x] Code passes linter rules (`clj-kondo --lint src`)
  - [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
  - [x] No new reflection warnings (`clojure -M:check-reflection`)
  - [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

  ## Testing
  #### Module Impacted
  Misc.

  #### Role
  Admin

  #### Steps
  1. Start the application pointing to the PSPS development GeoServer
  2. Check the logs for per-workspace capability loading messages
  3. Verify all layers load successfully

  #### Desired Outcome
  All layers from the PSPS GeoServer load without timeout errors. Logs show workspace-level loading messages (e.g. `Added 142 layers from https://... (workspace=fire_history) to https://...`).

  ## Screenshots
  <!-- N/A - no UI changes -->