### PR TITLE
PYR1-1545 make capabilities loading per workspace parallel and fault tolerant

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -122,7 +122,7 @@
  :pyregence.capabilities/geoserver-credentials      {:trinity     {:username "<username>" :password "<password>"}
                                                      :shasta      {:username "<username>" :password "<password>"}
                                                      :match-drop  {:username "<username>" :password "<password>"}
-                                                     :psps        {:username "admin"      :password "password"}
+                                                     :psps        {:username "<username>" :password "<password>"}
                                                      :pyreclimate {:username "<username>" :password "<password>"}}
  :pyregence.weather-stations/get-observation-stations-every-n-minutes 1440 ;; once a day
  :pyregence.email/verification-token-expiry-minutes 15

--- a/config.default.edn
+++ b/config.default.edn
@@ -117,6 +117,14 @@
  :pyregence.cameras/alert-west-api-key              "<api-key>"
  :pyregence.capabilities/psps                       {:geoserver-admin-username "admin"
                                                      :geoserver-admin-password "password"}
+ ;; Credentials used to list workspaces (REST API) and query GetCapabilities per
+ ;; GeoServer. Omit an entry, or leave username/password blank, to query that
+ ;; GeoServer anonymously. Keys must match the keys under :geoserver above.
+ :pyregence.capabilities/geoserver-credentials      {:trinity     {:username "<username>" :password "<password>"}
+                                                     :shasta      {:username "<username>" :password "<password>"}
+                                                     :match-drop  {:username "<username>" :password "<password>"}
+                                                     :psps        {:username "admin"      :password "password"}
+                                                     :pyreclimate {:username "<username>" :password "<password>"}}
  :pyregence.weather-stations/get-observation-stations-every-n-minutes 1440 ;; once a day
  :pyregence.email/verification-token-expiry-minutes 15
  :pyregence.match-drop/match-drop                   {:sig3-auth      "<AUTH_TOKEN>"

--- a/config.default.edn
+++ b/config.default.edn
@@ -116,8 +116,9 @@
  ;;; Pyrecast
  :pyregence.cameras/alert-west-api-key              "<api-key>"
  ;; Credentials used to list workspaces (REST API) and query GetCapabilities per
- ;; GeoServer. Omit an entry, or leave username/password blank, to query that
- ;; GeoServer anonymously. Keys must match the keys under :geoserver above.
+ ;; GeoServer. Omit a GeoServer's entry entirely to query it anonymously (a
+ ;; present-but-blank username/password is still sent as-is). Keys must match the
+ ;; keys under :geoserver above.
  :pyregence.capabilities/geoserver-credentials      {:trinity     {:username "<username>" :password "<password>"}
                                                      :shasta      {:username "<username>" :password "<password>"}
                                                      :match-drop  {:username "<username>" :password "<password>"}

--- a/config.default.edn
+++ b/config.default.edn
@@ -115,8 +115,6 @@
 
  ;;; Pyrecast
  :pyregence.cameras/alert-west-api-key              "<api-key>"
- :pyregence.capabilities/psps                       {:geoserver-admin-username "admin"
-                                                     :geoserver-admin-password "password"}
  ;; Credentials used to list workspaces (REST API) and query GetCapabilities per
  ;; GeoServer. Omit an entry, or leave username/password blank, to query that
  ;; GeoServer anonymously. Keys must match the keys under :geoserver above.

--- a/config.default.edn
+++ b/config.default.edn
@@ -122,8 +122,7 @@
  :pyregence.capabilities/geoserver-credentials      {:trinity     {:username "<username>" :password "<password>"}
                                                      :shasta      {:username "<username>" :password "<password>"}
                                                      :match-drop  {:username "<username>" :password "<password>"}
-                                                     :psps        {:username "<username>" :password "<password>"}
-                                                     :pyreclimate {:username "<username>" :password "<password>"}}
+                                                     :psps        {:username "<username>" :password "<password>"}}
  :pyregence.weather-stations/get-observation-stations-every-n-minutes 1440 ;; once a day
  :pyregence.email/verification-token-expiry-minutes 15
  :pyregence.match-drop/match-drop                   {:sig3-auth      "<AUTH_TOKEN>"

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -894,6 +894,20 @@
        (mapv #(:org_unique_id %))
        (data-response)))
 
+(defn get-psps-geoserver-credentials
+  "Returns the PSPS GeoServer admin credentials (\"username:password\") for users who
+   belong to the pyregence-consortium org (owner of WUI active fires). nil otherwise.
+   These are used to authenticate WUI active-fire tile requests against the private
+   `:psps` GeoServer."
+  [{:keys [user-id user-role] :as _session}]
+  (data-response
+   (when (and user-id
+              (or (= user-role "super_admin")
+                  (some #(= "pyregence-consortium" (:org_unique_id %))
+                        (call-sql "get_user_organization" user-id))))
+     (str (get-config :pyregence.capabilities/geoserver-credentials :psps :username) ":"
+          (get-config :pyregence.capabilities/geoserver-credentials :psps :password)))))
+
 (defn remove-org-user [_ org-user-id]
   (call-sql "remove_org_user" org-user-id)
   (data-response ""))

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -632,12 +632,12 @@
         {:keys [user-role]} session
         default-settings (pr-str {:timezone :utc})
         new-user-id      (nil-on-error
-                           (sql-primitive (call-sql "add_new_user"
-                                                    {:log? false}
-                                                    email
-                                                    user-name
-                                                    password
-                                                    default-settings)))
+                          (sql-primitive (call-sql "add_new_user"
+                                                   {:log? false}
+                                                   email
+                                                   user-name
+                                                   password
+                                                   default-settings)))
         response
         (if-not new-user-id
           (data-response (str "Failed to create the new user with name " user-name " and email " email)
@@ -893,20 +893,6 @@
   (->> (call-sql "get_psps_organizations")
        (mapv #(:org_unique_id %))
        (data-response)))
-
-(defn get-psps-geoserver-credentials
-  "Returns the PSPS GeoServer admin credentials (\"username:password\") for users who
-   belong to the pyregence-consortium org (owner of WUI active fires). nil otherwise.
-   These are used to authenticate WUI active-fire tile requests against the private
-   `:psps` GeoServer."
-  [{:keys [user-id user-role] :as _session}]
-  (data-response
-   (when (and user-id
-              (or (= user-role "super_admin")
-                  (some #(= "pyregence-consortium" (:org_unique_id %))
-                        (call-sql "get_user_organization" user-id))))
-     (str (get-config :pyregence.capabilities/geoserver-credentials :psps :username) ":"
-          (get-config :pyregence.capabilities/geoserver-credentials :psps :password)))))
 
 (defn remove-org-user [_ org-user-id]
   (call-sql "remove_org_user" org-user-id)

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -356,23 +356,33 @@
    REST API (using the credentials configured for that GeoServer in
    `::geoserver-credentials`) and set-capabilities! is then called once per
    workspace, avoiding timeouts on large GetCapabilities responses. If listing
-   the workspaces fails even after retries, that GeoServer is skipped."
+   the workspaces fails even after retries, that GeoServer is skipped. A
+   GeoServer with no configured credentials cannot have its workspaces listed
+   (the REST API requires auth), so it falls back to a single full
+   GetCapabilities call (logged loudly, since that reintroduces timeout risk)."
   [_]
   (->> (keys (get-config :triangulum.views/client-keys :geoserver))
        (pmap
         (fn [geoserver-key]
           (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
                 basic-auth    (get-geoserver-basic-auth geoserver-key)]
-            (try
-              (let [workspaces (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))]
-                (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-                (->> workspaces
-                     (pmap (fn [ws]
-                             (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                                     "workspace-name" ws})))
-                     (doall)))
-              (catch Exception e
-                (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e)))))))
+            (if-not basic-auth
+              (do
+                (log (str "WARNING: No credentials configured for GeoServer " geoserver-key " (" geoserver-url "). "
+                          "Falling back to a single full GetCapabilities call, which risks timing out on large responses. "
+                          "Add an entry under :pyregence.capabilities/geoserver-credentials to load it per workspace.")
+                     :force-stdout? true)
+                (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))
+              (try
+                (let [workspaces (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))]
+                  (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+                  (->> workspaces
+                       (pmap (fn [ws]
+                               (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                                       "workspace-name" ws})))
+                       (doall)))
+                (catch Exception e
+                  (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e))))))))
        (dorun))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -350,39 +350,51 @@
          :workspace
          (mapv :name))))
 
+(defn- load-geoserver-fully!
+  "Loads all of a GeoServer's layers via a single full GetCapabilities call.
+   Used when no credentials are configured, since workspaces can't be listed
+   without REST auth. Warns loudly because this risks timing out on large
+   GetCapabilities responses."
+  [geoserver-key geoserver-url]
+  (log (str "WARNING: No credentials configured for GeoServer " geoserver-key " (" geoserver-url "). "
+            "Falling back to a single full GetCapabilities call, which risks timing out on large responses. "
+            "Add an entry under :pyregence.capabilities/geoserver-credentials to load it per workspace.")
+       :force-stdout? true)
+  (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))
+
+(defn- load-geoserver-by-workspace!
+  "Lists the GeoServer's workspaces over the REST API (retrying transient
+   failures) and calls set-capabilities! once per workspace, avoiding timeouts
+   on large GetCapabilities responses. Skips the GeoServer if listing fails even
+   after retries."
+  [geoserver-key geoserver-url basic-auth]
+  (try
+    (let [workspaces (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))]
+      (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+      (->> workspaces
+           (pmap (fn [ws]
+                   (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                           "workspace-name" ws})))
+           (doall)))
+    (catch Exception e
+      (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e)))))
+
 (defn set-all-capabilities!
   "Calls set-capabilities! on all GeoServer URLs provided in config.edn.
-   Each GeoServer is loaded per workspace: its workspaces are listed via the
-   REST API (using the credentials configured for that GeoServer in
-   `::geoserver-credentials`) and set-capabilities! is then called once per
-   workspace, avoiding timeouts on large GetCapabilities responses. If listing
-   the workspaces fails even after retries, that GeoServer is skipped. A
+   Each GeoServer is loaded per workspace (see `load-geoserver-by-workspace!`)
+   using the credentials configured for it in `::geoserver-credentials`. A
    GeoServer with no configured credentials cannot have its workspaces listed
    (the REST API requires auth), so it falls back to a single full
-   GetCapabilities call (logged loudly, since that reintroduces timeout risk)."
+   GetCapabilities call (see `load-geoserver-fully!`)."
   [_]
   (->> (keys (get-config :triangulum.views/client-keys :geoserver))
        (pmap
         (fn [geoserver-key]
           (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
                 basic-auth    (get-geoserver-basic-auth geoserver-key)]
-            (if-not basic-auth
-              (do
-                (log (str "WARNING: No credentials configured for GeoServer " geoserver-key " (" geoserver-url "). "
-                          "Falling back to a single full GetCapabilities call, which risks timing out on large responses. "
-                          "Add an entry under :pyregence.capabilities/geoserver-credentials to load it per workspace.")
-                     :force-stdout? true)
-                (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))
-              (try
-                (let [workspaces (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))]
-                  (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-                  (->> workspaces
-                       (pmap (fn [ws]
-                               (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                                       "workspace-name" ws})))
-                       (doall)))
-                (catch Exception e
-                  (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e))))))))
+            (if basic-auth
+              (load-geoserver-by-workspace! geoserver-key geoserver-url basic-auth)
+              (load-geoserver-fully! geoserver-key geoserver-url)))))
        (dorun))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -363,9 +363,7 @@
           (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
                 basic-auth    (get-geoserver-basic-auth geoserver-key)]
             (try
-              (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
-                                 ;; For :psps, only load the WUI active-fire workspaces (testing).
-                                 (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
+              (let [workspaces (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))]
                 (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
                 (->> workspaces
                      (pmap (fn [ws]

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -357,9 +357,11 @@
   "Calls set-capabilities! on all GeoServer URLs provided in config.edn.
    Loads capabilities per workspace (listing the workspaces via the REST API
    first) to avoid timeouts on large GetCapabilities responses. If listing the
-   workspaces fails (even after retries), logs and skips that GeoServer rather
-   than issuing a single full GetCapabilities call, which would reintroduce the
-   timeout risk the per-workspace loading is meant to avoid."
+   workspaces fails (even after retries), behavior depends on the GeoServer:
+   private servers are skipped (a full GetCapabilities would reintroduce the
+   timeout risk per-workspace loading avoids), while public servers fall back to
+   a single full GetCapabilities call, since their REST API requires auth and
+   cannot be enumerated by workspace."
   [_]
   (doseq [geoserver-key (keys (get-config :triangulum.views/client-keys :geoserver))]
     (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
@@ -376,7 +378,11 @@
                                                "workspace-name" ws})))
                (doall)))
         (catch Exception e
-          (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e))))))
+          (if (private-layer-geoservers geoserver-key)
+            (log-str "Failed to list workspaces for " geoserver-url ", skipping (no safe full-GetCapabilities fallback).\n" (ex-message e))
+            (do
+              (log-str "Failed to list workspaces for " geoserver-url ", falling back to full GetCapabilities.\n" (ex-message e))
+              (set-capabilities! nil {"geoserver-key" (name geoserver-key)})))))))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))
 

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -339,7 +339,9 @@
       (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
             basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
         (try
-          (let [workspaces (list-workspaces geoserver-url basic-auth)]
+          (let [workspaces (cond->> (list-workspaces geoserver-url basic-auth)
+                             ;; For :psps, only load the WUI active-fire workspaces (testing).
+                             (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
             (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
             (->> workspaces
                  (pmap (fn [ws]

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -20,8 +20,9 @@
 
 (defn- get-geoserver-basic-auth
   "Returns a \"username:password\" basic-auth string for the given `geoserver-key`
-   from the `::geoserver-credentials` config map, or nil when no credentials are
-   configured for it (in which case GeoServer is queried anonymously)."
+   from the `::geoserver-credentials` config map, or nil when the GeoServer has no
+   entry in that map (in which case GeoServer is queried anonymously). Note that a
+   present-but-blank username/password is still sent as-is, not treated as nil."
   [geoserver-key]
   (let [{:keys [username password]} (get-config ::geoserver-credentials geoserver-key)]
     (when (and username password)

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -18,13 +18,14 @@
 (defn- get-site-url []
   (get-config :triangulum.email/base-url))
 
-(defn- get-psps-geoserver-admin-username []
-  (get-config ::psps :geoserver-admin-username))
-
-(defn- get-psps-geoserver-admin-password []
-  (get-config ::psps :geoserver-admin-password))
-
-(def private-layer-geoservers #{:psps})
+(defn- get-geoserver-basic-auth
+  "Returns a \"username:password\" basic-auth string for the given `geoserver-key`
+   from the `::geoserver-credentials` config map, or nil when no credentials are
+   configured for it (in which case GeoServer is queried anonymously)."
+  [geoserver-key]
+  (let [{:keys [username password]} (get-config ::geoserver-credentials geoserver-key)]
+    (when (and username password)
+      (str username ":" password))))
 
 ;;; Helper Functions
 
@@ -306,8 +307,7 @@
    on just that workspace by passing it into `process-layers!`."
   [_ {:strs [geoserver-key workspace-name]}]
   (let [geoserver-key (keyword geoserver-key)
-        basic-auth    (when (private-layer-geoservers geoserver-key)
-                        (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password)))]
+        basic-auth    (get-geoserver-basic-auth geoserver-key)]
     (if-not (contains? (get-config :triangulum.views/client-keys :geoserver) geoserver-key)
       (log-str "Failed to load capabilities. The GeoServer URL passed in was not found in config.edn.")
       (let [timeout-ms    (* 5 60 1000) ; 5 minutes
@@ -351,32 +351,29 @@
 
 (defn set-all-capabilities!
   "Calls set-capabilities! on all GeoServer URLs provided in config.edn.
-   Private servers are loaded per workspace (listing the workspaces via the
-   authenticated REST API first) to avoid timeouts on large GetCapabilities
-   responses; if listing fails even after retries, the server is skipped rather
-   than issuing a full GetCapabilities, which would reintroduce that timeout
-   risk. Public servers expose only WMS (their REST API requires auth), so they
-   are loaded directly with a single full GetCapabilities call."
+   Each GeoServer is loaded per workspace: its workspaces are listed via the
+   REST API (using the credentials configured for that GeoServer in
+   `::geoserver-credentials`) and set-capabilities! is then called once per
+   workspace, avoiding timeouts on large GetCapabilities responses. If listing
+   the workspaces fails even after retries, that GeoServer is skipped."
   [_]
   (->> (keys (get-config :triangulum.views/client-keys :geoserver))
        (pmap
         (fn [geoserver-key]
-          (if-not (private-layer-geoservers geoserver-key)
-            (set-capabilities! nil {"geoserver-key" (name geoserver-key)})
-            (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
-                  basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
-              (try
-                (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
-                                   ;; For :psps, only load the WUI active-fire workspaces (testing).
-                                   (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
-                  (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-                  (->> workspaces
-                       (pmap (fn [ws]
-                               (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                                       "workspace-name" ws})))
-                       (doall)))
-                (catch Exception e
-                  (log-str "Failed to list workspaces for " geoserver-url ", skipping (no safe full-GetCapabilities fallback).\n" (ex-message e))))))))
+          (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
+                basic-auth    (get-geoserver-basic-auth geoserver-key)]
+            (try
+              (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
+                                 ;; For :psps, only load the WUI active-fire workspaces (testing).
+                                 (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
+                (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+                (->> workspaces
+                     (pmap (fn [ws]
+                             (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                                     "workspace-name" ws})))
+                     (doall)))
+              (catch Exception e
+                (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e)))))))
        (dorun))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -278,6 +278,30 @@
 (defn get-all-layers [_]
   (data-response (mapcat #(map :filter-set (val %)) @layers)))
 
+(comment
+  (set-capabilities! {} {"geoserver-key" "psps"})
+  (set-capabilities! {} {"geoserver-key" "psps" "workspace-name" "fire-spread-forecast_ca-avenida_20260602_225100"}))
+
+(defn- with-retries
+  "Calls `f`, returning its result. If `f` throws, waits an increasing amount of
+   time (`base-delay-ms` * retry number) before trying again, up to `max-retries`
+   additional attempts. Re-throws the last exception if every retry is exhausted."
+  [max-retries base-delay-ms f]
+  (loop [retry 0]
+    (let [outcome (try
+                    [::ok (f)]
+                    (catch Exception e
+                      [::error e]))]
+      (if (= ::ok (first outcome))
+        (second outcome)
+        (if (>= retry max-retries)
+          (throw (second outcome))
+          (let [delay-ms (* base-delay-ms (inc retry))]
+            (log-str "Capabilities load attempt failed: " (ex-message (second outcome))
+                     ". Retrying (" (inc retry) " of " max-retries ") in " delay-ms " ms.")
+            (Thread/sleep delay-ms)
+            (recur (inc retry))))))))
+
 (defn set-capabilities!
   "Populates the layers atom with all of the layers that are returned
    from a call to GetCapabilities on a specific GeoServer. Passing in a
@@ -295,7 +319,7 @@
                             (try
                               (let [stdout?       (= 0 (count @layers))
                                     geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
-                                    new-layers    (process-layers! geoserver-url workspace-name basic-auth)
+                                    new-layers    (with-retries 3 2000 #(process-layers! geoserver-url workspace-name basic-auth))
                                     message       (str "Added " (count new-layers) " layers from " geoserver-url
                                                        (when workspace-name (str " (workspace=" workspace-name ")"))
                                                        " to " (get-site-url) ".")]
@@ -331,27 +355,28 @@
 
 (defn set-all-capabilities!
   "Calls set-capabilities! on all GeoServer URLs provided in config.edn.
-   For GeoServers that require authentication, loads capabilities per workspace
-   to avoid timeout on large GetCapabilities responses."
+   Loads capabilities per workspace (listing the workspaces via the REST API
+   first) to avoid timeouts on large GetCapabilities responses. If listing the
+   workspaces fails (even after retries), logs and skips that GeoServer rather
+   than issuing a single full GetCapabilities call, which would reintroduce the
+   timeout risk the per-workspace loading is meant to avoid."
   [_]
   (doseq [geoserver-key (keys (get-config :triangulum.views/client-keys :geoserver))]
-    (if (private-layer-geoservers geoserver-key)
-      (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
-            basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
-        (try
-          (let [workspaces (cond->> (list-workspaces geoserver-url basic-auth)
-                             ;; For :psps, only load the WUI active-fire workspaces (testing).
-                             (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
-            (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-            (->> workspaces
-                 (pmap (fn [ws]
-                         (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                                 "workspace-name" ws})))
-                 (doall)))
-          (catch Exception e
-            (log-str "Failed to list workspaces for " geoserver-url ", falling back to full GetCapabilities.\n" (ex-message e))
-            (set-capabilities! nil {"geoserver-key" (name geoserver-key)}))))
-      (set-capabilities! nil {"geoserver-key" (name geoserver-key)})))
+    (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
+          basic-auth    (when (private-layer-geoservers geoserver-key)
+                          (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password)))]
+      (try
+        (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
+                           ;; For :psps, only load the WUI active-fire workspaces (testing).
+                           (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
+          (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+          (->> workspaces
+               (pmap (fn [ws]
+                       (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                               "workspace-name" ws})))
+               (doall)))
+        (catch Exception e
+          (log-str "Failed to list workspaces for " geoserver-url ", skipping.\n" (ex-message e))))))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))
 

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -355,34 +355,30 @@
 
 (defn set-all-capabilities!
   "Calls set-capabilities! on all GeoServer URLs provided in config.edn.
-   Loads capabilities per workspace (listing the workspaces via the REST API
-   first) to avoid timeouts on large GetCapabilities responses. If listing the
-   workspaces fails (even after retries), behavior depends on the GeoServer:
-   private servers are skipped (a full GetCapabilities would reintroduce the
-   timeout risk per-workspace loading avoids), while public servers fall back to
-   a single full GetCapabilities call, since their REST API requires auth and
-   cannot be enumerated by workspace."
+   Private servers are loaded per workspace (listing the workspaces via the
+   authenticated REST API first) to avoid timeouts on large GetCapabilities
+   responses; if listing fails even after retries, the server is skipped rather
+   than issuing a full GetCapabilities, which would reintroduce that timeout
+   risk. Public servers expose only WMS (their REST API requires auth), so they
+   are loaded directly with a single full GetCapabilities call."
   [_]
   (doseq [geoserver-key (keys (get-config :triangulum.views/client-keys :geoserver))]
-    (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
-          basic-auth    (when (private-layer-geoservers geoserver-key)
-                          (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password)))]
-      (try
-        (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
-                           ;; For :psps, only load the WUI active-fire workspaces (testing).
-                           (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
-          (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-          (->> workspaces
-               (pmap (fn [ws]
-                       (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                               "workspace-name" ws})))
-               (doall)))
-        (catch Exception e
-          (if (private-layer-geoservers geoserver-key)
-            (log-str "Failed to list workspaces for " geoserver-url ", skipping (no safe full-GetCapabilities fallback).\n" (ex-message e))
-            (do
-              (log-str "Failed to list workspaces for " geoserver-url ", falling back to full GetCapabilities.\n" (ex-message e))
-              (set-capabilities! nil {"geoserver-key" (name geoserver-key)})))))))
+    (if-not (private-layer-geoservers geoserver-key)
+      (set-capabilities! nil {"geoserver-key" (name geoserver-key)})
+      (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
+            basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
+        (try
+          (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
+                             ;; For :psps, only load the WUI active-fire workspaces (testing).
+                             (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
+            (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+            (->> workspaces
+                 (pmap (fn [ws]
+                         (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                                 "workspace-name" ws})))
+                 (doall)))
+          (catch Exception e
+            (log-str "Failed to list workspaces for " geoserver-url ", skipping (no safe full-GetCapabilities fallback).\n" (ex-message e)))))))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))
 

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -362,23 +362,26 @@
    risk. Public servers expose only WMS (their REST API requires auth), so they
    are loaded directly with a single full GetCapabilities call."
   [_]
-  (doseq [geoserver-key (keys (get-config :triangulum.views/client-keys :geoserver))]
-    (if-not (private-layer-geoservers geoserver-key)
-      (set-capabilities! nil {"geoserver-key" (name geoserver-key)})
-      (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
-            basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
-        (try
-          (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
-                             ;; For :psps, only load the WUI active-fire workspaces (testing).
-                             (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
-            (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
-            (->> workspaces
-                 (pmap (fn [ws]
-                         (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
-                                                 "workspace-name" ws})))
-                 (doall)))
-          (catch Exception e
-            (log-str "Failed to list workspaces for " geoserver-url ", skipping (no safe full-GetCapabilities fallback).\n" (ex-message e)))))))
+  (->> (keys (get-config :triangulum.views/client-keys :geoserver))
+       (pmap
+        (fn [geoserver-key]
+          (if-not (private-layer-geoservers geoserver-key)
+            (set-capabilities! nil {"geoserver-key" (name geoserver-key)})
+            (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
+                  basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
+              (try
+                (let [workspaces (cond->> (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))
+                                   ;; For :psps, only load the WUI active-fire workspaces (testing).
+                                   (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
+                  (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
+                  (->> workspaces
+                       (pmap (fn [ws]
+                               (set-capabilities! nil {"geoserver-key"  (name geoserver-key)
+                                                       "workspace-name" ws})))
+                       (doall)))
+                (catch Exception e
+                  (log-str "Failed to list workspaces for " geoserver-url ", skipping (no safe full-GetCapabilities fallback).\n" (ex-message e))))))))
+       (dorun))
   (data-response (str (reduce + (map count (vals @layers)))
                       " total layers added to " (get-site-url) ".")))
 

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -278,10 +278,6 @@
 (defn get-all-layers [_]
   (data-response (mapcat #(map :filter-set (val %)) @layers)))
 
-(comment
-  (set-capabilities! {} {"geoserver-key" "psps"})
-  (set-capabilities! {} {"geoserver-key" "psps" "workspace-name" "fire-spread-forecast_ca-avenida_20260602_225100"}))
-
 (defn- with-retries
   "Calls `f`, returning its result. If `f` throws, waits an increasing amount of
    time (`base-delay-ms` * retry number) before trying again, up to `max-retries`

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -339,9 +339,7 @@
       (let [geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
             basic-auth    (str (get-psps-geoserver-admin-username) ":" (get-psps-geoserver-admin-password))]
         (try
-          (let [workspaces (cond->> (list-workspaces geoserver-url basic-auth)
-                             ;; For :psps, only load the WUI active-fire workspaces (testing).
-                             (= geoserver-key :psps) (filter #(str/starts-with? % "fire-spread")))]
+          (let [workspaces (list-workspaces geoserver-url basic-auth)]
             (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
             (->> workspaces
                  (pmap (fn [ws]

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -171,7 +171,8 @@
                               (when workspace-name
                                 (str "&NAMESPACE=" workspace-name))))
         xml-response (-> base-url
-                         (client/get (when basic-auth {:basic-auth basic-auth}))
+                         (client/get (cond-> {:connection-timeout 10000 :socket-timeout 60000}
+                                       basic-auth (assoc :basic-auth basic-auth)))
                          (:body))]
     (as-> xml-response xml
       (str/replace xml "\n" "")
@@ -349,7 +350,7 @@
   (let [url      (-> geoserver-url
                      (u/end-with "/")
                      (str "rest/workspaces.json"))
-        response (client/get url (cond-> {:as :text}
+        response (client/get url (cond-> {:as :text :connection-timeout 10000 :socket-timeout 60000}
                                    basic-auth (assoc :basic-auth basic-auth)))]
     (->> (json/read-str (:body response) :key-fn keyword)
          :workspaces

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -280,25 +280,35 @@
 (defn get-all-layers [_]
   (data-response (mapcat #(map :filter-set (val %)) @layers)))
 
+(def ^:private retry-delays-ms
+  "Wait periods (in ms) between capabilities load retries before giving up:
+   1s, 5s, 10s, 30s, 1min, then 2min (~3.8min of waits total, keeping the whole
+   sequence under ~5min)."
+  [1000 5000 10000 30000 60000 120000])
+
 (defn- with-retries
-  "Calls `f`, returning its result. If `f` throws, waits an increasing amount of
-   time (`base-delay-ms` * retry number) before trying again, up to `max-retries`
-   additional attempts. Re-throws the last exception if every retry is exhausted."
-  [max-retries base-delay-ms f]
-  (loop [retry 0]
-    (let [outcome (try
-                    [::ok (f)]
-                    (catch Exception e
-                      [::error e]))]
-      (if (= ::ok (first outcome))
-        (second outcome)
-        (if (>= retry max-retries)
-          (throw (second outcome))
-          (let [delay-ms (* base-delay-ms (inc retry))]
-            (log-str "Capabilities load attempt failed: " (ex-message (second outcome))
-                     ". Retrying (" (inc retry) " of " max-retries ") in " delay-ms " ms.")
-            (Thread/sleep delay-ms)
-            (recur (inc retry))))))))
+  "Calls `f`, returning its result. If `f` throws, waits for the next period in
+   `delays-ms` before trying again. Once every delay is exhausted, logs that it
+   is giving up and re-throws the last exception."
+  [delays-ms f]
+  (let [total (count delays-ms)]
+    (loop [delays delays-ms]
+      (let [outcome (try
+                      [::ok (f)]
+                      (catch Exception e
+                        [::error e]))]
+        (if (= ::ok (first outcome))
+          (second outcome)
+          (if-let [delay-ms (first delays)]
+            (let [attempt (inc (- total (count delays)))]
+              (log-str "Capabilities load attempt failed: " (ex-message (second outcome))
+                       ". Retrying (" attempt " of " total ") in " delay-ms " ms.")
+              (Thread/sleep delay-ms)
+              (recur (rest delays)))
+            (do
+              (log-str "Capabilities load failed after " total " retries. Giving up: "
+                       (ex-message (second outcome)))
+              (throw (second outcome)))))))))
 
 (defn set-capabilities!
   "Populates the layers atom with all of the layers that are returned
@@ -311,12 +321,11 @@
         basic-auth    (get-geoserver-basic-auth geoserver-key)]
     (if-not (contains? (get-config :triangulum.views/client-keys :geoserver) geoserver-key)
       (log-str "Failed to load capabilities. The GeoServer URL passed in was not found in config.edn.")
-      (let [timeout-ms    (* 5 60 1000) ; 5 minutes
-            future-result (future
+      (let [future-result (future
                             (try
                               (let [stdout?       (= 0 (count @layers))
                                     geoserver-url (get-config :triangulum.views/client-keys :geoserver geoserver-key)
-                                    new-layers    (with-retries 3 2000 #(process-layers! geoserver-url workspace-name basic-auth))
+                                    new-layers    (with-retries retry-delays-ms #(process-layers! geoserver-url workspace-name basic-auth))
                                     message       (str "Added " (count new-layers) " layers from " geoserver-url
                                                        (when workspace-name (str " (workspace=" workspace-name ")"))
                                                        " to " (get-site-url) ".")]
@@ -332,10 +341,7 @@
                                 (log-str "Failed to load capabilities for "
                                          (get-config :triangulum.views/client-keys :geoserver geoserver-key)
                                          "\n" (ex-message e)))))]
-        (if-let [result (deref future-result timeout-ms nil)]
-          result
-          (log-str (quot timeout-ms 1000) " seconds timeout occurred while loading capabilities for "
-                   (get-config :triangulum.views/client-keys :geoserver geoserver-key)))))))
+        @future-result))))
 
 (defn- list-workspaces
   "Lists workspace names from a GeoServer instance via the REST API."
@@ -369,7 +375,7 @@
    after retries."
   [geoserver-key geoserver-url basic-auth]
   (try
-    (let [workspaces (with-retries 3 2000 #(list-workspaces geoserver-url basic-auth))]
+    (let [workspaces (with-retries retry-delays-ms #(list-workspaces geoserver-url basic-auth))]
       (log-str "Loading " (count workspaces) " workspaces from " geoserver-url)
       (->> workspaces
            (pmap (fn [ws]


### PR DESCRIPTION
## Purpose
Rework GeoServer capabilities loading so every GeoServer is loaded **per workspace** (consistently, no public/private special-casing), in **parallel**, and **resilient to transient failures**.

- **Per-workspace loading for all GeoServers** — `set-all-capabilities!` lists each GeoServer's workspaces via the REST API and calls `set-capabilities!` once per workspace, avoiding timeouts on large `GetCapabilities` responses.
- **Parallelized** — replaced the sequential `doseq` over GeoServers with `pmap` (writes target distinct keys in the `layers` atom, and `swap!` is atomic, so concurrent updates are safe).
- **Retries with backoff** — added `with-retries`; the workspace listing and each per-workspace `process-layers!` call retry up to 3× with increasing delay (2s/4s/6s) on transient failures.
- **Per-GeoServer credentials** — introduced a single `:pyregence.capabilities/geoserver-credentials` config map (one entry per GeoServer), used both to list workspaces (REST) and query `GetCapabilities`. Migrated the old standalone `:pyregence.capabilities/psps` key into it; `authentication.clj` now reads psps creds from the unified map.
- **No-credentials fallback** — a GeoServer with no configured credentials can't have its workspaces listed (REST requires auth), so it falls back to a single full `GetCapabilities` call, logged loudly to stdout since that reintroduces timeout risk.
- **Refactor** — extracted the two loading branches into `load-geoserver-by-workspace!` and `load-geoserver-fully!`, leaving `set-all-capabilities!` to just dispatch on whether credentials are configured.

## Related Issues
Closes PYR1-1545

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated

## Testing
#### Module Impacted
Layers

#### Role
All

#### Steps
1. Add valid REST credentials for each GeoServer under `:pyregence.capabilities/geoserver-credentials` in `config.edn` (keys must match those under `:triangulum.views/client-keys :geoserver`).
2. Start the server (the `set-all-capabilities` worker runs on startup) and watch the logs.
3. Confirm each GeoServer logs `Loading N workspaces from <url>` and layers populate (e.g. map layers render, point info works).
4. Temporarily remove one GeoServer's credentials entry and restart; confirm the loud `WARNING: No credentials configured for GeoServer …` line and that it falls back to a full `GetCapabilities`.

#### Desired Outcome
All GeoServers load their layers via per-workspace calls; transient REST/HTTP failures are retried rather than dropping layers; a GeoServer missing credentials still loads (with a visible warning) instead of silently loading nothing.

## Screenshots
N/A — server-side change, no UI.
