### PR TITLE
Fix forgot-password toast: show one generic toast so it isn't eaten b…

### DIFF
--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -46,10 +46,8 @@
 
 (defn- request-password! []
   (go
-    (toast-message! "Submitting request. This may take a moment...")
-    ;; same toast for any email (no enumeration)
-    (<! (u-async/call-clj-async! "send-email" @email :reset))
     (toast-message! "If that email address is registered with PyreCast, we will send you an email to reset your password.")
+    (<! (u-async/call-clj-async! "send-email" @email :reset))
     (<! (timeout 4000))
     (u-browser/jump-to-url! "/forecast")))
 


### PR DESCRIPTION
The forgot-password confirmation toast stopped showing after [#1103](https://github.com/pyregence/pyregence/pull/1103) - the server now replies instantly, so the 4s redirect beats the second queued toast. Fix: show one generic toast up front.