### PR TITLE
PYR1-604/nfrds-drew

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -338,7 +338,51 @@
                                    :else               (= 1 (count sorted-options)))
                              #(select-param! % key)
                              selected-param-set]])))
-                     @!/processed-params)
+                     (cond-> @!/processed-params
+                       (#{:nfdrs-variable :nfdrs-constant} (-> @!/*params :fire-weather :model))
+                       (assoc-in [:band :options]
+                                 {:erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
+                                           :filter "erc"
+                                           :units "(ERC, Btu/sq ft)"}
+                                  :ercperc {:opt-label "ERC percentile"
+                                            :filter "ercperc"}
+                                  :bi {:opt-label "burning index (BI, ft * 10)"
+                                       :filter "bi"
+                                       :units "(BI, ft * 10)"}
+                                  :biperc {:opt-label  "BI percentile"
+                                           :filter "biperc"}
+                                  :sc      {:opt-label "spread component (ft/min)"
+                                            :filter "sc"
+                                            :units "(ft/min)"}
+                                  :scperc  {:opt-label  "SC percentile"
+                                            :filter     "scperc"}
+                                  :ic    {:opt-label "Ignition Component (%)"
+                                          :filter "ic"}
+                                  :sfdiperc {:opt-label "SFDI percentile (%)"
+                                             :filter "sfdiperc"}
+                                  :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                             :filter "sfdicat"}
+                                  :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
+                                       :filter "lh"
+                                       :units "(% or fraction)"}
+                                  :lw {:opt-label "Live woody fuel moisture (% or fraction)"
+                                       :filter "lw"
+                                       :units "(% or fraction)"}
+                                  :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
+                                        :filter "m1"
+                                        :units "(% or fraction)"}
+                                  :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
+                                        :filter "m10"
+                                        :units "(% or fraction)"}
+                                  :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
+                                         :filter "m100"
+                                         :units "(% or fraction)"}
+                                  :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
+                                          :filter "m1000"
+                                          :units "(% or fraction)"}
+                                  :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                          :filter "kbdiI"
+                                          :units "Index (0-800)"}})))
                [opacity-input]]]
              [sa/panel-section]
              [collapsible-panel-section

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -695,7 +695,7 @@
       (into (sorted-map-by cmp) opts))))
 
 ;;; Capabilities
-(defn- process-capabilities! [fire-names user-layers options-config psps-orgs-list user-psps-orgs-list & [selected-options]]
+(defn- process-capabilities! [fire-names user-layers options-config psps-orgs-list user-psps-orgs-list {:keys [subscription-tier]} user-role & [selected-options]]
   (reset! !/capabilities
           ;; Add in all layers from the organiation_layers DB table
           (-> (reduce (fn [acc {:keys [layer_path layer_config]}]
@@ -738,8 +738,71 @@
                                          {:opt-label  org-name
                                           :filter     org-unique-id}))
                                 {}
-                                user-psps-orgs-list))))
-  ;; Sort the Risk tab "Ignition Pattern" options alphabetically by :opt-label
+                                user-psps-orgs-list))
+              (cond->
+               (or
+                (#{"tier1_basic_paid" "tier2_pro" "tier3_enterprise"} subscription-tier)
+                (#{"super_admin"} user-role))
+                (as-> m
+                      (reduce
+                       (fn [m [k v]]
+                         (assoc-in m k v))
+                       m
+                       (cond->
+                        [[[:fire-weather :params :model :options :nfdrs-constant]
+                          {:opt-label "NFDRS Constant" :filter "nfdrs-constant" :geoserver-key :psps}]
+                         [[:fire-weather :params :model :options :nfdrs-variable]
+                          {:opt-label "NFDRS Variable" :filter "nfdrs-variable" :geoserver-key :psps}]]
+                         (#{:nfdrs-variable :nfdrs-constant} (-> @!/*params :fire-weather :model))
+                         (conj
+  ;;                         (-> @!/capabilities :fire-weather :params :band :options keys)
+  ;; ;; => (:rh :tmpf :ffwi :meq :pign :wd :ws :wg :apcptot :apcp01 :vpd :hdw :smoke :tcdc)
+
+                          [[:fire-weather :params :band :options]
+                           {:erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
+                                     :filter "erc"
+                                     :units "(ERC, Btu/sq ft)"}
+                            :ercperc {:opt-label "ERC percentile"
+                                      :filter "ercperc"}
+                            :bi {:opt-label "burning index (BI, ft * 10)"
+                                 :filter "bi"
+                                 :units "(BI, ft * 10)"}
+                            :biperc {:opt-label  "BI percentile"
+                                     :filter "biperc"}
+                            :sc      {:opt-label "spread component (ft/min)"
+                                      :filter "sc"
+                                      :units "(ft/min)"}
+                            :scperc  {:opt-label  "SC percentile"
+                                      :filter     "scperc"}
+                            :ic    {:opt-label "Ignition Component (%)"
+                                    :filter "ic"}
+                            :sfdiperc {:opt-label "SFDI percentile (%)"
+                                       :filter "sfdiperc"}
+                            :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                       :filter "sfdicat"}
+                            :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
+                                 :filter "lh"
+                                 :units "(% or fraction)"}
+                            :lw {:opt-label "Live woody fuel moisture (% or fraction)"
+                                 :filter "lw"
+                                 :units "(% or fraction)"}
+                            :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
+                                  :filter "m1"
+                                  :units "(% or fraction)"}
+                            :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
+                                  :filter "m10"
+                                  :units "(% or fraction)"}
+                            :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
+                                   :filter "m100"
+                                   :units "(% or fraction)"}
+                            :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
+                                    :filter "m1000"
+                                    :units "(% or fraction)"}
+                            :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                     :filter "kbdiI"
+                                     :units "Index (0-800)"}}])))))))
+
+;; Sort the Risk tab "Ignition Pattern" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:fire-risk :params :pattern :options] sort-by-opt-label)
   ;; Sort the PSPS tab "Utility Company" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:psps-zonal :params :utility :options] sort-by-opt-label)
@@ -822,6 +885,8 @@
                                options-config
                                @!/psps-orgs-list
                                @!/user-psps-orgs-list
+                               params
+                               user-role
                                (params->selected-options options-config @!/*forecast params)))
       (reset! !/the-cameras (edn/read-string (:body (<! fire-cameras-chan))))
       (reset! !/the-weather-stations (edn/read-string (:body (<! weather-stations-chan))))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -747,7 +747,6 @@
                       (reduce
                        (fn [m [k v]]
                          (assoc-in m k v))
-
                        m
                        [[[:fire-weather :params :model :options :nfdrs-constant]
                          {:opt-label "NFDRS Constant" :filter "nfdrs-constant" :geoserver-key :psps}]

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -747,60 +747,12 @@
                       (reduce
                        (fn [m [k v]]
                          (assoc-in m k v))
-                       m
-                       (cond->
-                        [[[:fire-weather :params :model :options :nfdrs-constant]
-                          {:opt-label "NFDRS Constant" :filter "nfdrs-constant" :geoserver-key :psps}]
-                         [[:fire-weather :params :model :options :nfdrs-variable]
-                          {:opt-label "NFDRS Variable" :filter "nfdrs-variable" :geoserver-key :psps}]]
-                         (#{:nfdrs-variable :nfdrs-constant} (-> @!/*params :fire-weather :model))
-                         (conj
-  ;;                         (-> @!/capabilities :fire-weather :params :band :options keys)
-  ;; ;; => (:rh :tmpf :ffwi :meq :pign :wd :ws :wg :apcptot :apcp01 :vpd :hdw :smoke :tcdc)
 
-                          [[:fire-weather :params :band :options]
-                           {:erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
-                                     :filter "erc"
-                                     :units "(ERC, Btu/sq ft)"}
-                            :ercperc {:opt-label "ERC percentile"
-                                      :filter "ercperc"}
-                            :bi {:opt-label "burning index (BI, ft * 10)"
-                                 :filter "bi"
-                                 :units "(BI, ft * 10)"}
-                            :biperc {:opt-label  "BI percentile"
-                                     :filter "biperc"}
-                            :sc      {:opt-label "spread component (ft/min)"
-                                      :filter "sc"
-                                      :units "(ft/min)"}
-                            :scperc  {:opt-label  "SC percentile"
-                                      :filter     "scperc"}
-                            :ic    {:opt-label "Ignition Component (%)"
-                                    :filter "ic"}
-                            :sfdiperc {:opt-label "SFDI percentile (%)"
-                                       :filter "sfdiperc"}
-                            :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
-                                       :filter "sfdicat"}
-                            :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
-                                 :filter "lh"
-                                 :units "(% or fraction)"}
-                            :lw {:opt-label "Live woody fuel moisture (% or fraction)"
-                                 :filter "lw"
-                                 :units "(% or fraction)"}
-                            :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
-                                  :filter "m1"
-                                  :units "(% or fraction)"}
-                            :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
-                                  :filter "m10"
-                                  :units "(% or fraction)"}
-                            :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
-                                   :filter "m100"
-                                   :units "(% or fraction)"}
-                            :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
-                                    :filter "m1000"
-                                    :units "(% or fraction)"}
-                            :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
-                                     :filter "kbdiI"
-                                     :units "Index (0-800)"}}])))))))
+                       m
+                       [[[:fire-weather :params :model :options :nfdrs-constant]
+                         {:opt-label "NFDRS Constant" :filter "nfdrs-constant" :geoserver-key :psps}]
+                        [[:fire-weather :params :model :options :nfdrs-variable]
+                         {:opt-label "NFDRS Variable" :filter "nfdrs-variable" :geoserver-key :psps}]])))))
 
 ;; Sort the Risk tab "Ignition Pattern" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:fire-risk :params :pattern :options] sort-by-opt-label)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -739,6 +739,7 @@
                                           :filter     org-unique-id}))
                                 {}
                                 user-psps-orgs-list))
+              ;;TODO consider moving this closer to the component.
               (cond->
                (or
                 (#{"tier1_basic_paid" "tier2_pro" "tier3_enterprise"} subscription-tier)


### PR DESCRIPTION
Adds NFRDS models and their weather params if the user has super-admin or their org has the right subscription role. The NFSRDS weather params will only show when the NFRDS model is selected to work a circle dependency issue that exists in other model to wp relationships, this means in order to get to other WP once the model is selected you have to change your model first.

This needs to go in with this [PR](https://github.com/PyreCast/pyrecast-gcp-deployment/pull/24)