### PR TITLE
PYR1-1546 Fix clj-kondo CI 403 on fork pull requests

### DIFF
--- a/.github/workflows/clj-kondo.yml
+++ b/.github/workflows/clj-kondo.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: DeLaGuardo/clojure-lint-action@master
+    - uses: actions/checkout@v4
+    - uses: DeLaGuardo/setup-clj-kondo@master
       with:
-        clj-kondo-args: --lint src --fail-level error
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        version: '2026.05.25'
+    - run: clj-kondo --lint src --fail-level error


### PR DESCRIPTION
## Purpose
Fixes the `clj-lint` CI check failing with a 403 on pull requests opened from forks.

The `DeLaGuardo/clojure-lint-action` posts its findings back through the GitHub Checks API (`create-a-check-run`), which requires a write-scoped token. For `pull_request` events from forks, GitHub downgrades `secrets.GITHUB_TOKEN` to read-only, so the action fails with `403 Resource not accessible by integration` — independent of any `permissions:` block (fork-PR tokens are capped read-only regardless).

This replaces the action with a direct clj-kondo invocation via `DeLaGuardo/setup-clj-kondo`:
- No Checks-API write is attempted, so fork PRs no longer 403.
- The lint still gates the build via `--fail-level error`.
- Also bumps `actions/checkout@v3 -> v4` and pins clj-kondo to `2026.05.25`.

Trade-off: findings now appear in the Actions **job log** rather than as inline PR annotations. Lint coverage and the pass/fail gate are unchanged.

## Related Issues
Surfaced by the fork PR #1097, whose `clj-lint` check 403s.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`) — N/A, CI-only change
- [ ] No new reflection warnings (`clojure -M:check-reflection`) — N/A, CI-only change
- [ ] For any large features/rearchitecting of the codebase, the relevant `docs` were updated — N/A

## Testing
#### Module Impacted
Misc. (CI / GitHub Actions)

#### Role
N/A

#### Steps
1. Open or re-run the `clj-lint` check on a pull request from a fork (e.g. #1097 after this lands on `main`).
2. Observe the `clj-lint` job runs clj-kondo and reports pass/fail without a 403.

#### Desired Outcome
`clj-lint` completes (green on clean code, red on `error`-level findings) for fork PRs instead of failing with `403 Resource not accessible by integration`.