### PR TITLE
PYR1-1546 Check if response is success before reading body

### DIFF
--- a/src/cljs/pyregence/components/settings/users_table.cljs
+++ b/src/cljs/pyregence/components/settings/users_table.cljs
@@ -31,8 +31,12 @@
                   "get-all-users"
                   "get-org-member-users")
           resp-chan              (u-async/call-clj-async! route)
-          {:keys [body]} (<! resp-chan)]
-      (map #(set/rename-keys % {:full-name :name :membership-status :org-membership-status}) (edn/read-string body)))))
+          {:keys [body success]} (<! resp-chan)]
+      (if success
+        (map #(set/rename-keys % {:full-name :name :membership-status :org-membership-status}) (edn/read-string body))
+        (do
+          (toast-message! (str "Unable to load users: " body))
+          [])))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Grid functionality
@@ -234,11 +238,11 @@
                            "Role"
                            db->display)
                           :get-selected-rows get-selected-rows}
-                          org-opt-selected?
-                          (assoc :select-org-msg (str "Assign Organization for "
-                                                      ({"organization_admin"  "Admin"
-                                                        "organization_member" "Member"} @checked)
-                                                      "."))))]
+                         org-opt-selected?
+                         (assoc :select-org-msg (str "Assign Organization for "
+                                                     ({"organization_admin"  "Admin"
+                                                       "organization_member" "Member"} @checked)
+                                                     "."))))]
              :status [update-user/drop-down
                       (let [org-opt-selected?
                             (and
@@ -264,7 +268,7 @@
                            "Status"
                            db->display)
                           :get-selected-rows get-selected-rows}
-                          org-opt-selected?
-                          (assoc :select-org-msg (str "Assign Organization for " (db->display @checked) " Users."))))]
+                         org-opt-selected?
+                         (assoc :select-org-msg (str "Assign Organization for " (db->display @checked) " Users."))))]
              nil)
            [table grid-api users users-selected? users-filter columns]]))})))


### PR DESCRIPTION
## Purpose
Addresses #1096 . Add a success guard when loading users. 

```clojure
(defn get-users! [user-role]
  (go
    (let [admin? (#{"super_admin" "account_manager"} user-role)
          route (if admin?
                  "get-all-users"
                  "get-org-member-users")
          resp-chan              (u-async/call-clj-async! route)
          {:keys [body]} (<! resp-chan)]
;;                ^ Here `body` returns as a string "Forbidden" for an organization_admin
;;                 This body later gets destructured so first char of this string "F" appears in the exception
      (map #(set/rename-keys % {:full-name :name :membership-status :org-membership-status}) (edn/read-string body)))))
```

Future effort could review the permissions for organization_admin so they can view their organization's users.

## Related Issues
Closes #1096 . I am unable to view jira issues.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [X] Code passes linter rules (`clj-kondo --lint src`) (No new findings introduced)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [X] No new reflection warnings (`clojure -M:check-reflection`)
- ~For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)~

## Testing
#### Module Impacted
Misc?

#### Role
Admin

#### Steps
1. Log in as an `organization_admin` user such as `admin@pyr.dev`
2. Navigate to Settings -> Organization Settings
3. Observe toast notification "Unable to load users: Forbidden"

#### Desired Outcome

 Page no longer crashes when opening the Organization Settings as an `organization_admin`.

<img width="1736" height="666" alt="Screenshot from 2026-06-17 11-27-45" src="https://github.com/user-attachments/assets/94eb99ce-6e65-47f6-a63c-ffb342fd6a3e" />
