### PR TITLE
PYR1-604/add-nfdrs-constant-and-variable-model-and-weather-params-to-weather-tab

### DIFF
--- a/.github/workflows/clj-kondo.yml
+++ b/.github/workflows/clj-kondo.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: DeLaGuardo/clojure-lint-action@master
+    - uses: actions/checkout@v4
+    - uses: DeLaGuardo/setup-clj-kondo@master
       with:
-        clj-kondo-args: --lint src --fail-level error
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        version: '2026.05.25'
+    - run: clj-kondo --lint src --fail-level error

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /.key
 /logs
 /target
+/deps-for-clj-watson.edn
 
 # Configuration files
 /config.edn

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths   ["src/clj" "src/cljs" "resources" "target" "src/sql"]
  :deps    {buddy/buddy-sign                                 {:mvn/version "3.5.351"}
-           clj-http/clj-http                                {:mvn/version "3.10.1"}
+           clj-http/clj-http                                {:mvn/version "3.13.1"}
            clj-tagsoup/clj-tagsoup                          {:mvn/version "0.3.0" :exclusions [org.clojure/data.xml org.clojure/clojure]}
            com.cognitect/transit-clj                        {:mvn/version "1.0.324"}
            com.cognitect/transit-cljs                       {:mvn/version "0.8.264"}
@@ -18,7 +18,7 @@
            org.clojure/data.json                            {:mvn/version "1.0.0"}
            org.clojure/data.xml                             {:mvn/version "0.0.8"}
            org.clojure/tools.cli                            {:mvn/version "1.0.194"}
-           org.postgresql/postgresql                        {:mvn/version "42.2.14"}
+           org.postgresql/postgresql                        {:mvn/version "42.7.11"}
            reagent/reagent                                  {:mvn/version "1.2.0"}
            ring/ring                                        {:mvn/version "1.9.4"}
            ring/ring-headers                                {:mvn/version "0.3.0"}

--- a/src/cljs/pyregence/components/settings/users_table.cljs
+++ b/src/cljs/pyregence/components/settings/users_table.cljs
@@ -31,8 +31,12 @@
                   "get-all-users"
                   "get-org-member-users")
           resp-chan              (u-async/call-clj-async! route)
-          {:keys [body]} (<! resp-chan)]
-      (map #(set/rename-keys % {:full-name :name :membership-status :org-membership-status}) (edn/read-string body)))))
+          {:keys [body success]} (<! resp-chan)]
+      (if success
+        (map #(set/rename-keys % {:full-name :name :membership-status :org-membership-status}) (edn/read-string body))
+        (do
+          (toast-message! (str "Unable to load users: " body))
+          [])))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Grid functionality
@@ -234,11 +238,11 @@
                            "Role"
                            db->display)
                           :get-selected-rows get-selected-rows}
-                          org-opt-selected?
-                          (assoc :select-org-msg (str "Assign Organization for "
-                                                      ({"organization_admin"  "Admin"
-                                                        "organization_member" "Member"} @checked)
-                                                      "."))))]
+                         org-opt-selected?
+                         (assoc :select-org-msg (str "Assign Organization for "
+                                                     ({"organization_admin"  "Admin"
+                                                       "organization_member" "Member"} @checked)
+                                                     "."))))]
              :status [update-user/drop-down
                       (let [org-opt-selected?
                             (and
@@ -264,7 +268,7 @@
                            "Status"
                            db->display)
                           :get-selected-rows get-selected-rows}
-                          org-opt-selected?
-                          (assoc :select-org-msg (str "Assign Organization for " (db->display @checked) " Users."))))]
+                         org-opt-selected?
+                         (assoc :select-org-msg (str "Assign Organization for " (db->display @checked) " Users."))))]
              nil)
            [table grid-api users users-selected? users-filter columns]]))})))

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -416,31 +416,31 @@
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
                                                                               :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd
-                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :hrrr          {:opt-label "HRRR"
-                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}
+                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}
                                                                               :filter    "hrrr"}
                                                               :hybrid        {:opt-label    "Hybrid"
                                                                               :filter       "hybrid"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p125      {:opt-label    "GFS 0.125\u00B0"
                                                                               :filter       "gfs0p125"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p25       {:opt-label    "GFS 0.250\u00B0"
                                                                               :filter       "gfs0p25"
-                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :nam-awip12    {:opt-label    "NAM 12 km"
                                                                               :filter       "nam-awip12"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :nam-conusnest {:opt-label    "NAM 3 km"
                                                                               :filter       "nam-conusnest"
-                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :cansac-wrf    {:opt-label    "CANSAC WRF"
                                                                               :filter       "cansac-wrf"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
-                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}})}
+                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -278,7 +278,6 @@
                                                               [:strong "Firebrand Ignition Probability"]
                                                               " - An estimate of the probability that a burning ember could ignite a receptive fuel bed based on its temperature and moisture content."]
                                                  :options    (array-map
-                                                               ;;TODO check filters
                                                               :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
                                                                        :filter "erc"
                                                                        :units "(ERC, Btu/sq ft)"}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -317,7 +317,7 @@
                                                               :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
                                                                       :filter "m1000"
                                                                       :units "(% or fraction)"}
-                                                              :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                                              :kbdiI {:opt-label "Keetch Byram Drought Index (0-800)"
                                                                        :filter "kbdiI"
                                                                        :units "Index (0-800)"}
                                                               :rh      {:opt-label "Relative humidity (%)"

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -263,7 +263,8 @@
                   :time-slider?    true
                   :always-utc?     true
                   :hover-text      "Gridded weather forecasts from several US operational weather models including key parameters that affect wildfire behavior."
-                  :params          {:band       {:opt-label  "Weather Parameter"
+                  :params          {:band       {:opt-label      "Weather Parameter"
+                                                 :default-option :rh
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Gridded weather forecasts from several US operational weather models having different spatial resolutions and forecast durations. Available quantities include common weather parameters and fire weather indices:"
                                                               [:br]
@@ -283,6 +284,10 @@
                                                               [:strong "Firebrand Ignition Probability"]
                                                               " - An estimate of the probability that a burning ember could ignite a receptive fuel bed based on its temperature and moisture content."]
                                                  :options    (array-map
+                                                              ;; SFDI category is the default/top output when an NFDRS model is selected
+                                                              :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                                                         :filter "sfdicat"
+                                                                         :disabled-for non-nfdrs-weather-models}
                                                               :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
                                                                        :filter "erc"
                                                                        :units "(ERC, Btu/sq ft)"
@@ -309,9 +314,6 @@
                                                                       :disabled-for non-nfdrs-weather-models}
                                                               :sfdiperc {:opt-label "SFDI percentile (%)"
                                                                          :filter "sfdiperc"
-                                                                         :disabled-for non-nfdrs-weather-models}
-                                                              :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
-                                                                         :filter "sfdicat"
                                                                          :disabled-for non-nfdrs-weather-models}
                                                               :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
                                                                    :filter "lh"

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -293,9 +293,9 @@
                                                                         :units "(ft/min)"}
                                                               :scperc  {:opt-label  "SC percentile"
                                                                         :filter     "scperc"}
-                                                              :ic    {:opt-label "SC percentile"
+                                                              :ic    {:opt-label "Ignition Component (%)"
                                                                       :filter "ic"}
-                                                              :sfdiperc {:opt-label "SFDI percentile"
+                                                              :sfdiperc {:opt-label "SFDI percentile (%)"
                                                                          :filter "sfdiperc"}
                                                               :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
                                                                          :filter "sfdicat"}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -278,6 +278,49 @@
                                                               [:strong "Firebrand Ignition Probability"]
                                                               " - An estimate of the probability that a burning ember could ignite a receptive fuel bed based on its temperature and moisture content."]
                                                  :options    (array-map
+                                                               ;;TODO check filters
+                                                              :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
+                                                                       :filter "erc"
+                                                                       :units "(ERC, Btu/sq ft)"}
+                                                              :ercperc {:opt-label "ERC percentile"
+                                                                        :filter "ercperc"}
+                                                              :bi {:opt-label "burning index (BI, ft * 10)"
+                                                                   :filter "bi"
+                                                                   :units "(BI, ft * 10)"}
+                                                              :biperc {:opt-label  "BI percentile"
+                                                                       :filter "biperc"}
+                                                              :sc      {:opt-label "spread component (ft/min)"
+                                                                        :filter "sc"
+                                                                        :units "(ft/min)"}
+                                                              :scperc  {:opt-label  "SC percentile"
+                                                                        :filter     "scperc"}
+                                                              :ic    {:opt-label "SC percentile"
+                                                                      :filter "ic"}
+                                                              :sfdiperc {:opt-label "SFDI percentile"
+                                                                         :filter "sfdiperc"}
+                                                              :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                                                         :filter "sfdicat"}
+                                                              :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
+                                                                   :filter "lh"
+                                                                   :units "(% or fraction)"}
+                                                              :lw {:opt-label "Live woody fuel moisture (% or fraction)"
+                                                                   :filter "lw"
+                                                                   :units "(% or fraction)"}
+                                                              :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
+                                                                    :filter "m1"
+                                                                    :units "(% or fraction)"}
+                                                              :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
+                                                                    :filter "m10"
+                                                                    :units "(% or fraction)"}
+                                                              :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
+                                                                     :filter "m100"
+                                                                     :units "(% or fraction)"}
+                                                              :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
+                                                                      :filter "m1000"
+                                                                      :units "(% or fraction)"}
+                                                              :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                                                       :filter "kbdiI"
+                                                                       :units "Index (0-800)"}
                                                               :rh      {:opt-label "Relative humidity (%)"
                                                                         :filter    "rh"
                                                                         :units     "%"}
@@ -373,30 +416,32 @@
                                                  :options    (array-map
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
-                                                                              :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd}}
+                                                                              :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd
+                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :hrrr          {:opt-label "HRRR"
+                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}
                                                                               :filter    "hrrr"}
                                                               :hybrid        {:opt-label    "Hybrid"
                                                                               :filter       "hybrid"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p125      {:opt-label    "GFS 0.125\u00B0"
                                                                               :filter       "gfs0p125"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p25       {:opt-label    "GFS 0.250\u00B0"
                                                                               :filter       "gfs0p25"
-                                                                              :disabled-for #{:smoke :tcdc}}
+                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :nam-awip12    {:opt-label    "NAM 12 km"
                                                                               :filter       "nam-awip12"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :nam-conusnest {:opt-label    "NAM 3 km"
                                                                               :filter       "nam-conusnest"
-                                                                              :disabled-for #{:smoke}}
+                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :cansac-wrf    {:opt-label    "CANSAC WRF"
                                                                               :filter       "cansac-wrf"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
-                                                                              :disabled-for #{:apcptot :apcp01 :smoke}})}
+                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -87,6 +87,11 @@
                              :filter-set    #{"fire-detections" "goes19-rgb"}
                              :geoserver-key :shasta}))
 
+(def ^:private non-nfdrs-weather-models
+  "All non-NFDRS weather models. The NFDRS-only Weather Parameters are
+   disabled-for these so they can only be selected with an NFDRS model."
+  #{:nbm :hrrr :hybrid :gfs0p125 :gfs0p25 :nam-awip12 :nam-conusnest :cansac-wrf :rtma-ru})
+
 (def near-term-forecast-options
   {:fuels        {:opt-label     "Fuels"
                   :filter        "fuels"
@@ -280,97 +285,121 @@
                                                  :options    (array-map
                                                               :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
                                                                        :filter "erc"
-                                                                       :units "(ERC, Btu/sq ft)"}
+                                                                       :units "(ERC, Btu/sq ft)"
+                                                                       :disabled-for non-nfdrs-weather-models}
                                                               :ercperc {:opt-label "ERC percentile"
-                                                                        :filter "ercperc"}
+                                                                        :filter "ercperc"
+                                                                        :disabled-for non-nfdrs-weather-models}
                                                               :bi {:opt-label "burning index (BI, ft * 10)"
                                                                    :filter "bi"
-                                                                   :units "(BI, ft * 10)"}
+                                                                   :units "(BI, ft * 10)"
+                                                                   :disabled-for non-nfdrs-weather-models}
                                                               :biperc {:opt-label  "BI percentile"
-                                                                       :filter "biperc"}
+                                                                       :filter "biperc"
+                                                                       :disabled-for non-nfdrs-weather-models}
                                                               :sc      {:opt-label "spread component (ft/min)"
                                                                         :filter "sc"
-                                                                        :units "(ft/min)"}
+                                                                        :units "(ft/min)"
+                                                                        :disabled-for non-nfdrs-weather-models}
                                                               :scperc  {:opt-label  "SC percentile"
-                                                                        :filter     "scperc"}
+                                                                        :filter     "scperc"
+                                                                        :disabled-for non-nfdrs-weather-models}
                                                               :ic    {:opt-label "Ignition Component (%)"
-                                                                      :filter "ic"}
+                                                                      :filter "ic"
+                                                                      :disabled-for non-nfdrs-weather-models}
                                                               :sfdiperc {:opt-label "SFDI percentile (%)"
-                                                                         :filter "sfdiperc"}
+                                                                         :filter "sfdiperc"
+                                                                         :disabled-for non-nfdrs-weather-models}
                                                               :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
-                                                                         :filter "sfdicat"}
+                                                                         :filter "sfdicat"
+                                                                         :disabled-for non-nfdrs-weather-models}
                                                               :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
                                                                    :filter "lh"
-                                                                   :units "(% or fraction)"}
+                                                                   :units "(% or fraction)"
+                                                                   :disabled-for non-nfdrs-weather-models}
                                                               :lw {:opt-label "Live woody fuel moisture (% or fraction)"
                                                                    :filter "lw"
-                                                                   :units "(% or fraction)"}
+                                                                   :units "(% or fraction)"
+                                                                   :disabled-for non-nfdrs-weather-models}
                                                               :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
                                                                     :filter "m1"
-                                                                    :units "(% or fraction)"}
+                                                                    :units "(% or fraction)"
+                                                                    :disabled-for non-nfdrs-weather-models}
                                                               :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
                                                                     :filter "m10"
-                                                                    :units "(% or fraction)"}
+                                                                    :units "(% or fraction)"
+                                                                    :disabled-for non-nfdrs-weather-models}
                                                               :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
                                                                      :filter "m100"
-                                                                     :units "(% or fraction)"}
+                                                                     :units "(% or fraction)"
+                                                                     :disabled-for non-nfdrs-weather-models}
                                                               :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
                                                                       :filter "m1000"
-                                                                      :units "(% or fraction)"}
+                                                                      :units "(% or fraction)"
+                                                                      :disabled-for non-nfdrs-weather-models}
                                                               :kbdiI {:opt-label "Keetch Byram Drought Index (0-800)"
-                                                                       :filter "kbdiI"
-                                                                       :units "Index (0-800)"}
+                                                                      :filter "kbdiI"
+                                                                      :units "Index (0-800)"
+                                                                      :disabled-for non-nfdrs-weather-models}
                                                               :rh      {:opt-label "Relative humidity (%)"
                                                                         :filter    "rh"
-                                                                        :units     "%"}
+                                                                        :units     "%"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :tmpf    {:opt-label "Temperature (\u00B0F)"
                                                                         :filter    "tmpf"
-                                                                        :units     "\u00B0F"}
+                                                                        :units     "\u00B0F"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :ffwi    {:opt-label "Fosberg Fire Weather Index"
                                                                         :filter    "ffwi"
-                                                                        :units     ""}
+                                                                        :units     ""
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :meq     {:opt-label "Fine dead fuel moisture (%)"
                                                                         :filter    "meq"
-                                                                        :units     "%"}
+                                                                        :units     "%"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :pign    {:opt-label "Firebrand ignition probability (%)"
                                                                         :filter    "pign"
-                                                                        :units     "%"}
+                                                                        :units     "%"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :wd      {:opt-label       "Wind direction (\u00B0)"
                                                                         :filter          "wd"
                                                                         :units           "\u00B0"
-                                                                        :reverse-legend? false}
+                                                                        :reverse-legend? false
+                                                                        :disabled-for    #{:nfdrs-constant :nfdrs-variable}}
                                                               :ws      {:opt-label "Sustained wind speed (mph)"
                                                                         :filter    "ws"
-                                                                        :units     "mph"}
+                                                                        :units     "mph"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :wg      {:opt-label "Wind gust (mph)"
                                                                         :filter    "wg"
-                                                                        :units     "mph"}
+                                                                        :units     "mph"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :apcptot {:opt-label       "Accumulated precipitation (in)"
                                                                         :filter          "apcptot"
                                                                         :units           "inches"
-                                                                        :disabled-for    #{:gfs0p125 :hybrid :rtma-ru :ecmwf :nve}
+                                                                        :disabled-for    #{:gfs0p125 :hybrid :rtma-ru :ecmwf :nve :nfdrs-constant :nfdrs-variable}
                                                                         :reverse-legend? false}
                                                               :apcp01  {:opt-label       "1-hour precipitation (in)"
                                                                         :filter          "apcp01"
                                                                         :units           "inches"
-                                                                        :disabled-for    #{:nam-awip12 :nbm :cansac-wrf :rtma-ru :ecmwf :nve}
+                                                                        :disabled-for    #{:nam-awip12 :nbm :cansac-wrf :rtma-ru :ecmwf :nve :nfdrs-constant :nfdrs-variable}
                                                                         :reverse-legend? false}
                                                               :vpd     {:opt-label    "Vapor pressure deficit (hPa)"
                                                                         :filter       "vpd"
                                                                         :units        "hPa"
-                                                                        :disabled-for #{:nbm :ecmwf :nve}}
+                                                                        :disabled-for #{:nbm :ecmwf :nve :nfdrs-constant :nfdrs-variable}}
                                                               :hdw     {:opt-label    "Hot-Dry-Windy Index (hPa*m/s)"
                                                                         :filter       "hdw"
                                                                         :units        "hPa*m/s"
-                                                                        :disabled-for #{:nbm :ecmwf}}
+                                                                        :disabled-for #{:nbm :ecmwf :nfdrs-constant :nfdrs-variable}}
                                                               :smoke   {:opt-label    "Smoke density (\u00b5g/m\u00b3)"
                                                                         :filter       "smoke"
                                                                         :units        "\u00b5g/m\u00b3"
-                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nam-conusnest :nbm :cansac-wrf :rtma-ru :ecmwf :nve}}
+                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nam-conusnest :nbm :cansac-wrf :rtma-ru :ecmwf :nve :nfdrs-constant :nfdrs-variable}}
                                                               :tcdc    {:opt-label    "Total cloud cover (%)"
                                                                         :filter       "tcdc"
                                                                         :units        "%"
-                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nbm :cansac-wrf :ecmwf :nve}})}
+                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nbm :cansac-wrf :ecmwf :nve :nfdrs-constant :nfdrs-variable}})}
                                     :model      {:opt-label  "Model"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               [:strong "NBM"]

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -686,7 +686,7 @@
       (into (sorted-map-by cmp) opts))))
 
 ;;; Capabilities
-(defn- process-capabilities! [fire-names user-layers options-config psps-orgs-list user-psps-orgs-list & [selected-options]]
+(defn- process-capabilities! [fire-names user-layers options-config psps-orgs-list user-psps-orgs-list {:keys [subscription-tier]} user-role & [selected-options]]
   (reset! !/capabilities
           ;; Add in all layers from the organiation_layers DB table
           (-> (reduce (fn [acc {:keys [layer_path layer_config]}]
@@ -722,8 +722,26 @@
                                          {:opt-label  org-name
                                           :filter     org-unique-id}))
                                 {}
-                                user-psps-orgs-list))))
-  ;; Sort the Risk tab "Ignition Pattern" options alphabetically by :opt-label
+                                user-psps-orgs-list))
+              (cond->
+               (or
+                (#{"tier1_basic_paid" "tier2_pro" "tier3_enterprise"} subscription-tier)
+                (#{"super_admin"} user-role))
+                (as-> m
+                      (reduce
+                       (fn [m [k v]]
+                         (assoc-in m k v))
+                       m
+                       [[[:fire-weather :params :model :options :nfdrs-constant]
+                         {:opt-label "NFDRS Constant", :filter "nfdrs-constant", :geoserver-key :psps,
+                          :disabled-for  #{:hdw :apcptot :apcp01 :vpd :smoke
+                                           :tcdc  :rh :tmpf :ffwi :meq :pign :wd :ws :wg}}]
+                        [[:fire-weather :params :model :options :nfdrs-variable]
+                         {:opt-label "NFDRS Variable", :filter "nfdrs-variable", :geoserver-key :psps,
+                          :disabled-for #{:hdw :apcptot :apcp01 :vpd
+                                          :smoke :tcdc  :rh :tmpf :ffwi :meq :pign :wd :ws :wg}}]])))))
+
+  ;; TODO Consider sorting the Risk tab "Ignition Pattern" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:fire-risk :params :pattern :options] sort-by-opt-label)
   ;; Sort the PSPS tab "Utility Company" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:psps-zonal :params :utility :options] sort-by-opt-label)
@@ -806,6 +824,8 @@
                                options-config
                                @!/psps-orgs-list
                                @!/user-psps-orgs-list
+                               params
+                               user-role
                                (params->selected-options options-config @!/*forecast params)))
       (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras-chan))))
       (reset! !/the-weather-stations (edn/read-string (:body (<! weather-stations-chan))))


### PR DESCRIPTION
Adds NFDRS constant and variable model and their exclusive weather parameters to the weather tab if the user is an Organization Admin or Organization Member with a tier1_basic_paid subscription or above, or a Super Admin. 

This is dependent on a deployment [PR here ](https://github.com/PyreCast/pyrecast-gcp-deployment/pull/24 )to sync the layers.

