### PR TITLE
PYR1-996 Add editable Match Drop access toggle to admin user grid

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -761,6 +761,15 @@
       (data-response (str "Match drop access updated to " match-drop-access?))
       (data-response "Match drop access was not able to be updated." {:status 403}))))
 
+(defn update-user-match-drop-access
+  "Allows an admin to grant or revoke Match Drop access for a user by their email."
+  [_ email match-drop-access?]
+  (if-let [user-id-to-update (sql-primitive (call-sql "get_user_id_by_email" email))]
+    (do (call-sql "update_user_match_drop_access" user-id-to-update match-drop-access?)
+        (data-response (str "Match Drop access for " email " updated to " match-drop-access?)))
+    (data-response (str "There is no user with the email " email)
+                   {:status 403})))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Organization Management
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -116,6 +116,9 @@
    [:post "/clj/get-user-match-drop-access"]         {:handler (clj-handler authentication/get-user-match-drop-access)
                                                      :auth-type #{:member :token}
                                                      :auth-action :block}
+   [:post "/clj/update-user-match-drop-access"]      {:handler (clj-handler authentication/update-user-match-drop-access)
+                                                     :auth-type #{:account-manager :token}
+                                                     :auth-action :block}
 
    ;; -- Organization Management
    [:post "/clj/add-org-users"]                      {:handler (clj-handler authentication/add-org-users)

--- a/src/cljs/pyregence/components/settings/pages/admin.cljs
+++ b/src/cljs/pyregence/components/settings/pages/admin.cljs
@@ -1,9 +1,26 @@
 (ns pyregence.components.settings.pages.admin
   (:require
+   [clojure.core.async                        :refer [go <!]]
+   [goog.object                               :as goog]
+   [pyregence.components.messaging            :refer [toast-message!]]
    [pyregence.components.settings.roles       :as roles]
    [pyregence.components.settings.users-table :refer [table-with-buttons]]
    [pyregence.components.utils                :refer [card main-styles]]
+   [pyregence.utils.async-utils               :as u-async]
    [reagent.core                              :as r]))
+
+(defn- update-match-drop-access!
+  "Persists a Match Drop access change made via the editable grid toggle."
+  [params]
+  (let [field (goog/get (goog/get params "colDef") "field")]
+    (when (= field "match-drop-access")
+      (let [email   (goog/get (goog/get params "data") "email")
+            new-val (boolean (goog/get params "newValue"))]
+        (go
+          (let [{:keys [success]} (<! (u-async/call-clj-async! "update-user-match-drop-access" email new-val))]
+            (if success
+              (toast-message! (str "Match Drop access for " email " set to " (if new-val "enabled" "disabled") "."))
+              (toast-message! (str "Unable to update Match Drop access for " email ".")))))))))
 
 (defn main
   [{:keys [user-role] :as m}]
@@ -17,6 +34,7 @@
                               :statuses                    ["accepted" "pending" "none"]
                               :show-export-to-csv? true
                               :choose-org?         true
+                              :on-cell-value-changed       update-match-drop-access!
                               :columns
                               (let [boolean-renderer
                                     (fn [params]
@@ -31,7 +49,9 @@
                                           (if v "✓" "✗")])))]
                                 [{:field "user-id"               :headerName "User ID"               :filter false :width 110}
                                  {:field "organization-name"     :headerName "Org Name"              :filter "agTextColumnFilter"}
-                                 {:field "match-drop-access"     :headerName "Match Drop?"           :filter false :width 150 :cellRenderer boolean-renderer}
+                                 {:field "match-drop-access"     :headerName "Match Drop?"           :filter false :width 150
+                                  :editable     true
+                                  :cellRenderer "agCheckboxCellRenderer"}
                                  {:field "email-verified"        :headerName "Email Verified?"       :filter false :width 150 :cellRenderer boolean-renderer}
                                  {:field "last-login-date"       :headerName "Last Login Date"       :filter "agDateColumnFilter" :width 300}
                                  {:field "settings"              :headerName "Settings"              :filter false :width 200 :autoHeight true

--- a/src/cljs/pyregence/components/settings/users_table.cljs
+++ b/src/cljs/pyregence/components/settings/users_table.cljs
@@ -73,13 +73,14 @@
 
 ;;TODO figure out why we can't inline this it seems to have an interaction with getselectedrows.
 (defn table
-  [grid-api users users-selected? users-filter columns]
+  [grid-api users users-selected? users-filter columns on-cell-value-changed]
   [:div {:style {:height "100%"
                  :width  "100%"}}
    [:div {:style {:height "100%" :width "100%"}}
     [:> AgGridReact
      {:onGridReady                #(reset! grid-api (goog/get % "api"))
       :onRowDataUpdated           #(api-call @grid-api "autoSizeAllColumns")
+      :onCellValueChanged         (or on-cell-value-changed (constantly nil))
       :rowSelection               #js {:mode      "multiRow"
                                        :selectAll "filtered"}
       :domLayout                  "autoHeight"
@@ -135,6 +136,7 @@
                    columns
                    show-export-to-csv?
                    choose-org?
+                   on-cell-value-changed
                    users-filter] :or {users-filter identity} :as m}]
         (let [org-names             (->> m :organizations (map :org-name))
               tab-selected-org-name (some-> org-id->org
@@ -271,4 +273,4 @@
                          org-opt-selected?
                          (assoc :select-org-msg (str "Assign Organization for " (db->display @checked) " Users."))))]
              nil)
-           [table grid-api users users-selected? users-filter columns]]))})))
+           [table grid-api users users-selected? users-filter columns on-cell-value-changed]]))})))


### PR DESCRIPTION
## Purpose
Makes the **Match Drop?** column in the admin *MEMBER USER-LIST* grid an interactive checkbox so admins can grant or revoke a user's Match Drop access directly from the UI. Previously this column was read-only (green ✓ / red ✗) and the only way to change a user's `match_drop_access` was a direct database update.

- Adds an `update-user-match-drop-access` handler (looks up the user by email and flips `match_drop_access` via the existing `update_user_match_drop_access` SQL function) and a `POST /clj/update-user-match-drop-access` route, gated to account managers / super admins (same access level as the admin user grid).
- Renders the `match-drop-access` column with `agCheckboxCellRenderer` + `:editable true`, and threads an `onCellValueChanged` callback through the users table to persist toggles with a success/failure toast.

## Related Issues
Closes PYR1-1538

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Match Drop, Misc. (Admin Settings > Member User-List)

#### Role
Admin (super admin / account manager)

#### Steps
1. Log in as a super admin or account manager.
2. Open Settings > Admin (the MEMBER USER-LIST grid).
3. In the **Match Drop?** column, click the checkbox for a user to toggle it on/off.
4. Confirm a toast appears indicating the access was enabled/disabled.
5. Reload the page (or re-open the admin grid) and verify the checkbox reflects the persisted value.
6. As that user, verify Match Drop access matches the toggle (access granted when checked, denied when unchecked).

#### Desired Outcome
Toggling the checkbox persists the user's `match_drop_access` value and is reflected on reload and in the user's actual Match Drop access.

## Screenshots
<img width="839" height="472" alt="image" src="https://github.com/user-attachments/assets/9b3bad9f-f30a-4f74-af73-d2edc8d88fef" />

