### PR TITLE
PYR1-1557 Fix :disabled-for sets that nested the planning set instead of merging it

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -1,5 +1,6 @@
 (ns pyregence.config
-  (:require [clojure.string               :as str]
+  (:require [clojure.set                  :as set]
+            [clojure.string               :as str]
             [pyregence.state              :as !]
             [pyregence.utils.misc-utils   :as u-misc]
             [pyregence.utils.number-utils :as u-num]
@@ -506,11 +507,11 @@
                                                               :crown-fire-area {:opt-label    "Crown fire area"
                                                                                 :filter-set   #{"fire-risk-forecast" "crown-fire-area"}
                                                                                 :units        "Acres"
-                                                                                :disabled-for (conj all-utility-companies all-utility-companies-planning :tlines)}
+                                                                                :disabled-for (set/union all-utility-companies all-utility-companies-planning #{:tlines})}
                                                               :plignrate       {:opt-label    "Power line ignition rate"
                                                                                 :filter-set   #{"fire-risk-forecast" "plignrate"}
                                                                                 :units        "Ignitions/line-mi/hr"
-                                                                                :disabled-for (conj all-utility-companies all-utility-companies-planning :all :tlines)}
+                                                                                :disabled-for (set/union all-utility-companies all-utility-companies-planning #{:all :tlines})}
                                                               :area-p          {:opt-label    "Fire area percentile"
                                                                                 :filter-set   #{"fire-risk-planning" "area-p"}
                                                                                 :units        "%"


### PR DESCRIPTION
## Purpose
The `:disabled-for` sets for the "Crown fire area" and "Power line ignition rate" fire-risk outputs were built with `(conj all-utility-companies all-utility-companies-planning ...)`, which adds the planning set as a single nested element instead of merging its members. Since every `:disabled-for` consumer compares keywords via `set/intersection`, planning-pattern keywords (e.g. `:anza-planning`) never matched, leaving those two outputs enabled for utility planning patterns when they should be disabled. This PR builds the sets with `set/union` so they are flat keyword sets and the planning patterns disable the outputs as intended.

## Related Issues
Closes PYR1-1557

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Side Panel

#### Role
User (member of a utility/PSPS organization)

#### Steps
1. Log in as a member of a utility organization and go to the Risk Forecast tab.
2. Under Ignition Pattern, select the organization's planning pattern (e.g. "Anza Planning").
3. Open the Output dropdown.

#### Desired Outcome
"Crown fire area" and "Power line ignition rate" are disabled for the planning pattern, matching the behavior already seen with the non-planning utility pattern.

## Screenshots
N/A — no UI changes beyond the corrected option disabling.