### PR TITLE
PYR1-1501 Upgrade fast-uri to v3.1.2 to fix 2 Dependabot alerts in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,9 +1124,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "overrides": {
     "vega": "^6.2.0",
-    "protocol-buffers-schema": "^3.6.1"
+    "protocol-buffers-schema": "^3.6.1",
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
## Purpose
Fixes Dependabot alert (`fast-uri < 3.1.2`, allowlist bypass via percent-encoded path/host normalization). Dev-only, transitive via `webpack -> ajv`. Pinned to `^3.1.2` via npm override.

## Related Issues
Closes PYR1-1501
