### PR TITLE
only show active fire background circle when 'All Active Fires' 

### DIFF
--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -3,7 +3,6 @@
    [clojure.set                 :as set]
    [herb.core                   :refer [<class]]
    [pyregence.components.common :refer [tool-tip-wrapper]]
-   [pyregence.components.mapbox :as mb]
    [pyregence.styles             :as $]))
 
 ;; This is needed so that we can show the tabs on the src/cljs/pyregence/pages/account_settings.cljs page

--- a/src/cljs/pyregence/components/forecast_tabs.cljs
+++ b/src/cljs/pyregence/components/forecast_tabs.cljs
@@ -56,8 +56,6 @@
                 :top
                 [:label {:style    ($forecast-label (= current-forecast forecast-key) mobile?)
                          :class    (<class $/p-add-hover)
-                         :on-click (fn []
-                                     (when-not (= forecast-key :active-fire) (mb/remove-layer! "fire-active-background"))
-                                     (on-forecast-select forecast-key))}
+                         :on-click #(on-forecast-select forecast-key)}
                  opt-label]]))
            tabs))]))

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -242,7 +242,7 @@
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
-      (when-not (= (:type current-layer) "active-fires") (mb/remove-layer! "fire-active-background"))
+      (when-not (= (:type (current-layer)) "active-fires") (mb/remove-layer! "fire-active-background"))
       (cond
         (and
          (= :active-fire @!/*forecast)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -242,9 +242,7 @@
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
-      (let [{:keys [type forecast]} (current-layer)]
-        (when (or (not= type "active-fires") (= forecast "fire-spread-forecast"))
-          (mb/remove-layer! "fire-active-background")))
+      (when-not (= (:type current-layer) "active-fires") (mb/remove-layer! "fire-active-background"))
       (cond
         (and
          (= :active-fire @!/*forecast)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -242,6 +242,9 @@
       (when model-times (process-model-times! model-times))
       (reset! !/param-layers layers)
       (swap! !/*layer-idx #(max 0 (min % (- (count (or (:times (first @!/param-layers)) @!/param-layers)) 1))))
+      (let [{:keys [type forecast]} (current-layer)]
+        (when (or (not= type "active-fires") (= forecast "fire-spread-forecast"))
+          (mb/remove-layer! "fire-active-background")))
       (cond
         (and
          (= :active-fire @!/*forecast)


### PR DESCRIPTION
only show active fire background circle when 'All Active Fires'

The location and timing of this remove-layer function seems... questionable.

Broadly speaking the question is if the layer showing is connected to a UX
change: user clicks new tab and user clicks new fire, or a layer change, e.g
the user has selected an active fire layer. Right now, it seems the later, so
the current solution of binding it to the layer is better. As in the icon and the circle layer should travel together.

But then it's a
question of when to check and its very unclear "when" this get-layers function
is called, but in testing it seems ok.

But this works, and thats better then nothing.

To test it, load the active fires tab, notice the circle is removed whenever Active Fires > Fire Name isn't "All Active Fires"