### PR TITLE
PYR1-1343 Use `backlink` instead of `url` for active fire popup source link

### DIFF
--- a/src/cljs/pyregence/components/popups.cljs
+++ b/src/cljs/pyregence/components/popups.cljs
@@ -66,7 +66,7 @@
 
 (defn fire-popup
   "Popup body for active fires."
-  [{:keys [prettyname containper acres source url icon show-link? on-click]}]
+  [{:keys [prettyname containper acres source backlink icon show-link? on-click]}]
   [:div {:style {:display        "flex"
                  :flex-direction "column"
                  :gap            "12px"}}
@@ -79,7 +79,7 @@
     (when source
       [:div {:style {:display "flex" :gap "8px" :flex-direction "column"}}
        [:strong {:style {:color ($/color-picker :neutral-md-gray)}} "Source(s):"]
-       [:a {:href url :target "_blank"}
+       [:a {:href backlink :target "_blank"}
         [:div {:style {:display        "flex"
                        :flex-direction "column"
                        :gap            "5px"}}


### PR DESCRIPTION
## Purpose
The active fire popup's "Source(s)" link was reading a `:url` property from the feature, but the active-fire data provides the source link under the `backlink` column. As a result the source box rendered with an empty `href` and linked nowhere. This change reads `backlink` instead of `url` so the source box links to the correct provider URL (e.g. `share.watchduty.org`).

## Related Issues
Closes PYR1-1343

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Point Info > Active Fire Popup

#### Role
All

#### Steps
1. Open the near-term forecast map with the Active Fires layer enabled.
2. Click an active fire that has a Watch Duty source (e.g. one with a `backlink`).
3. In the popup, click the grey "Source(s)" box.

#### Desired Outcome
The source box links out to the correct provider URL (e.g. `https://share.watchduty.org/i/...`) in a new tab, instead of a broken/empty link.
