### PR TITLE
PYR1-1554 The Time Slider's time toggle and speed control now shows on mobile.

### DIFF
--- a/src/cljs/pyregence/components/map_controls/time_slider.cljs
+++ b/src/cljs/pyregence/components/map_controls/time_slider.cljs
@@ -13,16 +13,20 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- $time-slider []
-  {:align-items   "center"
-   :border-radius "5px 5px 0 0"
-   :bottom        "0"
-   :display       "flex"
-   :left          "0"
-   :margin-left   "auto"
-   :margin-right  "auto"
-   :padding       ".5rem"
-   :right         "0"
-   :width         (if @!/mobile? "20rem" "min-content")})
+  (cond->
+   {:align-items   "center"
+    :border-radius "5px 5px 0 0"
+    :bottom        "0"
+    :display       "flex"
+    :left          "0"
+    :margin-left   "auto"
+    :margin-right  "auto"
+    :padding       ".5rem"
+    :right         "0"
+    :width         (if @!/mobile? "20rem" "min-content")}
+    @!/mobile?
+    (merge {:justify-content "center"
+            :flex-flow "wrap"})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Root Component
@@ -100,10 +104,9 @@
                                    (if @!/animate? (stop-animation!) (start-animation!)))]
 
     [:div#time-slider {:style ($/combine $/tool $time-slider)}
-     (when-not @!/mobile?
-       [:div {:style ($/combine $/flex-col {:align-items "flex-start"})}
-        [radio "UTC"   @!/show-utc? true  select-time-zone! true]
-        [radio "Local" @!/show-utc? false select-time-zone! true]])
+     [:div {:style ($/combine $/flex-col {:align-items "flex-start"})}
+      [radio "UTC"   @!/show-utc? true  select-time-zone! true]
+      [radio "Local" @!/show-utc? false select-time-zone! true]]
 
      [:div {:style ($/flex-col)}
       [:input {:type      "range"
@@ -129,13 +132,12 @@
       [tool-tip-wrapper "Next layer" :bottom
        [tool-button :next-button #(cycle-layer! 1)]]]
 
-     (when-not @!/mobile?
-       [:select {:value     (or @*speed 1)
-                 :style     ($/combine $/dropdown {:padding "0 0.5rem" :width "5rem"})
-                 :on-change #(reset! *speed (u-dom/input-int-value %))}
-        (map-indexed (fn [idx {:keys [opt-label]}]
-                       [:option {:key idx :value idx} opt-label])
-                     c/speeds)])]
+     [:select {:value     (or @*speed 1)
+               :style     ($/combine $/dropdown {:padding "0 0.5rem" :width "5rem"})
+               :on-change #(reset! *speed (u-dom/input-int-value %))}
+      (map-indexed (fn [idx {:keys [opt-label]}]
+                     [:option {:key idx :value idx} opt-label])
+                   c/speeds)]]
 
     (finally
       (mb/stop-buffer-polling!)


### PR DESCRIPTION
As the title says, the time slider's time toggle (utc and local) and speed control (back forward and speed inc) now shows on mobile. Note this takes up mores space on horizontal mobile view, but it makes
them fit on the vertical mobile view. It doesn't change the desktop view.

To test this, do exactly that, try the different views in the browser, if you can go the extra mile and try our mobile emulator.

An easy improvement would be to be to use the space better on the horizontal view. Thanks and good luck reviewer.