### PR TITLE
Add ATCO Electric organization to PyreCast

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -97,7 +97,7 @@
                         :geoserver-key :shasta}})
 
 ;; TODO add in an API route to dynamically grab this from the org_unique_id column in the organizations table
-(def all-utility-companies #{:anza :beartooth :bighorn :butte :canadian-valley
+(def all-utility-companies #{:anza :atco :beartooth :bighorn :butte :canadian-valley
                              :capital :clp :columbia-basin :consumers :cotton :cowlitz
                              :dso :flathead :garkane :grand-valley :highline
                              :holy-cross :la-plata :lea-county :liberty :lincoln


### PR DESCRIPTION
## Summary
Onboards **ATCO Electric** as a new enterprise organization in PyreCast.

- Adds `:atco` to `all-utility-companies` in `config.cljs`.

## References
- Dev-docs: [new-utility.gmi](https://gitlab.sig-gis.com/sig-gis/dev-docs/blob/main/document-root/operations/geoservers/prod/parrot/new-utility.gmi#L198)
