### PR TITLE
PYR1-604 Add NFDRS weather layers (rebased)

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -339,7 +339,9 @@
                              #(select-param! % key)
                              selected-param-set]])))
                      (cond-> @!/processed-params
-                       (c/nfdrs?)
+                       ;; `:band` only exists on the Weather tab; gate on it so we don't
+                       ;; assoc-in a phantom header-less :band dropdown onto other tabs.
+                       (and (= @!/*forecast :fire-weather) (c/nfdrs?))
                        (assoc-in [:band :options]
                                  c/nfdrs-weather-params)))
                [opacity-input]]]

--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -339,11 +339,15 @@
                              #(select-param! % key)
                              selected-param-set]])))
                      (cond-> @!/processed-params
-                       ;; `:band` only exists on the Weather tab; gate on it so we don't
-                       ;; assoc-in a phantom header-less :band dropdown onto other tabs.
+                       ;; On the Weather tab, show only the Weather Parameters compatible with the
+                       ;; selected model: the NFDRS params when an NFDRS model is selected, the
+                       ;; standard params otherwise. (`:band` only exists on the Weather tab, so the
+                       ;; tab guard also keeps us from assoc-ing a phantom :band onto other tabs.)
                        (and (= @!/*forecast :fire-weather) (c/nfdrs?))
-                       (assoc-in [:band :options]
-                                 c/nfdrs-weather-params)))
+                       (assoc-in [:band :options] c/nfdrs-weather-params)
+
+                       (and (= @!/*forecast :fire-weather) (not (c/nfdrs?)))
+                       (update-in [:band :options] #(apply dissoc % (keys c/nfdrs-weather-params)))))
                [opacity-input]]]
              [sa/panel-section]
              [collapsible-panel-section

--- a/src/cljs/pyregence/components/mapbox.cljs
+++ b/src/cljs/pyregence/components/mapbox.cljs
@@ -1214,8 +1214,11 @@
                           :transformRequest (fn [url resource-type]
                                               (when (and (str/starts-with? url (:psps @!/geoserver-urls))
                                                          (= resource-type "Tile"))
-                                                #js {:url     url
-                                                     :headers #js {:authorization (str "Basic " (js/window.btoa (get-current-layer-geoserver-credentials)))}}))
+                                                (if-let [credentials (get-current-layer-geoserver-credentials)]
+                                                  #js {:url     url
+                                                       :headers #js {:authorization (str "Basic " (js/window.btoa credentials))}}
+                                                  ;; No credentials resolved -> don't send a bogus auth header.
+                                                  #js {:url url})))
                           :transition       {:duration 500 :delay 0}}
                          (when-not (:zoom opts)
                            {:bounds c/california-extent})

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -331,7 +331,6 @@
                                                               [:strong "Firebrand Ignition Probability"]
                                                               " - An estimate of the probability that a burning ember could ignite a receptive fuel bed based on its temperature and moisture content."]
                                                  :options    (array-map
-                                                               ;;TODO check filters
                                                               :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
                                                                        :filter "erc"
                                                                        :units "(ERC, Btu/sq ft)"}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -50,7 +50,7 @@
    :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
            :filter "m1000"
            :units "(% or fraction)"}
-   :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+   :kbdiI {:opt-label "Keetch Byram Drought Index (0-800)"
             :filter "kbdiI"
             :units "Index (0-800)"}})
 

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -469,31 +469,31 @@
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
                                                                               :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd
-                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :hrrr          {:opt-label "HRRR"
-                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}
+                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}
                                                                               :filter    "hrrr"}
                                                               :hybrid        {:opt-label    "Hybrid"
                                                                               :filter       "hybrid"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p125      {:opt-label    "GFS 0.125\u00B0"
                                                                               :filter       "gfs0p125"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p25       {:opt-label    "GFS 0.250\u00B0"
                                                                               :filter       "gfs0p25"
-                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :nam-awip12    {:opt-label    "NAM 12 km"
                                                                               :filter       "nam-awip12"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :nam-conusnest {:opt-label    "NAM 3 km"
                                                                               :filter       "nam-conusnest"
-                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :cansac-wrf    {:opt-label    "CANSAC WRF"
                                                                               :filter       "cansac-wrf"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
-                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}})}
+                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -140,6 +140,11 @@
                              :filter-set    #{"fire-detections" "goes19-rgb"}
                              :geoserver-key :shasta}))
 
+(def ^:private non-nfdrs-weather-models
+  "All non-NFDRS weather models. The NFDRS-only Weather Parameters are
+   disabled-for these so they can only be selected with an NFDRS model."
+  #{:nbm :hrrr :hybrid :gfs0p125 :gfs0p25 :nam-awip12 :nam-conusnest :cansac-wrf :rtma-ru})
+
 (def near-term-forecast-options
   {:fuels        {:opt-label     "Fuels"
                   :filter        "fuels"
@@ -333,97 +338,121 @@
                                                  :options    (array-map
                                                               :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
                                                                        :filter "erc"
-                                                                       :units "(ERC, Btu/sq ft)"}
+                                                                       :units "(ERC, Btu/sq ft)"
+                                                                       :disabled-for non-nfdrs-weather-models}
                                                               :ercperc {:opt-label "ERC percentile"
-                                                                        :filter "ercperc"}
+                                                                        :filter "ercperc"
+                                                                        :disabled-for non-nfdrs-weather-models}
                                                               :bi {:opt-label "burning index (BI, ft * 10)"
                                                                    :filter "bi"
-                                                                   :units "(BI, ft * 10)"}
+                                                                   :units "(BI, ft * 10)"
+                                                                   :disabled-for non-nfdrs-weather-models}
                                                               :biperc {:opt-label  "BI percentile"
-                                                                       :filter "biperc"}
+                                                                       :filter "biperc"
+                                                                       :disabled-for non-nfdrs-weather-models}
                                                               :sc      {:opt-label "spread component (ft/min)"
                                                                         :filter "sc"
-                                                                        :units "(ft/min)"}
+                                                                        :units "(ft/min)"
+                                                                        :disabled-for non-nfdrs-weather-models}
                                                               :scperc  {:opt-label  "SC percentile"
-                                                                        :filter     "scperc"}
+                                                                        :filter     "scperc"
+                                                                        :disabled-for non-nfdrs-weather-models}
                                                               :ic    {:opt-label "Ignition Component (%)"
-                                                                      :filter "ic"}
+                                                                      :filter "ic"
+                                                                      :disabled-for non-nfdrs-weather-models}
                                                               :sfdiperc {:opt-label "SFDI percentile (%)"
-                                                                         :filter "sfdiperc"}
+                                                                         :filter "sfdiperc"
+                                                                         :disabled-for non-nfdrs-weather-models}
                                                               :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
-                                                                         :filter "sfdicat"}
+                                                                         :filter "sfdicat"
+                                                                         :disabled-for non-nfdrs-weather-models}
                                                               :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
                                                                    :filter "lh"
-                                                                   :units "(% or fraction)"}
+                                                                   :units "(% or fraction)"
+                                                                   :disabled-for non-nfdrs-weather-models}
                                                               :lw {:opt-label "Live woody fuel moisture (% or fraction)"
                                                                    :filter "lw"
-                                                                   :units "(% or fraction)"}
+                                                                   :units "(% or fraction)"
+                                                                   :disabled-for non-nfdrs-weather-models}
                                                               :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
                                                                     :filter "m1"
-                                                                    :units "(% or fraction)"}
+                                                                    :units "(% or fraction)"
+                                                                    :disabled-for non-nfdrs-weather-models}
                                                               :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
                                                                     :filter "m10"
-                                                                    :units "(% or fraction)"}
+                                                                    :units "(% or fraction)"
+                                                                    :disabled-for non-nfdrs-weather-models}
                                                               :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
                                                                      :filter "m100"
-                                                                     :units "(% or fraction)"}
+                                                                     :units "(% or fraction)"
+                                                                     :disabled-for non-nfdrs-weather-models}
                                                               :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
                                                                       :filter "m1000"
-                                                                      :units "(% or fraction)"}
+                                                                      :units "(% or fraction)"
+                                                                      :disabled-for non-nfdrs-weather-models}
                                                               :kbdiI {:opt-label "Keetch Byram Drought Index (0-800)"
-                                                                       :filter "kbdiI"
-                                                                       :units "Index (0-800)"}
+                                                                      :filter "kbdiI"
+                                                                      :units "Index (0-800)"
+                                                                      :disabled-for non-nfdrs-weather-models}
                                                               :rh      {:opt-label "Relative humidity (%)"
                                                                         :filter    "rh"
-                                                                        :units     "%"}
+                                                                        :units     "%"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :tmpf    {:opt-label "Temperature (\u00B0F)"
                                                                         :filter    "tmpf"
-                                                                        :units     "\u00B0F"}
+                                                                        :units     "\u00B0F"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :ffwi    {:opt-label "Fosberg Fire Weather Index"
                                                                         :filter    "ffwi"
-                                                                        :units     ""}
+                                                                        :units     ""
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :meq     {:opt-label "Fine dead fuel moisture (%)"
                                                                         :filter    "meq"
-                                                                        :units     "%"}
+                                                                        :units     "%"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :pign    {:opt-label "Firebrand ignition probability (%)"
                                                                         :filter    "pign"
-                                                                        :units     "%"}
+                                                                        :units     "%"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :wd      {:opt-label       "Wind direction (\u00B0)"
                                                                         :filter          "wd"
                                                                         :units           "\u00B0"
-                                                                        :reverse-legend? false}
+                                                                        :reverse-legend? false
+                                                                        :disabled-for    #{:nfdrs-constant :nfdrs-variable}}
                                                               :ws      {:opt-label "Sustained wind speed (mph)"
                                                                         :filter    "ws"
-                                                                        :units     "mph"}
+                                                                        :units     "mph"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :wg      {:opt-label "Wind gust (mph)"
                                                                         :filter    "wg"
-                                                                        :units     "mph"}
+                                                                        :units     "mph"
+                                                                        :disabled-for #{:nfdrs-constant :nfdrs-variable}}
                                                               :apcptot {:opt-label       "Accumulated precipitation (in)"
                                                                         :filter          "apcptot"
                                                                         :units           "inches"
-                                                                        :disabled-for    #{:gfs0p125 :hybrid :rtma-ru :ecmwf :nve}
+                                                                        :disabled-for    #{:gfs0p125 :hybrid :rtma-ru :ecmwf :nve :nfdrs-constant :nfdrs-variable}
                                                                         :reverse-legend? false}
                                                               :apcp01  {:opt-label       "1-hour precipitation (in)"
                                                                         :filter          "apcp01"
                                                                         :units           "inches"
-                                                                        :disabled-for    #{:nam-awip12 :nbm :cansac-wrf :rtma-ru :ecmwf :nve}
+                                                                        :disabled-for    #{:nam-awip12 :nbm :cansac-wrf :rtma-ru :ecmwf :nve :nfdrs-constant :nfdrs-variable}
                                                                         :reverse-legend? false}
                                                               :vpd     {:opt-label    "Vapor pressure deficit (hPa)"
                                                                         :filter       "vpd"
                                                                         :units        "hPa"
-                                                                        :disabled-for #{:nbm :ecmwf :nve}}
+                                                                        :disabled-for #{:nbm :ecmwf :nve :nfdrs-constant :nfdrs-variable}}
                                                               :hdw     {:opt-label    "Hot-Dry-Windy Index (hPa*m/s)"
                                                                         :filter       "hdw"
                                                                         :units        "hPa*m/s"
-                                                                        :disabled-for #{:nbm :ecmwf}}
+                                                                        :disabled-for #{:nbm :ecmwf :nfdrs-constant :nfdrs-variable}}
                                                               :smoke   {:opt-label    "Smoke density (\u00b5g/m\u00b3)"
                                                                         :filter       "smoke"
                                                                         :units        "\u00b5g/m\u00b3"
-                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nam-conusnest :nbm :cansac-wrf :rtma-ru :ecmwf :nve}}
+                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nam-conusnest :nbm :cansac-wrf :rtma-ru :ecmwf :nve :nfdrs-constant :nfdrs-variable}}
                                                               :tcdc    {:opt-label    "Total cloud cover (%)"
                                                                         :filter       "tcdc"
                                                                         :units        "%"
-                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nbm :cansac-wrf :ecmwf :nve}})}
+                                                                        :disabled-for #{:gfs0p125 :gfs0p25 :hybrid :nam-awip12 :nbm :cansac-wrf :ecmwf :nve :nfdrs-constant :nfdrs-variable}})}
                                     :model      {:opt-label  "Model"
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               [:strong "NBM"]

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -346,9 +346,9 @@
                                                                         :units "(ft/min)"}
                                                               :scperc  {:opt-label  "SC percentile"
                                                                         :filter     "scperc"}
-                                                              :ic    {:opt-label "SC percentile"
+                                                              :ic    {:opt-label "Ignition Component (%)"
                                                                       :filter "ic"}
-                                                              :sfdiperc {:opt-label "SFDI percentile"
+                                                              :sfdiperc {:opt-label "SFDI percentile (%)"
                                                                          :filter "sfdiperc"}
                                                               :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
                                                                          :filter "sfdicat"}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -370,7 +370,7 @@
                                                               :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
                                                                       :filter "m1000"
                                                                       :units "(% or fraction)"}
-                                                              :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                                              :kbdiI {:opt-label "Keetch Byram Drought Index (0-800)"
                                                                        :filter "kbdiI"
                                                                        :units "Index (0-800)"}
                                                               :rh      {:opt-label "Relative humidity (%)"

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -499,32 +499,30 @@
                                                  :options    (array-map
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
-                                                                              :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd
-                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd}}
                                                               :hrrr          {:opt-label "HRRR"
-                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}
                                                                               :filter    "hrrr"}
                                                               :hybrid        {:opt-label    "Hybrid"
                                                                               :filter       "hybrid"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc}}
                                                               :gfs0p125      {:opt-label    "GFS 0.125\u00B0"
                                                                               :filter       "gfs0p125"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc}}
                                                               :gfs0p25       {:opt-label    "GFS 0.250\u00B0"
                                                                               :filter       "gfs0p25"
-                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:smoke :tcdc}}
                                                               :nam-awip12    {:opt-label    "NAM 12 km"
                                                                               :filter       "nam-awip12"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
                                                               :nam-conusnest {:opt-label    "NAM 3 km"
                                                                               :filter       "nam-conusnest"
-                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:smoke}}
                                                               :cansac-wrf    {:opt-label    "CANSAC WRF"
                                                                               :filter       "cansac-wrf"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
-                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1 :m10 :m100 :m1000 :kbdiI}})}
+                                                                              :disabled-for #{:apcptot :apcp01 :smoke}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -316,7 +316,8 @@
                   :time-slider?    true
                   :always-utc?     true
                   :hover-text      "Gridded weather forecasts from several US operational weather models including key parameters that affect wildfire behavior."
-                  :params          {:band       {:opt-label  "Weather Parameter"
+                  :params          {:band       {:opt-label      "Weather Parameter"
+                                                 :default-option :rh
                                                  :hover-text [:p {:style {:margin-bottom "0"}}
                                                               "Gridded weather forecasts from several US operational weather models having different spatial resolutions and forecast durations. Available quantities include common weather parameters and fire weather indices:"
                                                               [:br]
@@ -336,6 +337,10 @@
                                                               [:strong "Firebrand Ignition Probability"]
                                                               " - An estimate of the probability that a burning ember could ignite a receptive fuel bed based on its temperature and moisture content."]
                                                  :options    (array-map
+                                                              ;; SFDI category is the default/top output when an NFDRS model is selected
+                                                              :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                                                         :filter "sfdicat"
+                                                                         :disabled-for non-nfdrs-weather-models}
                                                               :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
                                                                        :filter "erc"
                                                                        :units "(ERC, Btu/sq ft)"
@@ -362,9 +367,6 @@
                                                                       :disabled-for non-nfdrs-weather-models}
                                                               :sfdiperc {:opt-label "SFDI percentile (%)"
                                                                          :filter "sfdiperc"
-                                                                         :disabled-for non-nfdrs-weather-models}
-                                                              :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
-                                                                         :filter "sfdicat"
                                                                          :disabled-for non-nfdrs-weather-models}
                                                               :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
                                                                    :filter "lh"

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -331,6 +331,49 @@
                                                               [:strong "Firebrand Ignition Probability"]
                                                               " - An estimate of the probability that a burning ember could ignite a receptive fuel bed based on its temperature and moisture content."]
                                                  :options    (array-map
+                                                               ;;TODO check filters
+                                                              :erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
+                                                                       :filter "erc"
+                                                                       :units "(ERC, Btu/sq ft)"}
+                                                              :ercperc {:opt-label "ERC percentile"
+                                                                        :filter "ercperc"}
+                                                              :bi {:opt-label "burning index (BI, ft * 10)"
+                                                                   :filter "bi"
+                                                                   :units "(BI, ft * 10)"}
+                                                              :biperc {:opt-label  "BI percentile"
+                                                                       :filter "biperc"}
+                                                              :sc      {:opt-label "spread component (ft/min)"
+                                                                        :filter "sc"
+                                                                        :units "(ft/min)"}
+                                                              :scperc  {:opt-label  "SC percentile"
+                                                                        :filter     "scperc"}
+                                                              :ic    {:opt-label "SC percentile"
+                                                                      :filter "ic"}
+                                                              :sfdiperc {:opt-label "SFDI percentile"
+                                                                         :filter "sfdiperc"}
+                                                              :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                                                         :filter "sfdicat"}
+                                                              :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
+                                                                   :filter "lh"
+                                                                   :units "(% or fraction)"}
+                                                              :lw {:opt-label "Live woody fuel moisture (% or fraction)"
+                                                                   :filter "lw"
+                                                                   :units "(% or fraction)"}
+                                                              :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
+                                                                    :filter "m1"
+                                                                    :units "(% or fraction)"}
+                                                              :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
+                                                                    :filter "m10"
+                                                                    :units "(% or fraction)"}
+                                                              :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
+                                                                     :filter "m100"
+                                                                     :units "(% or fraction)"}
+                                                              :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
+                                                                      :filter "m1000"
+                                                                      :units "(% or fraction)"}
+                                                              :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                                                       :filter "kbdiI"
+                                                                       :units "Index (0-800)"}
                                                               :rh      {:opt-label "Relative humidity (%)"
                                                                         :filter    "rh"
                                                                         :units     "%"}
@@ -426,30 +469,32 @@
                                                  :options    (array-map
                                                               :nbm           {:opt-label    "NBM"
                                                                               :filter       "nbm"
-                                                                              :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd}}
+                                                                              :disabled-for #{:apcp01 :hdw :smoke :tcdc :vpd
+                                                                                              :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :hrrr          {:opt-label "HRRR"
+                                                                              :disabled-for #{:erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}
                                                                               :filter    "hrrr"}
                                                               :hybrid        {:opt-label    "Hybrid"
                                                                               :filter       "hybrid"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p125      {:opt-label    "GFS 0.125\u00B0"
                                                                               :filter       "gfs0p125"
-                                                                              :disabled-for #{:apcptot :smoke :tcdc}}
+                                                                              :disabled-for #{:apcptot :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :gfs0p25       {:opt-label    "GFS 0.250\u00B0"
                                                                               :filter       "gfs0p25"
-                                                                              :disabled-for #{:smoke :tcdc}}
+                                                                              :disabled-for #{:smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :nam-awip12    {:opt-label    "NAM 12 km"
                                                                               :filter       "nam-awip12"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :nam-conusnest {:opt-label    "NAM 3 km"
                                                                               :filter       "nam-conusnest"
-                                                                              :disabled-for #{:smoke}}
+                                                                              :disabled-for #{:smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :cansac-wrf    {:opt-label    "CANSAC WRF"
                                                                               :filter       "cansac-wrf"
-                                                                              :disabled-for #{:apcp01 :smoke :tcdc}}
+                                                                              :disabled-for #{:apcp01 :smoke :tcdc :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}}
                                                               :rtma-ru       {:opt-label    "RTMA"
                                                                               :filter       "rtma-ru"
-                                                                              :disabled-for #{:apcptot :apcp01 :smoke}})}
+                                                                              :disabled-for #{:apcptot :apcp01 :smoke :erc :ercperc :bi :biperc :sc :scperc :ic :sfdiperc :sfdicat :lh :lw :m1:m10 :m100 :m1000 :kbdiI}})}
                                     :model-init {:opt-label  "Forecast Start Time"
                                                  :hover-text "Start time for the forecast cycle, new data comes every 6 hours."
                                                  :options    {:loading {:opt-label "Loading..."}}}}}

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -740,7 +740,6 @@
                                           :filter     org-unique-id}))
                                 {}
                                 user-psps-orgs-list))
-              ;;TODO consider moving this closer to the component.
               (cond->
                (or
                 (#{"tier1_basic_paid" "tier2_pro" "tier3_enterprise"} subscription-tier)
@@ -751,11 +750,15 @@
                          (assoc-in m k v))
                        m
                        [[[:fire-weather :params :model :options :nfdrs-constant]
-                         {:opt-label "NFDRS Constant" :filter "nfdrs-constant" :geoserver-key :psps}]
+                         {:opt-label "NFDRS Constant", :filter "nfdrs-constant", :geoserver-key :psps,
+                          :disabled-for  #{:hdw :apcptot :apcp01 :vpd :smoke
+                                           :tcdc  :rh :tmpf :ffwi :meq :pign :wd :ws :wg}}]
                         [[:fire-weather :params :model :options :nfdrs-variable]
-                         {:opt-label "NFDRS Variable" :filter "nfdrs-variable" :geoserver-key :psps}]])))))
+                         {:opt-label "NFDRS Variable", :filter "nfdrs-variable", :geoserver-key :psps,
+                          :disabled-for #{:hdw :apcptot :apcp01 :vpd
+                                          :smoke :tcdc  :rh :tmpf :ffwi :meq :pign :wd :ws :wg}}]])))))
 
-;; Sort the Risk tab "Ignition Pattern" options alphabetically by :opt-label
+  ;; TODO Consider sorting the Risk tab "Ignition Pattern" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:fire-risk :params :pattern :options] sort-by-opt-label)
   ;; Sort the PSPS tab "Utility Company" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:psps-zonal :params :utility :options] sort-by-opt-label)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -389,7 +389,7 @@
                               (subs raw-org-id 0 (- (count raw-org-id) (count "-planning")))
                               raw-org-id)
             matching-psps-org (cond
-                                (= selected-org-id "ecmwf") ; "ecmwf" is the Euro weather forecast which all utility companies have access to
+                                (#{"ecmwf" "nfdrs-constant" "nfdrs-variable"} selected-org-id) ; the Euro (ecmwf) and NFDRS weather layers aren't utility-specific - all PSPS companies have access, so any PSPS org's credentials work
                                 (first @!/user-psps-orgs-list)
 
                                 (= selected-org-id :only-underlays) ; The fuels and active fire tabs don't have any utility-specific layers, so only underlays are an option here

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -751,12 +751,10 @@
                        m
                        [[[:fire-weather :params :model :options :nfdrs-constant]
                          {:opt-label "NFDRS Constant", :filter "nfdrs-constant", :geoserver-key :psps,
-                          :disabled-for  #{:hdw :apcptot :apcp01 :vpd :smoke
-                                           :tcdc  :rh :tmpf :ffwi :meq :pign :wd :ws :wg}}]
+                          :disabled-for #{}}]
                         [[:fire-weather :params :model :options :nfdrs-variable]
                          {:opt-label "NFDRS Variable", :filter "nfdrs-variable", :geoserver-key :psps,
-                          :disabled-for #{:hdw :apcptot :apcp01 :vpd
-                                          :smoke :tcdc  :rh :tmpf :ffwi :meq :pign :wd :ws :wg}}]])))))
+                          :disabled-for #{}}]])))))
 
   ;; TODO Consider sorting the Risk tab "Ignition Pattern" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:fire-risk :params :pattern :options] sort-by-opt-label)

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -472,6 +472,12 @@
   (do (reset! !/*forecast :fuels)
       (selected-layer-cred-match))             ;=> {:match :underlay}
 
+  ;; Param not populated yet (e.g. tiles requested before process-capabilities!
+  ;; sets @!/*params) -> nil, so no creds resolve instead of throwing on (name nil).
+  (do (reset! !/*forecast :fire-weather)
+      (reset! !/*params   {})
+      (selected-layer-cred-match))             ;=> nil
+
   ;; --- get-current-layer-geoserver-credentials (end-to-end) ---------------------
 
   (def sample-orgs [{:org-unique-id "pge" :geoserver-credentials "pge-creds"}
@@ -499,6 +505,15 @@
     (reset! !/most-recent-optional-layer {})
     (reset! !/*forecast :fire-risk)
     (reset! !/*params   {:fire-risk {:pattern :some-other-utility}})
+    (get-current-layer-geoserver-credentials)) ;=> nil
+
+  ;; Selected layer's param not populated yet -> nil credentials (no NPE); the
+  ;; caller (mapbox transformRequest) then sends the tile with no auth header.
+  (with-redefs [wui/wui-fire-selected? (constantly false)]
+    (reset! !/user-psps-orgs-list sample-orgs)
+    (reset! !/most-recent-optional-layer {})
+    (reset! !/*forecast :fire-weather)
+    (reset! !/*params   {})
     (get-current-layer-geoserver-credentials)) ;=> nil
   )
 

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -353,56 +353,144 @@
                                 (remove (fn [leg] (nil? (get leg "label"))) %)
                                 (doall %)))))
 
-(defn- get-current-layer-geoserver-credentials
-  "Returns the GeoServer credentials associated with a specific layer for
-   users that are a part of at least one PSPS organization. Determines the credentials
-   by finding the utility company associated with the currently selected layer (via the values in the *params atom) and then
-   looking up that utility company's credentials using the `!/user-psps-orgs-list` atom.
-   Note that this assumes that the key associated with a specific utility company
-   is **exactly** the same as the `org-unique-id` set in the organizations DB table.
-   The Euro forecast (associated with the `:ecmwf` key on the weather tab) is an edge
-   case because each PSPS company has access to it. Returns `nil` if the user does
-   not belong to a PSPS organization or the current layer doesn't require GeoServer credentials.
+(def ^:private shared-weather-layer-ids
+  "Layer ids every PSPS company can access: the Euro (`ecmwf`) forecast and the NFDRS
+   weather layers. They aren't utility-specific, so any PSPS org's GeoServer
+   credentials will authenticate them."
+  #{"ecmwf" "nfdrs-constant" "nfdrs-variable"})
 
-   Note that super_admins can resolve credentials from *all* orgs."
+(def ^:private forecast->credential-keypath
+  "For each forecast type, the path into `@!/*params` holding the selected layer's
+   org-unique-id. `:only-underlays` flags tabs with no utility-specific layers. A
+   forecast absent from this map doesn't require GeoServer credentials."
+  {:fuels        :only-underlays
+   :fire-weather [:fire-weather :model]
+   :fire-risk    [:fire-risk :pattern]
+   :active-fire  :only-underlays
+   :psps-zonal   [:psps-zonal :utility]})
+
+(defn- selected-layer-org-id
+  "The org-unique-id of the currently selected non-WUI layer, or `:only-underlays`
+   for tabs without utility-specific layers. Strips the `-planning` suffix used by
+   utility fire-risk-planning keys. Returns nil when the current forecast needs no
+   GeoServer credentials.
+
+   TODO we shouldn't force the layer_path key to equal org-unique-id from the DB; we
+   should encode the org-id in the layer_config itself."
+  []
+  (when-some [keypath (forecast->credential-keypath @!/*forecast)]
+    (if (= keypath :only-underlays)
+      :only-underlays
+      (let [raw-org-id (name (get-in @!/*params keypath))]
+        (if (str/ends-with? raw-org-id "-planning")
+          (subs raw-org-id 0 (- (count raw-org-id) (count "-planning")))
+          raw-org-id)))))
+
+(defn- get-current-layer-geoserver-credentials
+  "Returns the GeoServer credentials a PSPS user should send for the currently
+   selected layer, or nil when the user belongs to no PSPS org or the layer needs no
+   credentials.
+
+   Credentials are resolved by matching the layer's org-unique-id against the user's
+   PSPS orgs in `@!/user-psps-orgs-list`. This assumes the layer's org key is exactly
+   the `org-unique-id` from the organizations DB table. Super_admins can resolve
+   credentials from *all* orgs.
+
+   Edge cases: WUI active fires are private to the pyregence-consortium org, and the
+   Euro/NFDRS weather layers are shared across every PSPS company."
   []
   (when (seq @!/user-psps-orgs-list)
-    (if (wui/wui-fire-selected?)
-      ;; WUI active fires are private to the pyregence-consortium org, which is just a
-      ;; regular PSPS org: authenticate with its own GeoServer credentials.
-      (-> (into {} (map (juxt :org-unique-id identity)) @!/user-psps-orgs-list)
-          (get-in [wui/wui-org-unique-id :geoserver-credentials]))
-      (when-some [keypath (case @!/*forecast
-                            :fuels        :only-underlays
-                            :fire-weather [:fire-weather :model]
-                            :fire-risk    [:fire-risk :pattern]
-                            :active-fire  :only-underlays
-                            :psps-zonal   [:psps-zonal :utility]
-                            nil)]
-      (let [;; TODO in the future we shouldn't force the layer_path key to be the same as org-unique-id from the DB, we should encode the org-id in the layer_config itself
-            raw-org-id      (if (= keypath :only-underlays)
-                              keypath
-                              (name (get-in @!/*params keypath)))
-            ;; Normalize utility fire-risk-planning keys from "utility-name-planning" -> "utility-name"
-            selected-org-id (if (and (string? raw-org-id)
-                                     (str/ends-with? raw-org-id "-planning"))
-                              (subs raw-org-id 0 (- (count raw-org-id) (count "-planning")))
-                              raw-org-id)
-            matching-psps-org (cond
-                                (#{"ecmwf" "nfdrs-constant" "nfdrs-variable"} selected-org-id) ; the Euro (ecmwf) and NFDRS weather layers aren't utility-specific - all PSPS companies have access, so any PSPS org's credentials work
-                                (first @!/user-psps-orgs-list)
+    (let [optional-layer         @!/most-recent-optional-layer
+          optional-layer-serves? (fn [org-unique-id]
+                                   (boolean (and (seq optional-layer)
+                                                 ((:filter-set optional-layer) org-unique-id))))
+          selected-org-id        (when-not (wui/wui-fire-selected?)
+                                   (selected-layer-org-id))
+          matching-org
+          (cond
+            ;; WUI active fires are private to the pyregence-consortium org (itself a
+            ;; regular PSPS org): authenticate with its own credentials.
+            (wui/wui-fire-selected?)
+            (first (filter #(= wui/wui-org-unique-id (:org-unique-id %)) @!/user-psps-orgs-list))
 
-                                (= selected-org-id :only-underlays) ; The fuels and active fire tabs don't have any utility-specific layers, so only underlays are an option here
-                                (first (filter #(and (seq @!/most-recent-optional-layer)
-                                                     ((:filter-set @!/most-recent-optional-layer) (:org-unique-id %)))
-                                               @!/user-psps-orgs-list))
+            ;; Shared weather layers aren't utility-specific, so any org's creds work.
+            (shared-weather-layer-ids selected-org-id)
+            (first @!/user-psps-orgs-list)
 
-                                :else
-                                (first (filter #(or (= selected-org-id (:org-unique-id %)) ; There should only be one matching entry because each `:org-unique-id` is unique
-                                                    (and (seq @!/most-recent-optional-layer) ; We're dealing with an optional layer that's associated with a utility company
-                                                         ((:filter-set @!/most-recent-optional-layer) (:org-unique-id %))))
-                                               @!/user-psps-orgs-list)))]
-        (:geoserver-credentials matching-psps-org))))))
+            ;; Fuels/active-fire tabs expose only underlays; match via the optional layer.
+            (= selected-org-id :only-underlays)
+            (first (filter #(optional-layer-serves? (:org-unique-id %)) @!/user-psps-orgs-list))
+
+            ;; Utility-specific layer: match the org directly, or via its optional layer.
+            ;; Only one org can match since each `:org-unique-id` is unique.
+            selected-org-id
+            (first (filter #(or (= selected-org-id (:org-unique-id %))
+                                (optional-layer-serves? (:org-unique-id %)))
+                           @!/user-psps-orgs-list)))]
+      (:geoserver-credentials matching-org))))
+
+(comment
+  ;; Worked examples for the GeoServer-credential resolution above. These read the
+  ;; global state atoms, so evaluate them one-by-one in a figwheel cljs REPL (they
+  ;; aren't run by `bb test`, which is JVM-only and can't load this namespace).
+
+  ;; --- Pure lookups -------------------------------------------------------------
+
+  ;; Shared (non-utility) weather layers: every PSPS company has access.
+  (shared-weather-layer-ids "ecmwf")           ;=> "ecmwf"
+  (shared-weather-layer-ids "nfdrs-variable")  ;=> "nfdrs-variable"
+  (shared-weather-layer-ids "pge")             ;=> nil
+
+  ;; Forecast -> where the selected layer's org-id lives in @!/*params.
+  (forecast->credential-keypath :fire-weather) ;=> [:fire-weather :model]
+  (forecast->credential-keypath :fuels)        ;=> :only-underlays
+  (forecast->credential-keypath :not-a-tab)    ;=> nil  ; unlisted -> needs no creds
+
+  ;; --- selected-layer-org-id (reads @!/*forecast + @!/*params) ------------------
+
+  ;; A utility layer id passes through unchanged.
+  (do (reset! !/*forecast :fire-risk)
+      (reset! !/*params   {:fire-risk {:pattern :pge}})
+      (selected-layer-org-id))                 ;=> "pge"
+
+  ;; The "-planning" suffix is normalized away ("pge-planning" -> "pge").
+  (do (reset! !/*forecast :fire-risk)
+      (reset! !/*params   {:fire-risk {:pattern :pge-planning}})
+      (selected-layer-org-id))                 ;=> "pge"
+
+  ;; Tabs without utility-specific layers resolve to the :only-underlays sentinel.
+  (do (reset! !/*forecast :fuels)
+      (selected-layer-org-id))                 ;=> :only-underlays
+
+  ;; --- get-current-layer-geoserver-credentials (end-to-end) ---------------------
+
+  (def sample-orgs [{:org-unique-id "pge" :geoserver-credentials "pge-creds"}
+                    {:org-unique-id "sce" :geoserver-credentials "sce-creds"}])
+
+  ;; Shared weather layer: not utility-specific, so the first org's creds are used.
+  (with-redefs [wui/wui-fire-selected? (constantly false)]
+    (reset! !/user-psps-orgs-list sample-orgs)
+    (reset! !/most-recent-optional-layer {})
+    (reset! !/*forecast :fire-weather)
+    (reset! !/*params   {:fire-weather {:model :ecmwf}})
+    (get-current-layer-geoserver-credentials)) ;=> "pge-creds"
+
+  ;; Utility-specific layer: matches that exact org by :org-unique-id.
+  (with-redefs [wui/wui-fire-selected? (constantly false)]
+    (reset! !/user-psps-orgs-list sample-orgs)
+    (reset! !/most-recent-optional-layer {})
+    (reset! !/*forecast :fire-risk)
+    (reset! !/*params   {:fire-risk {:pattern :sce}})
+    (get-current-layer-geoserver-credentials)) ;=> "sce-creds"
+
+  ;; No matching org (and no optional layer) -> nil credentials.
+  (with-redefs [wui/wui-fire-selected? (constantly false)]
+    (reset! !/user-psps-orgs-list sample-orgs)
+    (reset! !/most-recent-optional-layer {})
+    (reset! !/*forecast :fire-risk)
+    (reset! !/*params   {:fire-risk {:pattern :some-other-utility}})
+    (get-current-layer-geoserver-credentials)) ;=> nil
+  )
 
 ;; Use <! for synchronous behavior or leave it off for asynchronous behavior.
 (defn- get-legend!

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -361,30 +361,40 @@
 
 (def ^:private forecast->credential-keypath
   "For each forecast type, the path into `@!/*params` holding the selected layer's
-   org-unique-id. `:only-underlays` flags tabs with no utility-specific layers. A
-   forecast absent from this map doesn't require GeoServer credentials."
+   org/model id (a utility `org-unique-id`, or a shared-weather model like `ecmwf`).
+   `:only-underlays` flags tabs with no utility-specific layers. A forecast absent
+   from this map doesn't require GeoServer credentials."
   {:fuels        :only-underlays
    :fire-weather [:fire-weather :model]
    :fire-risk    [:fire-risk :pattern]
    :active-fire  :only-underlays
    :psps-zonal   [:psps-zonal :utility]})
 
-(defn- selected-layer-org-id
-  "The org-unique-id of the currently selected non-WUI layer, or `:only-underlays`
-   for tabs without utility-specific layers. Strips the `-planning` suffix used by
-   utility fire-risk-planning keys. Returns nil when the current forecast needs no
-   GeoServer credentials.
+(defn- selected-layer-cred-match
+  "Describes how to resolve GeoServer credentials for the currently selected non-WUI
+   layer, as a map:
+
+     {:match :any}             shared weather layers -- any PSPS org's creds work
+     {:match :underlay}        tabs exposing only underlays -- match via the optional layer
+     {:match :org, :org-id id} a utility-specific layer -- match that org (or its underlay)
+
+   Returns nil when the current forecast needs no GeoServer credentials. Strips the
+   `-planning` suffix used by utility fire-risk-planning keys.
 
    TODO we shouldn't force the layer_path key to equal org-unique-id from the DB; we
    should encode the org-id in the layer_config itself."
   []
   (when-some [keypath (forecast->credential-keypath @!/*forecast)]
     (if (= keypath :only-underlays)
-      :only-underlays
-      (let [raw-org-id (name (get-in @!/*params keypath))]
-        (if (str/ends-with? raw-org-id "-planning")
-          (subs raw-org-id 0 (- (count raw-org-id) (count "-planning")))
-          raw-org-id)))))
+      {:match :underlay}
+      ;; nil when the param isn't populated yet (e.g. tiles requested before
+      ;; process-capabilities! sets @!/*params) -> resolves to no credentials.
+      (when-some [layer-id (some-> (get-in @!/*params keypath)
+                                   name
+                                   (str/replace #"-planning$" ""))]
+        (if (shared-weather-layer-ids layer-id)
+          {:match :any}
+          {:match :org :org-id layer-id})))))
 
 (defn- get-current-layer-geoserver-credentials
   "Returns the GeoServer credentials a PSPS user should send for the currently
@@ -400,33 +410,28 @@
    Euro/NFDRS weather layers are shared across every PSPS company."
   []
   (when (seq @!/user-psps-orgs-list)
-    (let [optional-layer         @!/most-recent-optional-layer
-          optional-layer-serves? (fn [org-unique-id]
-                                   (boolean (and (seq optional-layer)
-                                                 ((:filter-set optional-layer) org-unique-id))))
-          selected-org-id        (when-not (wui/wui-fire-selected?)
-                                   (selected-layer-org-id))
+    (let [orgs                    @!/user-psps-orgs-list
+          optional-layer          @!/most-recent-optional-layer
+          optional-layer-serves-org? (fn [org-unique-id]
+                                       (boolean (and (seq optional-layer)
+                                                     ((:filter-set optional-layer) org-unique-id))))
           matching-org
-          (cond
+          (if (wui/wui-fire-selected?)
             ;; WUI active fires are private to the pyregence-consortium org (itself a
-            ;; regular PSPS org): authenticate with its own credentials.
-            (wui/wui-fire-selected?)
-            (first (filter #(= wui/wui-org-unique-id (:org-unique-id %)) @!/user-psps-orgs-list))
-
-            ;; Shared weather layers aren't utility-specific, so any org's creds work.
-            (shared-weather-layer-ids selected-org-id)
-            (first @!/user-psps-orgs-list)
-
-            ;; Fuels/active-fire tabs expose only underlays; match via the optional layer.
-            (= selected-org-id :only-underlays)
-            (first (filter #(optional-layer-serves? (:org-unique-id %)) @!/user-psps-orgs-list))
-
-            ;; Utility-specific layer: match the org directly, or via its optional layer.
-            ;; Only one org can match since each `:org-unique-id` is unique.
-            selected-org-id
-            (first (filter #(or (= selected-org-id (:org-unique-id %))
-                                (optional-layer-serves? (:org-unique-id %)))
-                           @!/user-psps-orgs-list)))]
+            ;; regular PSPS org): authenticate with its own credentials only.
+            (first (filter #(= wui/wui-org-unique-id (:org-unique-id %)) orgs))
+            (let [{:keys [match org-id]} (selected-layer-cred-match)]
+              (case match
+                ;; Shared weather layers aren't utility-specific, so any org's creds work.
+                :any      (first orgs)
+                ;; Underlay-only tabs (fuels/active-fire): match via the optional layer.
+                :underlay (first (filter #(optional-layer-serves-org? (:org-unique-id %)) orgs))
+                ;; Utility-specific layer: match the org directly, or via its optional
+                ;; layer. Only one org can match since each `:org-unique-id` is unique.
+                :org      (first (filter #(or (= org-id (:org-unique-id %))
+                                              (optional-layer-serves-org? (:org-unique-id %)))
+                                         orgs))
+                nil)))]
       (:geoserver-credentials matching-org))))
 
 (comment
@@ -446,21 +451,26 @@
   (forecast->credential-keypath :fuels)        ;=> :only-underlays
   (forecast->credential-keypath :not-a-tab)    ;=> nil  ; unlisted -> needs no creds
 
-  ;; --- selected-layer-org-id (reads @!/*forecast + @!/*params) ------------------
+  ;; --- selected-layer-cred-match (reads @!/*forecast + @!/*params) --------------
 
-  ;; A utility layer id passes through unchanged.
+  ;; A utility layer id -> match that org.
   (do (reset! !/*forecast :fire-risk)
       (reset! !/*params   {:fire-risk {:pattern :pge}})
-      (selected-layer-org-id))                 ;=> "pge"
+      (selected-layer-cred-match))             ;=> {:match :org, :org-id "pge"}
 
   ;; The "-planning" suffix is normalized away ("pge-planning" -> "pge").
   (do (reset! !/*forecast :fire-risk)
       (reset! !/*params   {:fire-risk {:pattern :pge-planning}})
-      (selected-layer-org-id))                 ;=> "pge"
+      (selected-layer-cred-match))             ;=> {:match :org, :org-id "pge"}
 
-  ;; Tabs without utility-specific layers resolve to the :only-underlays sentinel.
+  ;; A shared (non-utility) weather layer -> any org's creds work.
+  (do (reset! !/*forecast :fire-weather)
+      (reset! !/*params   {:fire-weather {:model :ecmwf}})
+      (selected-layer-cred-match))             ;=> {:match :any}
+
+  ;; Tabs without utility-specific layers -> match via the optional layer.
   (do (reset! !/*forecast :fuels)
-      (selected-layer-org-id))                 ;=> :only-underlays
+      (selected-layer-cred-match))             ;=> {:match :underlay}
 
   ;; --- get-current-layer-geoserver-credentials (end-to-end) ---------------------
 

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -863,11 +863,9 @@
                          (assoc-in m k v))
                        m
                        [[[:fire-weather :params :model :options :nfdrs-constant]
-                         {:opt-label "NFDRS Constant", :filter "nfdrs-constant", :geoserver-key :psps,
-                          :disabled-for #{}}]
+                         {:opt-label "NFDRS Constant", :filter "nfdrs-constant", :geoserver-key :psps}]
                         [[:fire-weather :params :model :options :nfdrs-variable]
-                         {:opt-label "NFDRS Variable", :filter "nfdrs-variable", :geoserver-key :psps,
-                          :disabled-for #{}}]])))))
+                         {:opt-label "NFDRS Variable", :filter "nfdrs-variable", :geoserver-key :psps}]])))))
 
   ;; TODO Consider sorting the Risk tab "Ignition Pattern" options alphabetically by :opt-label
   (swap! !/capabilities update-in [:fire-risk :params :pattern :options] sort-by-opt-label)


### PR DESCRIPTION
## Purpose

Adds the two **NFDRS** weather layers (NFDRS Constant / NFDRS Variable) and their fire-danger parameters (SFDI category/percentile, ERC and ERC percentile, BI and BI percentile, spread & ignition components, 1/10/100/1000-hour and live fuel moistures, KBDI) to the Weather tab, available to paid subscription tiers and super_admins.

Overall behavior:

- **Model-driven Weather Parameter list.** Selecting an NFDRS model shows only the NFDRS indices; selecting a standard model (Hybrid, HRRR, NBM, ...) shows only the standard parameters. The two sets are never shown together, so the dropdown has no permanently-disabled entries, and users without NFDRS access never see the NFDRS parameters.
- **Auto-switching parameters.** Disabling lives on the parameters only (one-directional), so changing the Model swaps the Weather Parameter to a compatible one: selecting an NFDRS model defaults to SFDI category, and switching back restores a standard default. This removes the previous dead-end where NFDRS and standard options mutually disabled each other.
- **Shared GeoServer credentials.** NFDRS layers live on the protected `:psps` GeoServer but are not utility-specific, so (like the Euro `ecmwf` forecast) any PSPS org's credentials grant access. Credential resolution was refactored around an explicit match descriptor, made nil-safe (tiles requested before params load no longer throw), and no longer sends a bogus auth header when no credentials resolve.
- **Related fixes:** corrupt `:kbdiI` key (zero-width space), `:m1:m10` key split, a no-op `:disabled-for #{}` on the NFDRS model options, and a stray SFDI dropdown that leaked onto non-Weather tabs.

## Related Issues
Closes PYR1-604

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (N/A - no DB/schema changes)

## Testing

#### Module Impacted
Side Panel > Weather tab (Weather Parameter / Model); Layers > NFDRS weather layers

#### Role
Admin (super_admin) or paid-tier User; also free-tier User / Visitor for the hiding behavior

#### Steps
1. As a super_admin or paid-tier user, open the **Weather** tab.
2. Select the **NFDRS Variable** (or **NFDRS Constant**) model. The Weather Parameter auto-switches to **SFDI category**, and the parameter dropdown lists only NFDRS indices.
3. Confirm the NFDRS tiles, legend, and point-info load (HTTP 200 with valid PSPS credentials).
4. Switch the Model back to a standard model (e.g. **Hybrid**). The Weather Parameter dropdown lists only standard parameters, with no NFDRS entries.
5. Switch to another tab (Fuels / Risk / Active Fires / PSPS) and confirm no stray SFDI/NFDRS dropdown appears.
6. As a free-tier user (no NFDRS model access), open the Weather tab and confirm no NFDRS parameters appear.

#### Desired Outcome
NFDRS layers render with valid credentials; the Weather Parameter list always matches the selected model; and users without NFDRS access never see NFDRS parameters or a stray dropdown on other tabs.
