### PR TITLE
Fix super_admin load crash from str/lower-case nil in sort-by-opt-label

### DIFF
--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -687,10 +687,13 @@
 
 (defn- sort-by-opt-label [opts]
   (when opts
-    (doseq [[k v] opts]
-      (when (nil? (:opt-label v))
-        (js/console.warn "sort-by-opt-label nil :opt-label →" (pr-str k) (pr-str v))))
     (let [cmp (fn [a b]
+                (when (nil? (opts a))
+                  (js/console.warn "sort-by-opt-label lookup of absent key:" (pr-str a)
+                                   "— present keys:" (pr-str (keys opts))))
+                (when (nil? (opts b))
+                  (js/console.warn "sort-by-opt-label lookup of absent key:" (pr-str b)
+                                   "— present keys:" (pr-str (keys opts))))
                 (compare (str/lower-case (or (:opt-label (opts a)) ""))
                          (str/lower-case (or (:opt-label (opts b)) ""))))]
       (into (sorted-map-by cmp) opts))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -687,10 +687,8 @@
 
 (defn- sort-by-opt-label [opts]
   (when opts
-    ;; NOTE: a sorted-map-by re-runs `cmp` on every later get/contains?/assoc,
-    ;; including for keys not present in `opts` (e.g. a :default-option that has
-    ;; no matching option). Guard the :opt-label lookup so such absent-key
-    ;; lookups sort as "" instead of throwing on (str/lower-case nil).
+    ;; sorted-map-by re-runs cmp on later get/contains? for absent keys, so
+    ;; guard the :opt-label lookup against nil to avoid (str/lower-case nil).
     (let [cmp (fn [a b]
                 (compare (str/lower-case (or (:opt-label (opts a)) ""))
                          (str/lower-case (or (:opt-label (opts b)) ""))))]

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -687,13 +687,11 @@
 
 (defn- sort-by-opt-label [opts]
   (when opts
+    ;; NOTE: a sorted-map-by re-runs `cmp` on every later get/contains?/assoc,
+    ;; including for keys not present in `opts` (e.g. a :default-option that has
+    ;; no matching option). Guard the :opt-label lookup so such absent-key
+    ;; lookups sort as "" instead of throwing on (str/lower-case nil).
     (let [cmp (fn [a b]
-                (when (nil? (opts a))
-                  (js/console.warn "sort-by-opt-label lookup of absent key:" (pr-str a)
-                                   "— present keys:" (pr-str (keys opts))))
-                (when (nil? (opts b))
-                  (js/console.warn "sort-by-opt-label lookup of absent key:" (pr-str b)
-                                   "— present keys:" (pr-str (keys opts))))
                 (compare (str/lower-case (or (:opt-label (opts a)) ""))
                          (str/lower-case (or (:opt-label (opts b)) ""))))]
       (into (sorted-map-by cmp) opts))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -687,9 +687,12 @@
 
 (defn- sort-by-opt-label [opts]
   (when opts
+    (doseq [[k v] opts]
+      (when (nil? (:opt-label v))
+        (js/console.warn "sort-by-opt-label nil :opt-label →" (pr-str k) (pr-str v))))
     (let [cmp (fn [a b]
-                (compare (str/lower-case (:opt-label (opts a)))
-                         (str/lower-case (:opt-label (opts b)))))]
+                (compare (str/lower-case (or (:opt-label (opts a)) ""))
+                         (str/lower-case (or (:opt-label (opts b)) ""))))]
       (into (sorted-map-by cmp) opts))))
 
 ;;; Capabilities


### PR DESCRIPTION
## Purpose
Fixes a hard crash on load for `super_admin` users (`Uncaught TypeError: can't access property "toLowerCase", a is null`).

Root cause is in `sort-by-opt-label`. It builds a `sorted-map-by` whose comparator looks the key back up in the source map (`(:opt-label (opts a))`). A `sorted-map-by` re-runs that comparator on every later `get`/`contains?` — including for keys that aren't in the map — so an absent-key lookup evaluates `(str/lower-case nil)` and throws. Super admins hit it because they load every org, which is what surfaces the bad lookups.

Temporary diagnostic logging in the comparator exposed exactly which lookups were failing:

```
sort-by-opt-label lookup of absent key: :pyregence-consortium — present keys: (:all :tlines)
sort-by-opt-label lookup of absent key: :key — present keys: (:conus-buildings :state-boundaries :county-boundaries :us-trans-lines :current-year-perimeters :viirs-hotspots :modis-hotspots :goes-imagery)
```

The `:pyregence-consortium` lookup is the trigger: the fire-risk pattern `:default-option` was set to `(keyword org-unique-id)`, but the real option keys are `:<org>-planning`, and `pyregence-consortium`/`public` have no planning option at all — so the default referenced a key that never existed.

Changes:
- **`sort-by-opt-label`** — guard the `:opt-label` lookup in the comparator so absent-key lookups sort as `""` instead of throwing. This neutralizes the whole class of crash regardless of which key is looked up.
- **Pattern `:default-option`** — build the `-planning` key to match the actual option keys, and only set it when that option exists; otherwise fall back to the first option (`:all`).

## Related Issues
Closes PYR1-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Side Panel > Layers (fire-risk Ignition Pattern), Layers > Optional Layers (underlays)

#### Role
Admin (super_admin)

#### Steps
1. Log in as a `super_admin` whose first PSPS org is `pyregence-consortium` (or any org with no `-planning` option).
2. Load the forecast page.

#### Desired Outcome
Page loads without the `toLowerCase` console error; the fire-risk Ignition Pattern defaults to a valid option (its `-planning` option when one exists, otherwise `All-cause fires`).

---

## Screenshots
N/A (no visual change beyond the page loading successfully)
