### PR TITLE
Add CI workflow to run babashka tests

### DIFF
--- a/.github/workflows/bb-tests.yml
+++ b/.github/workflows/bb-tests.yml
@@ -45,7 +45,14 @@ jobs:
     - name: Install psql client
       run: sudo apt-get update && sudo apt-get install -y postgresql-client
     - name: Create config from default
-      run: cp config.default.edn config.edn
+      run: |
+        bb -e '(spit "config.edn"
+                     (pr-str (-> (slurp "config.default.edn")
+                                 clojure.edn/read-string
+                                 (assoc :triangulum.build-db/admin-pass "postgres"
+                                        :triangulum.server/mode         "dev"
+                                        :triangulum.email/pass          "ci"
+                                        :triangulum.views/gtag-id       "G-CI"))))'
     - name: Build database with dev data
       run: clojure -M:build-db build-all --dev-data --admin-pass postgres
     - name: Run tests

--- a/.github/workflows/bb-tests.yml
+++ b/.github/workflows/bb-tests.yml
@@ -1,0 +1,32 @@
+name: babashka tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  bb-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+    - uses: DeLaGuardo/setup-clojure@13.4
+      with:
+        cli: latest
+        bb: latest
+    - name: Cache clojure dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.deps.clj
+        key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+        restore-keys: cljdeps-
+    - run: bb test

--- a/.github/workflows/bb-tests.yml
+++ b/.github/workflows/bb-tests.yml
@@ -10,6 +10,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
@@ -29,4 +42,11 @@ jobs:
           ~/.deps.clj
         key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
         restore-keys: cljdeps-
-    - run: bb test
+    - name: Install psql client
+      run: sudo apt-get update && sudo apt-get install -y postgresql-client
+    - name: Create config from default
+      run: cp config.default.edn config.edn
+    - name: Build database with dev data
+      run: clojure -M:build-db build-all --dev-data --admin-pass postgres
+    - name: Run tests
+      run: bb test

--- a/.github/workflows/bb-tests.yml
+++ b/.github/workflows/bb-tests.yml
@@ -51,6 +51,7 @@ jobs:
                                  clojure.edn/read-string
                                  (assoc :triangulum.build-db/admin-pass "postgres"
                                         :triangulum.server/mode         "dev"
+                                        :triangulum.email/host          "smtp.ci.local"
                                         :triangulum.email/pass          "ci"
                                         :triangulum.views/gtag-id       "G-CI"))))'
     - name: Build database with dev data

--- a/bb.edn
+++ b/bb.edn
@@ -23,7 +23,7 @@
   build-all             (clojure "-M:build-db build-all")
   dev-data              (clojure "-M:build-db build-all --dev-data")
   functions             (clojure "-M:build-db functions")
-  test                  (clojure "-X:rct-test")
+  test                  (clojure "-M:rct-test")
   prod                  (do
                           (run 'install)
                           (run 'functions)

--- a/deps.edn
+++ b/deps.edn
@@ -58,8 +58,7 @@
                               :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                               :main-opts   ["-m" "cognitect.test-runner"]
                               :exec-fn     cognitect.test-runner.api/test}
-           :rct-test         {:exec-fn    com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree!
-                              :exec-args  {:dirs #{"src"}}}
+           :rct-test         {:main-opts ["-e" "(require 'com.mjdowney.rich-comment-tests.test-runner) (let [{:keys [fail error]} (com.mjdowney.rich-comment-tests.test-runner/run-tests-in-file-tree! :dirs #{\"src\"})] (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0)))"]}
            :clj-watson       {:replace-deps
                               {io.github.clj-holmes/clj-watson
                                {:git/tag "v6.0.1" :git/sha "b520351"}}

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -115,6 +115,10 @@
   (log-in nil "invalid@example.com" "wrongpass")
   ;=>> {:status 403}
 
+  ;; TEMP: deliberately failing assertion to verify CI fails the build
+  (+ 1 1)
+  ;=> 3
+
   ;; Test valid login without 2FA
   (do
     (save-user-settings! 2 {})

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -115,10 +115,6 @@
   (log-in nil "invalid@example.com" "wrongpass")
   ;=>> {:status 403}
 
-  ;; TEMP: deliberately failing assertion to verify CI fails the build
-  (+ 1 1)
-  ;=> 3
-
   ;; Test valid login without 2FA
   (do
     (save-user-settings! 2 {})

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -122,8 +122,9 @@
   ;=>> {:status 200 :session some?}
 
   ;; Test login with TOTP 2FA
-  (log-in nil "totp-2fa@pyr.dev" "totp2fa"))
+  (log-in nil "totp-2fa@pyr.dev" "totp2fa")
   ;=>> {:status 200 :body string?}
+  )
 
 ;; Integration test: sends a real 2FA code via SMTP, so it is intentionally
 ;; left out of the automated rct suite (no ^:rct/test metadata). Run manually.

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -122,12 +122,16 @@
   ;=>> {:status 200 :session some?}
 
   ;; Test login with TOTP 2FA
-  (log-in nil "totp-2fa@pyr.dev" "totp2fa")
+  (log-in nil "totp-2fa@pyr.dev" "totp2fa"))
   ;=>> {:status 200 :body string?}
 
+;; Integration test: sends a real 2FA code via SMTP, so it is intentionally
+;; left out of the automated rct suite (no ^:rct/test metadata). Run manually.
+(comment
   ;; Test login with email 2FA
-  (log-in nil "email-2fa@pyr.dev" "email2fa"))
+  (log-in nil "email-2fa@pyr.dev" "email2fa")
   ;=>> {:status 200 :body string?}
+  )
 
 (defn log-out [_] (data-response "" {:session nil}))
 

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -275,8 +275,9 @@
                             "workspace-name" "fire-weather-forecast_.*"})
     (let [result (map :workspace (:shasta @layers))]
       (reset! layers original-layers)
-      result)))
+      result))
   ;=>> ["fire-risk-forecast_20250101_00"]
+  )
 
 (defn get-all-layers [_]
   (data-response (mapcat #(map :filter-set (val %)) @layers)))


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that runs the babashka test suite (`bb test` → `clojure -X:rct-test`) on PRs to `main`.

## What's included
- **`.github/workflows/bb-tests.yml`** — on `pull_request` to `main`:
  - Sets up Temurin Java 21, Clojure CLI + babashka, caches deps
  - Spins up a `postgres:15` service container
  - Generates `config.edn` from `config.default.edn`
  - Builds the schema + functions + dev data via `clojure -M:build-db build-all --dev-data --admin-pass postgres`
  - Runs `bb test`
- **Excluded the email-2FA login rct test** from the automated suite (moved into an untagged `(comment ...)` block) since it sends a real 2FA code over SMTP. It's left as a manual integration test.

## Notes
- The DB-backed rct tests require Postgres + dev data, which the service container + `build-db` now provide in CI.
- First CI run is the real validation of the DB provisioning step.