### PR TITLE
Revert "PYR-1555/Send nfdrs weather param query to server to get layers (#1114)"

### DIFF
--- a/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
+++ b/src/cljs/pyregence/components/map_controls/collapsible_panel.cljs
@@ -339,9 +339,50 @@
                              #(select-param! % key)
                              selected-param-set]])))
                      (cond-> @!/processed-params
-                       (c/nfdrs?)
+                       (#{:nfdrs-variable :nfdrs-constant} (-> @!/*params :fire-weather :model))
                        (assoc-in [:band :options]
-                                 c/nfdrs-weather-params)))
+                                 {:erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
+                                           :filter "erc"
+                                           :units "(ERC, Btu/sq ft)"}
+                                  :ercperc {:opt-label "ERC percentile"
+                                            :filter "ercperc"}
+                                  :bi {:opt-label "burning index (BI, ft * 10)"
+                                       :filter "bi"
+                                       :units "(BI, ft * 10)"}
+                                  :biperc {:opt-label  "BI percentile"
+                                           :filter "biperc"}
+                                  :sc      {:opt-label "spread component (ft/min)"
+                                            :filter "sc"
+                                            :units "(ft/min)"}
+                                  :scperc  {:opt-label  "SC percentile"
+                                            :filter     "scperc"}
+                                  :ic    {:opt-label "Ignition Component (%)"
+                                          :filter "ic"}
+                                  :sfdiperc {:opt-label "SFDI percentile (%)"
+                                             :filter "sfdiperc"}
+                                  :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
+                                             :filter "sfdicat"}
+                                  :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
+                                       :filter "lh"
+                                       :units "(% or fraction)"}
+                                  :lw {:opt-label "Live woody fuel moisture (% or fraction)"
+                                       :filter "lw"
+                                       :units "(% or fraction)"}
+                                  :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
+                                        :filter "m1"
+                                        :units "(% or fraction)"}
+                                  :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
+                                        :filter "m10"
+                                        :units "(% or fraction)"}
+                                  :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
+                                         :filter "m100"
+                                         :units "(% or fraction)"}
+                                  :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
+                                          :filter "m1000"
+                                          :units "(% or fraction)"}
+                                  :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
+                                          :filter "kbdiI"
+                                          :units "Index (0-800)"}})))
                [opacity-input]]]
              [sa/panel-section]
              [collapsible-panel-section

--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -6,58 +6,6 @@
             [pyregence.utils.string-utils :as u-str]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; NFDRS Weather Params
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(def nfdrs-weather-params
-  {:erc    {:opt-label "Energy Release Component (ERC, Btu/sq ft)"
-            :filter "erc"
-            :units "(ERC, Btu/sq ft)"}
-   :ercperc {:opt-label "ERC percentile"
-             :filter "ercperc"}
-   :bi {:opt-label "burning index (BI, ft * 10)"
-        :filter "bi"
-        :units "(BI, ft * 10)"}
-   :biperc {:opt-label  "BI percentile"
-            :filter "biperc"}
-   :sc      {:opt-label "spread component (ft/min)"
-             :filter "sc"
-             :units "(ft/min)"}
-   :scperc  {:opt-label  "SC percentile"
-             :filter     "scperc"}
-   :ic    {:opt-label "Ignition Component (%)"
-           :filter "ic"}
-   :sfdiperc {:opt-label "SFDI percentile (%)"
-              :filter "sfdiperc"}
-   :sfdicat  {:opt-label "SFDI category (1=low, 2=moderate, 3=high, 4=very high, 5=severe)"
-              :filter "sfdicat"}
-   :lh {:opt-label "Live herbaceous fuel moisture (% or fraction)"
-        :filter "lh"
-        :units "(% or fraction)"}
-   :lw {:opt-label "Live woody fuel moisture (% or fraction)"
-        :filter "lw"
-        :units "(% or fraction)"}
-   :m1  {:opt-label "1-hour fuel moisture (% or fraction)"
-         :filter "m1"
-         :units "(% or fraction)"}
-   :m10 {:opt-label "10-hour fuel moisture (% or fraction)"
-         :filter "m10"
-         :units "(% or fraction)"}
-   :m100 {:opt-label "100-hour fuel moisture (% or fraction)"
-          :filter "m100"
-          :units "(% or fraction)"}
-   :m1000 {:opt-label "1000-hour fuel moisture (% or fraction)"
-           :filter "m1000"
-           :units "(% or fraction)"}
-   :kbdiI​ {:opt-label "Keetch Byram Drought Index (0-800)"
-            :filter "kbdiI"
-            :units "Index (0-800)"}})
-
-(defn nfdrs?
-  []
-  (#{:nfdrs-variable :nfdrs-constant} (-> @!/*params :fire-weather :model)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Feature Flags
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Reverts the squash-merge of #1114 (`PYR-1555/Send nfdrs weather param query to server to get layers`).

The author requested a revert. This PR reverts the merged changes from `main` back to the state at `9fcf2d3b`.

The original changes are not lost — I've restored the original PR commits on the **`send-nfdrs-weather-param-query-to-server-to-get-layers`** branch, so they remain available there for re-work / re-submission.
