### PR TITLE
PYR1-1550 PYR1-1518 Stop user email enumeration

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -734,14 +734,6 @@
     ;; TODO what should this failure message be.
     (data-response "" {:status 400})))
 
-(defn user-email-taken
-  ([_ email]
-   (user-email-taken nil email -1))
-  ([_ email user-id-to-ignore]
-   (if (sql-primitive (call-sql "user_email_taken" email user-id-to-ignore))
-     (data-response "User email is taken")
-     (data-response "User email is not taken" {:status 403}))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Access Control
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -79,7 +79,7 @@
 
 ^:rct/test
 (comment
-  ;; same 200 + generic body whether or not the account exists.
+  ;; identical 200 + generic body whether or not the account exists (no enumeration).
   (let [reset-resp (fn [user-name]
                      (with-redefs [dispatch-off-thread (fn [thunk] (thunk)) ; run the send inline
                                    call-sql            (fn [_ & _] [{:get_user_name_by_email user-name}])
@@ -87,11 +87,12 @@
                                    send-mail           (fn [& _] {:error :SUCCESS})]
                        (select-keys (send-verification-email! "probe@x" "Reset"
                                                               messages/password-reset-email :security)
-                                    [:status :body])))]
-    (= (reset-resp "Existing User")
-       (reset-resp nil)
-       {:status 200 :body (pr-str generic-reset-response)}))
-  ;=> true
+                                    [:status :body])))
+        resp       (reset-resp "Existing User")]
+    [(= resp (reset-resp nil))
+     (:status resp)
+     (str/includes? (:body resp) generic-reset-response)])
+  ;=> [true 200 true]
   )
 
 (defn send-2fa-code

--- a/src/clj/pyregence/email.clj
+++ b/src/clj/pyregence/email.clj
@@ -5,6 +5,7 @@
             [triangulum.config        :refer [get-config]]
             [triangulum.database      :refer [call-sql sql-primitive]]
             [triangulum.email         :refer [send-mail]]
+            [triangulum.logging       :refer [log-str]]
             [triangulum.response      :refer [data-response]]))
 
 ;; Helper to get security email config
@@ -44,22 +45,54 @@
   []
   (format "%06d" (rand-int 1000000)))
 
+(def ^:private generic-reset-response
+  "If that email address is registered with PyreCast, we will send you an email to reset your password.")
+
+(defn- dispatch-off-thread
+  "Runs `thunk` off-thread, logging failures."
+  [thunk]
+  (future
+    (try (thunk)
+         (catch Exception e (log-str "Background task failed: " (.getMessage e))))))
+
 (defn- send-verification-email!
-  "Send verification email with a token.
-   config-type can be :security (for password resets) or :support (for new users)."
+  "Send a verification email with a token. config-type is :security (password reset) or :support (new user).
+   The :security path responds identically and sends off-thread, so it can't enumerate accounts."
   [email subject message-fn config-type]
-  (let [user-name          (sql-primitive (call-sql "get_user_name_by_email" email))
-        verification-token (str (UUID/randomUUID))
-        base-url           (get-config :triangulum.email/base-url)
-        fmt                (get-email-format email)
-        body               (message-fn fmt base-url email user-name verification-token)
-        ;; Use security config only for :security type, otherwise use default
-        email-config       (when (= config-type :security)
-                             (get-security-email-config))
-        from-name          (if (= config-type :security) "PyreCast Security" "PyreCast Support")
-        result             (send-mail email nil from-name subject body fmt email-config)]
-    (call-sql "set_verification_token" email verification-token nil)
-    (data-response email {:status (when-not (= :SUCCESS (:error result)) 400)})))
+  (let [security? (= config-type :security)
+        user-name (sql-primitive (call-sql "get_user_name_by_email" email))
+        send!     (fn []
+                    (let [verification-token (str (UUID/randomUUID))
+                          base-url           (get-config :triangulum.email/base-url)
+                          fmt                (get-email-format email)
+                          body               (message-fn fmt base-url email user-name verification-token)
+                          ;; nil for non-security, so send-mail uses its default config
+                          email-config       (when security? (get-security-email-config))
+                          from-name          (if security? "PyreCast Security" "PyreCast Support")
+                          result             (send-mail email nil from-name subject body fmt email-config)]
+                      (call-sql "set_verification_token" email verification-token nil)
+                      result))]
+    (if security?
+      (do (when user-name (dispatch-off-thread send!))
+          (data-response generic-reset-response {:status 200}))
+      (data-response email {:status (when-not (= :SUCCESS (:error (send!))) 400)}))))
+
+^:rct/test
+(comment
+  ;; same 200 + generic body whether or not the account exists.
+  (let [reset-resp (fn [user-name]
+                     (with-redefs [dispatch-off-thread (fn [thunk] (thunk)) ; run the send inline
+                                   call-sql            (fn [_ & _] [{:get_user_name_by_email user-name}])
+                                   get-email-format    (fn [_] :text)
+                                   send-mail           (fn [& _] {:error :SUCCESS})]
+                       (select-keys (send-verification-email! "probe@x" "Reset"
+                                                              messages/password-reset-email :security)
+                                    [:status :body])))]
+    (= (reset-resp "Existing User")
+       (reset-resp nil)
+       {:status 200 :body (pr-str generic-reset-response)}))
+  ;=> true
+  )
 
 (defn send-2fa-code
   "Sends a time-limited 2FA code to the user's email"

--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -97,9 +97,6 @@
    [:post "/clj/get-user-name-by-email"]             {:handler (clj-handler authentication/get-current-user-name-by-email)
                                                      :auth-type   :member
                                                      :auth-action :block}
-   [:post "/clj/user-email-taken"]                   {:handler (clj-handler authentication/user-email-taken)
-                                                     :auth-type :token
-                                                     :auth-action :block}
    [:post "/clj/update-own-user-name"]               {:handler (clj-handler authentication/update-own-user-name)
                                                      :auth-type #{:member :token}
                                                      :auth-action :block}

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -17,7 +17,6 @@
 ;; State
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defonce pending? (r/atom false))
 (defonce forgot?  (r/atom false))
 (defonce email    (r/atom ""))
 (defonce password (r/atom ""))
@@ -47,21 +46,12 @@
 
 (defn- request-password! []
   (go
-    (reset! pending? true)
     (toast-message! "Submitting request. This may take a moment...")
-    (cond
-      (not (:success (<! (u-async/call-clj-async! "user-email-taken" @email))))
-      (toast-message! (str "There is no user with the email '" @email "'"))
-
-      (:success (<! (u-async/call-clj-async! "send-email" @email :reset)))
-      (do (toast-message! "Please check your email for a password reset link.")
-          (<! (timeout 4000))
-          (u-browser/jump-to-url! "/forecast"))
-
-      :else
-      (toast-message! ["An error occurred."
-                       "Please try again shortly or contact support@pyrecast.com for help."]))
-    (reset! pending? false)))
+    ;; same toast for any email (no enumeration)
+    (<! (u-async/call-clj-async! "send-email" @email :reset))
+    (toast-message! "If that email address is registered with PyreCast, we will send you an email to reset your password.")
+    (<! (timeout 4000))
+    (u-browser/jump-to-url! "/forecast")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; UI Components

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -46,29 +46,24 @@
                        "Please contact support@pyrecast.com for help."]))))
 
 (defn- register! []
-  (go
-    (reset! pending? true)
-    (let [email-chan (u-async/call-clj-async! "user-email-taken" @email)
-          errors     (remove nil?
-                             ;;TODO consider adding an email validation.
-                             [(when (u-data/missing-data? @email @re-email @password @re-password)
-                                "You must fill in all required information to continue.")
+  (reset! pending? true)
+  (let [errors (remove nil?
+                 ;;TODO consider adding an email validation.
+                 [(when (u-data/missing-data? @email @re-email @password @re-password)
+                    "You must fill in all required information to continue.")
 
-                              (when-not (= @email @re-email)
-                                "The emails you have entered do not match.")
+                  (when-not (= @email @re-email)
+                    "The emails you have entered do not match.")
 
-                              (when (< (count @password) 8)
-                                "Your password must be at least 8 characters long.")
+                  (when (< (count @password) 8)
+                    "Your password must be at least 8 characters long.")
 
-                              (when-not (= @password @re-password)
-                                "The passwords you have entered do not match.")
-
-                              (when (:success (<! email-chan))
-                                (str "A user with the email '" @email "' has already been created."))])]
-      (if (pos? (count errors))
-        (do (toast-message! errors)
-            (reset! pending? false))
-        (add-user!)))))
+                  (when-not (= @password @re-password)
+                    "The passwords you have entered do not match.")])]
+    (if (pos? (count errors))
+      (do (toast-message! errors)
+          (reset! pending? false))
+      (add-user!))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; UI Components

--- a/src/cljs/pyregence/pages/reset_password.cljs
+++ b/src/cljs/pyregence/pages/reset_password.cljs
@@ -38,10 +38,7 @@
                             "Your password must be at least 8 characters long.")
 
                           (when (not= @password @re-password)
-                            "Password fields do not match.")
-
-                          (when-not (:success (<! (u-async/call-clj-async! "user-email-taken" @email -1)))
-                            (str "The email '" @email "' does not exist."))])]
+                            "Password fields do not match.")])] ; token is validated server-side
 
       (if (pos? (count errors))
         (do (toast-message! errors)
@@ -50,7 +47,7 @@
           (do (toast-message! "Your password has been reset successfully.")
               (<! (timeout 2000))
               (u-browser/jump-to-url! "/forecast"))
-          (do (toast-message! (str "Error reseting password for " @email "."))
+          (do (toast-message! "Error resetting password.")
               (reset! pending? false)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/sql/changes/2026-06-24-drop-user-email-taken-function.sql
+++ b/src/sql/changes/2026-06-24-drop-user-email-taken-function.sql
@@ -1,0 +1,4 @@
+-- Drops user_email_taken: its only caller was the /clj/user-email-taken endpoint,
+-- removed as an account-enumeration vector. The users.email UNIQUE constraint
+-- still enforces uniqueness on insert.
+DROP FUNCTION IF EXISTS user_email_taken(text, integer);

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -71,17 +71,6 @@ RETURNS text AS $$
 
 $$ LANGUAGE SQL;
 
--- Returns true if user information is taken, excludes user_id
-CREATE OR REPLACE FUNCTION user_email_taken(_email text, _user_id_to_ignore integer)
- RETURNS boolean AS $$
-
-    SELECT count(1) > 0
-    FROM users
-    WHERE user_uid != _user_id_to_ignore
-        AND email = lower_trim(_email)
-
-$$ LANGUAGE SQL;
-
 --------------------------------------------------------------------------------
 -- User Creation functions
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

The app revealed whether an email is registered. Two fixes:

- Forgot-password now returns one generic response for any email.
- Removed the `/clj/user-email-taken` endpoint and the registration pre-check that used it (the DB still enforces unique emails).

## Related Issues
Closes PYR1-1550 PYR1-1518
