### PR TITLE
Fix delete-users route auth bypass and red flag layer under advanced optimizations

### DIFF
--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -86,7 +86,7 @@
                                                      :auth-type :token
                                                      :auth-action :block}
    [:post "/clj/delete-users"]                       {:handler     (clj-handler authentication/delete-users)
-                                                     :auth-type   {:token :super-admin}
+                                                     :auth-type   #{:token :super-admin}
                                                      :auth-action :block}
    [:post "/clj/get-current-user-settings"]          {:handler (clj-handler authentication/get-current-user-settings)
                                                      :auth-type :member

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -46,7 +46,7 @@
     (let [data (-> (<! (u-async/call-clj-async! "get-red-flag-layer"))
                    (:body)
                    (js/JSON.parse))]
-      (if (empty? (.-features data))
+      (if (empty? (aget data "features"))
         (do
           (toast-message! "There are no red flag warnings at this time.")
           (reset! !/show-red-flag? false))


### PR DESCRIPTION
## Purpose
Two independent, low-risk bug fixes (one commit each):

1. **`delete-users` route authorization bypass** — the `/clj/delete-users` route declared `:auth-type {:token :super-admin}` (a map) instead of a set. `route-authenticator` iterates a non-keyword `auth-type`; iterating a map yields `MapEntry` pairs that match none of the `case` clauses and fall through to the `true` default, so `every?` returns `true` unconditionally and the route-level authorization (both the bearer-token and super-admin checks) is bypassed. Changed to `#{:token :super-admin}` so each condition is evaluated, matching every other multi-condition route.

2. **Red flag layer broken under `:advanced` optimizations** — `toggle-red-flag-layer!` read the parsed GetCapabilities response with `(.-features data)`. Property access via `.-property` on a `js/JSON.parse` result is renamed by the Closure compiler under `:advanced`, resolving to `undefined` at runtime in the uberjar build. As a result `(empty? ...)` is always true: the toggle always reports "There are no red flag warnings" and never draws the layer in production, while working under `bb dev` (`:optimizations :none`). Switched to `(aget data "features")`, matching the convention used elsewhere (e.g. `invert-geojson`).

## Related Issues
Closes PYR1-###

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)
- [ ] For any large features/rearchitecting of the codebase, the relevant `docs` were updated

## Testing
#### Module Impacted
- Misc. (User Management API / route auth)
- Toolbars > Red Flag layer

#### Role
Fix 1: Admin (super-admin). Fix 2: User/Visitor.

#### Steps
Fix 1 (route auth):
1. Build/run the app.
2. Confirm `/clj/delete-users` still requires a valid auth token and super-admin session (non-super-admin requests are rejected).

Fix 2 (red flag layer):
1. Build the uberjar (`:advanced` optimizations) — this bug does not reproduce under `bb dev`.
2. Toggle the Red Flag layer in the toolbar when active warnings exist.

#### Desired Outcome
Fix 1: `/clj/delete-users` route-level auth is enforced again (token + super-admin) rather than always allowing.

Fix 2: The red flag layer renders when warnings exist; the "no red flag warnings" toast only appears when there are genuinely none.

## Screenshots
N/A