### PR TITLE
PYR1-1552/remove-active-fire-background-when-not-on-active-fire-tab

### DIFF
--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -3,6 +3,7 @@
    [clojure.set                 :as set]
    [herb.core                   :refer [<class]]
    [pyregence.components.common :refer [tool-tip-wrapper]]
+   [pyregence.components.mapbox :as mb]
    [pyregence.styles             :as $]))
 
 ;; This is needed so that we can show the tabs on the src/cljs/pyregence/pages/account_settings.cljs page
@@ -55,6 +56,8 @@
                 :top
                 [:label {:style    ($forecast-label (= current-forecast forecast-key) mobile?)
                          :class    (<class $/p-add-hover)
-                         :on-click #(on-forecast-select forecast-key)}
+                         :on-click (fn []
+                                     (when-not (= forecast-key :active-fire) (mb/remove-layer! "fire-active-background"))
+                                     (on-forecast-select forecast-key))}
                  opt-label]]))
            tabs))]))


### PR DESCRIPTION
Just like the title says, this removes the fire-active-background (the red circles behind the active fire icons) when the user isn't  on the active fire tab.

To see this bug, visit prod on the active fire tab and then move to another tab and notice the background circle is still there...which we don't want. To see the fix, spin this up locally and do the same thing and notice its not there anymore.