### PR TITLE
PYR1-1512 Enforce non-predictable identifiers in PyreCast

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -688,10 +688,12 @@
 
 (defn update-user-name
   "Allows an organization admin to update the name of a user by their email."
-  [_ email new-name]
+  [{:keys [user-id]} email new-name]
   (if-let [user-id-to-update (sql-primitive (call-sql "get_user_id_by_email" email))]
-    (do (call-sql "update_user_name" user-id-to-update new-name)
-        (data-response (str "User's name successfully updated to " new-name)))
+    (if (sql-primitive (call-sql "can_admin_user" user-id user-id-to-update))
+      (do (call-sql "update_user_name" user-id-to-update new-name)
+          (data-response (str "User's name successfully updated to " new-name)))
+      (data-response "You are not authorized to manage this user." {:status 403}))
     (data-response (str "There is no user with the email " email)
                    {:status 403})))
 
@@ -792,13 +794,15 @@
                 :archived-date         archived_date}))
        (data-response)))
 
-(defn add-org-user [_ org-id email]
-  (if-let [user-id-to-add (sql-primitive (call-sql "get_user_id_by_email" email))]
-    (do
-      (call-sql "add_org_user" org-id user-id-to-add)
-      (data-response ""))
-    (data-response (str "There is no user with the email " email)
-                   {:status 403})))
+(defn add-org-user [{:keys [user-id]} org-id email]
+  (if-not (sql-primitive (call-sql "can_admin_org" user-id org-id))
+    (data-response "You are not authorized to manage this organization." {:status 403})
+    (if-let [user-id-to-add (sql-primitive (call-sql "get_user_id_by_email" email))]
+      (do
+        (call-sql "add_org_user" org-id user-id-to-add)
+        (data-response ""))
+      (data-response (str "There is no user with the email " email)
+                     {:status 403}))))
 
 (defn add-org-users [{:keys [user-role organization-id]} org-id users]
   ;; Prevent none SA&AM from changing other orgs.
@@ -900,21 +904,29 @@
        (mapv #(:org_unique_id %))
        (data-response)))
 
-(defn remove-org-user [_ org-user-id]
-  (call-sql "remove_org_user" org-user-id)
-  (data-response ""))
+(defn remove-org-user [{:keys [user-id]} org-user-id]
+  (if (sql-primitive (call-sql "can_admin_user" user-id org-user-id))
+    (do (call-sql "remove_org_user" org-user-id)
+        (data-response ""))
+    (data-response "You are not authorized to manage this user." {:status 403})))
 
-(defn update-org-info [_ org-id org-name email-domains auto-add? auto-accept?]
-  (call-sql "update_org_info" org-id org-name email-domains auto-add? auto-accept?)
-  (data-response ""))
+(defn update-org-info [{:keys [user-id]} org-id org-name email-domains auto-add? auto-accept?]
+  (if (sql-primitive (call-sql "can_admin_org" user-id org-id))
+    (do (call-sql "update_org_info" org-id org-name email-domains auto-add? auto-accept?)
+        (data-response ""))
+    (data-response "You are not authorized to manage this organization." {:status 403})))
 
-(defn update-org-user-role [_ user-id new-role]
-  (call-sql "update_org_user_role" user-id new-role)
-  (data-response ""))
+(defn update-org-user-role [{:keys [user-id]} target-user-id new-role]
+  (if (sql-primitive (call-sql "can_admin_user" user-id target-user-id))
+    (do (call-sql "update_org_user_role" target-user-id new-role)
+        (data-response ""))
+    (data-response "You are not authorized to manage this user." {:status 403})))
 
-(defn update-user-org-membership-status [_ user-id new-status]
-  (call-sql "update_org_membership_status" user-id new-status)
-  (data-response ""))
+(defn update-user-org-membership-status [{:keys [user-id]} target-user-id new-status]
+  (if (sql-primitive (call-sql "can_admin_user" user-id target-user-id))
+    (do (call-sql "update_org_membership_status" target-user-id new-status)
+        (data-response ""))
+    (data-response "You are not authorized to manage this user." {:status 403})))
 
 (defn delete-users
   [{:keys [user-email user-role]} users-to-delete]
@@ -923,3 +935,48 @@
     (do
       (call-sql "delete_users" user-email (into-array String users-to-delete))
       (data-response ""))))
+
+^:rct/test
+(comment
+  ;; --- IDOR guards (PYR1-1512) ---
+  ;; Seed data: user 1 (admin@pyr.dev) is organization_admin of org 1;
+  ;; user 2 (user@pyr.dev) is a member of org 1; user 3 (account_manager@pyr.dev)
+  ;; is an account_manager with no org; user 12 is an admin/member of org 2.
+
+  ;; can_admin_org: org admin may manage their own org, not another; AM manages any
+  (sql-primitive (call-sql "can_admin_org" 1 1))
+  ;=> true
+  (sql-primitive (call-sql "can_admin_org" 1 2))
+  ;=> false
+  (sql-primitive (call-sql "can_admin_org" 3 2))
+  ;=> true
+
+  ;; can_admin_user: org admin may manage a user in their org, not one in another
+  (sql-primitive (call-sql "can_admin_user" 1 2))
+  ;=> true
+  (sql-primitive (call-sql "can_admin_user" 1 12))
+  ;=> false
+
+  ;; Handlers deny an org admin acting outside their org (no mutation occurs)
+  (update-org-info {:user-id 1} 2 "Hacked" "@hack.com" false false)
+  ;=>> {:status 403}
+
+  (add-org-user {:user-id 1} 2 "user@pyr.dev")
+  ;=>> {:status 403}
+
+  (remove-org-user {:user-id 1} 12)
+  ;=>> {:status 403}
+
+  (update-org-user-role {:user-id 1} 12 "organization_admin")
+  ;=>> {:status 403}
+
+  (update-user-org-membership-status {:user-id 1} 12 "accepted")
+  ;=>> {:status 403}
+
+  (update-user-name {:user-id 1} "kiarapichler@deleteme.com" "Hacked")
+  ;=>> {:status 403}
+
+  ;; An account_manager (user 3) is allowed to manage any org
+  (sql-primitive (call-sql "can_admin_user" 3 12))
+  ;=> true
+  )

--- a/src/clj/pyregence/match_drop.clj
+++ b/src/clj/pyregence/match_drop.clj
@@ -462,16 +462,23 @@
 
 (defn delete-match-drop!
   "Deletes the specified match drop from the DB and removes it from the GeoServer
-   via the 'remove' action passed to the GeoSync Microservice"
-  [_ match-job-id]
-  (let [sig3-endpoint (get-config :triangulum.views/client-keys :features :sig3-endpoint)]
-    (delete-match-drop-using-kubernetes! sig3-endpoint match-job-id)))
+   via the 'remove' action passed to the GeoSync Microservice.
+   Only the match drop's owner may delete it."
+  [{:keys [user-id]} match-job-id]
+  (let [job (get-match-job-from-match-job-id! match-job-id)]
+    (if (and job (= user-id (:user-id job)))
+      (let [sig3-endpoint (get-config :triangulum.views/client-keys :features :sig3-endpoint)]
+        (delete-match-drop-using-kubernetes! sig3-endpoint match-job-id))
+      (data-response "You are not authorized to delete this match drop." {:status 403}))))
 
 (defn get-md-status
-  "Returns the current status of the given match drop run."
-  [_ match-job-id]
-  (data-response (-> (get-match-job-from-match-job-id! match-job-id)
-                     (select-keys [:display-name :geoserver-workspace :message :md-status :job-log]))))
+  "Returns the current status of the given match drop run.
+   Only the match drop's owner may view it."
+  [{:keys [user-id]} match-job-id]
+  (let [job (get-match-job-from-match-job-id! match-job-id)]
+    (if (and job (= user-id (:user-id job)))
+      (data-response (select-keys job [:display-name :geoserver-workspace :message :md-status :job-log]))
+      (data-response "You are not authorized to view this match drop." {:status 403}))))
 
 (defn get-md-available-dates
   "Gets the available dates for Match Drops in UTC.
@@ -513,3 +520,15 @@
                    "- :shasta layers may not be loaded")
           (data-response {:type "FeatureCollection" :features []}
                          {:type :json})))))
+
+^:rct/test
+(comment
+  ;; --- Match drop ownership guard (PYR1-1512) ---
+  ;; A match drop the session user does not own (here a non-existent job) must
+  ;; not be viewable or deletable; both return 403 without revealing existence.
+  (get-md-status {:user-id 1} 999999999)
+  ;=>> {:status 403}
+
+  (delete-match-drop! {:user-id 1} 999999999)
+  ;=>> {:status 403}
+  )

--- a/src/sql/functions/organization_functions.sql
+++ b/src/sql/functions/organization_functions.sql
@@ -2,6 +2,35 @@
 -- REQUIRES: user
 
 --------------------------------------------------------------------------------
+---  Authorization predicates
+--------------------------------------------------------------------------------
+-- True when the requesting user may administer the given organization.
+-- super_admins and account_managers may administer any org; an
+-- organization_admin may administer only their own org. Used to prevent IDOR:
+-- org-scoped mutations must gate on this so an admin of one org cannot act on
+-- another org by passing its id.
+CREATE OR REPLACE FUNCTION can_admin_org(_requesting_user_id integer, _org_id integer)
+RETURNS boolean AS $$
+    SELECT EXISTS (
+      SELECT 1
+      FROM users
+      WHERE user_uid = _requesting_user_id
+        AND (user_role IN ('super_admin', 'account_manager')
+             OR (user_role = 'organization_admin'
+                 AND organization_rid = _org_id))
+    )
+$$ LANGUAGE SQL;
+
+-- True when the requesting user may administer the given target user, i.e. they
+-- can administer the target user's organization. Users with no organization can
+-- only be administered by super_admins/account_managers.
+CREATE OR REPLACE FUNCTION can_admin_user(_requesting_user_id integer, _target_user_id integer)
+RETURNS boolean AS $$
+    SELECT can_admin_org(_requesting_user_id,
+                         (SELECT organization_rid FROM users WHERE user_uid = _target_user_id))
+$$ LANGUAGE SQL;
+
+--------------------------------------------------------------------------------
 ---  Organizations
 --------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION get_org_subscription_tier(_org_id integer)


### PR DESCRIPTION
## Summary

Fixes the IDOR (Insecure Direct Object Reference) exposure behind PYR1-1512 by enforcing **per-resource authorization** on the org/user admin and match-drop endpoints. Following the [OWASP IDOR Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html), the fix is an access-control check scoped to the acting user (derived from the session), not obfuscation of identifiers.

The endpoints were **role-gated but not resource-scoped**: the route layer verified a caller was *an* `organization_admin`, but the handlers then acted on whatever org/user id the client supplied. So an admin of one organization could edit another org, or change/remove users in it, by passing a foreign id. Match-drop delete/status acted on any job id regardless of owner.

## Changes

- **New SQL authorization predicates** (`organization_functions.sql`):
  - `can_admin_org(requesting_user, org_id)` — `super_admin`/`account_manager` may administer any org; an `organization_admin` only their own.
  - `can_admin_user(requesting_user, target_user)` — delegates to `can_admin_org` via the target user's org.
- **Gated the org/user admin handlers** (`authentication.clj`) on those predicates, using the acting user from the session; cross-org/cross-user requests now return `403`:
  - `update-org-info`, `add-org-user` (org-scoped)
  - `remove-org-user`, `update-org-user-role`, `update-user-org-membership-status`, `update-user-name` (user-scoped)
  - `super_admin`/`account_manager` remain unrestricted.
- **Scoped match-drop to the owner** (`match_drop.clj`): `delete-match-drop!` and `get-md-status` verify the job belongs to the session user, returning a uniform `403` that does not reveal whether the job exists.
- **Tests**: added `^:rct/test` blocks asserting the predicates allow same-org and deny cross-org access, that each guarded handler returns `403` across org boundaries, and that match-drop access to a non-owned job is denied.

No schema or primary-key changes: existing integer ids are kept; the fix is purely authorization. The predicates are `CREATE OR REPLACE` functions loaded by `bb functions` on deploy.

## Test plan

- [x] `bb test` — 22 tests, 129 assertions, 0 failures.
- [ ] As an `organization_admin`, confirm actions on your own org/users still succeed and actions targeting another org/user return `403`.
- [ ] Confirm `account_manager`/`super_admin` retain cross-org access.
- [ ] Confirm a user cannot view (`get-md-status`) or delete another user's match drop.
