### PR TITLE
PYR1-1108 Password needs min 12 chars max 128 one uppercase and one number

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -183,8 +183,6 @@
 (defn set-user-password
   "Sets a new password for user with valid reset token."
   [session email password token]
-  ;;TODO should this be a cond? (so we dont nest ifs)
-  ;;TODO should this share more logic with add-new-user when it comes to passwords?
   (if-not (valid-password? password)
     (data-response (password->invalid-password-msg password) {:status 400})
     (if-let [user (first (call-sql "set_user_password" {:log? false} email password token))]

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -60,6 +60,50 @@
          _     (.nextBytes (SecureRandom.) bytes)]
      (.encodeToString (Base64/getEncoder) bytes))))
 
+(defn valid-password?
+  "Passwords must be between 12 and 128 chars and contain at least 1 upper case letter and number."
+  [password]
+  (and
+   ;; between 12 and 128
+   (<= 12 (count password) 128)
+   ;; digit
+   (boolean (re-find #"\d" password))
+   ;; upper case
+   (boolean (re-find #"[A-Z]" password))))
+
+^:rct/test
+(comment
+  ;; Must have 12 characters
+  (valid-password? "Helloworld1")
+  ;; => false at 11
+
+  (valid-password? "Helloworld12")
+  ;; => true at 12
+
+  (valid-password? (clojure.string/join "" (repeat 11 "Helloworld12")))
+  ;; => false over 128
+
+  (valid-password? (clojure.string/join "" (repeat 10 "Helloworld12")))
+  ;; => true less then 128
+
+;; Must have one upper case
+  (valid-password? "helloworld12")
+  ;; => false with no upper case
+
+  (valid-password? "Helloworld12")
+  ;; => true with one
+
+  (valid-password? "Helloworldaa")
+  ;; => false with no number
+
+  (valid-password? "Helloworld12")
+  ;; => true with at least one number
+  )
+
+(defn password->invalid-password-msg
+  [password]
+  (str "Invalid Password:'" password "'. Passwords must be between 12 and 128 chars and contain at least 1 upper case letter and number. "))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Authentication & Session Management
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -139,9 +183,13 @@
 (defn set-user-password
   "Sets a new password for user with valid reset token."
   [session email password token]
-  (if-let [user (first (call-sql "set_user_password" {:log? false} email password token))]
-    (successful-login user session)
-    (data-response "Invalid or expired reset token" {:status 403})))
+  ;;TODO should this be a cond? (so we dont nest ifs)
+  ;;TODO should this share more logic with add-new-user when it comes to passwords?
+  (if-not (valid-password? password)
+    (data-response (password->invalid-password-msg password) {:status 400})
+    (if-let [user (first (call-sql "set_user_password" {:log? false} email password token))]
+      (successful-login user session)
+      (data-response "Invalid or expired reset token" {:status 403}))))
 
 (defn verify-user-email
   "Verifies user email with the provided token."
@@ -626,51 +674,54 @@
     explicitly assign a new user to an organization via `:org-id`.
   - All organization assignments are validated server-side using the session context."
   [session email user-name password & [org-name-or-opts]]
-  (let [org-name (cond (string? org-name-or-opts)             org-name-or-opts
-                       (map? org-name-or-opts) (or (:org-name org-name-or-opts)
-                                                   (get org-name-or-opts "org-name"))
-                       :else                                  nil)
-        org-id   (when (map? org-name-or-opts)
-                   (or (:org-id org-name-or-opts)
-                       (get org-name-or-opts "org-id")))
-        org-name         (when (and (string? org-name) (seq org-name)) org-name)
-        {:keys [user-role]} session
-        default-settings (pr-str {:timezone :utc})
-        new-user-id      (nil-on-error
-                          (sql-primitive (call-sql "add_new_user"
-                                                   {:log? false}
-                                                   email
-                                                   user-name
-                                                   password
-                                                   default-settings)))
-        response
-        (if-not new-user-id
-          (data-response (str "Failed to create the new user with name " user-name " and email " email)
-                         {:status 403})
-          (cond
+  ;;TODO this needs to pass the reason for the 403 to the front end that is {:status 403 :error {:invalid-password "blah blah blah"}}
+  (if-not (valid-password? password)
+    (data-response (password->invalid-password-msg password) {:status 400})
+    (let [org-name (cond (string? org-name-or-opts)             org-name-or-opts
+                         (map? org-name-or-opts) (or (:org-name org-name-or-opts)
+                                                     (get org-name-or-opts "org-name"))
+                         :else                                  nil)
+          org-id   (when (map? org-name-or-opts)
+                     (or (:org-id org-name-or-opts)
+                         (get org-name-or-opts "org-id")))
+          org-name         (when (and (string? org-name) (seq org-name)) org-name)
+          {:keys [user-role]} session
+          default-settings (pr-str {:timezone :utc})
+          new-user-id      (nil-on-error
+                            (sql-primitive (call-sql "add_new_user"
+                                                     {:log? false}
+                                                     email
+                                                     user-name
+                                                     password
+                                                     default-settings)))
+          response
+          (if-not new-user-id
+            (data-response (str "Failed to create the new user with name " user-name " and email " email)
+                           {:status 403})
+            (cond
             ;; If org-id is provided, we explicitly assign the org (must be super_admin or organization_admin)
             ;; This happens when a super_admin or org_admin is manually adding a user via the admin page
             ;; The new user will have a user_role of organization_member and a user_status of active
-            org-id
-            (if (or (= user-role "super_admin")
-                    (= user-role "organization_admin"))
-              (do
-                (call-sql "add_org_user" org-id new-user-id)
-                (data-response "User created and added to organization."))
-              (data-response "User does not have permission to assign users to this organization."
-                             {:status 403}))
+              org-id
+              (if (or (= user-role "super_admin")
+                      (= user-role "organization_admin"))
+                (do
+                  (call-sql "add_org_user" org-id new-user-id)
+                  (data-response "User created and added to organization."))
+                (data-response "User does not have permission to assign users to this organization."
+                               {:status 403}))
 
             ;; No org-id provided — use email domain-based auto-assignment (dependent on org auto_add settings)
-            :else
-            (let [domain (re-find #"@{1}.+" email)]
-              (if (call-sql "auto_add_org_user" new-user-id domain)
-                (data-response "User created and added to an organization by email domain (when auto_add is true for that organization).")
-                (data-response "User created successfully but something went wrong when calling auto_add_org_user."
-                               {:status 403})))))]
+              :else
+              (let [domain (re-find #"@{1}.+" email)]
+                (if (call-sql "auto_add_org_user" new-user-id domain)
+                  (data-response "User created and added to an organization by email domain (when auto_add is true for that organization).")
+                  (data-response "User created successfully but something went wrong when calling auto_add_org_user."
+                                 {:status 403})))))]
     ;; Stash org-name in session for marketplace provisioning
-    (cond-> response
-      (and new-user-id org-name (:marketplace-signup session))
-      (assoc :session (assoc-in session [:marketplace-signup :org-name] org-name)))))
+      (cond-> response
+        (and new-user-id org-name (:marketplace-signup session))
+        (assoc :session (assoc-in session [:marketplace-signup :org-name] org-name))))))
 
 (defn get-current-user-settings
   "Returns settings for the current user."

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -64,6 +64,8 @@
   "Passwords must be between 12 and 64 chars and contain at least 1 upper case letter and number."
   [password]
   (and
+   ;; check if it's a strong
+   (string? password)
    ;; between 12 and 64
    (<= 12 (count password) 64)
    ;; digit

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -61,11 +61,11 @@
      (.encodeToString (Base64/getEncoder) bytes))))
 
 (defn valid-password?
-  "Passwords must be between 12 and 128 chars and contain at least 1 upper case letter and number."
+  "Passwords must be between 12 and 64 chars and contain at least 1 upper case letter and number."
   [password]
   (and
-   ;; between 12 and 128
-   (<= 12 (count password) 128)
+   ;; between 12 and 64
+   (<= 12 (count password) 64)
    ;; digit
    (boolean (re-find #"\d" password))
    ;; upper case
@@ -80,11 +80,11 @@
   (valid-password? "Helloworld12")
   ;; => true at 12
 
-  (valid-password? (clojure.string/join "" (repeat 11 "Helloworld12")))
-  ;; => false over 128
+  (valid-password? (clojure.string/join "" (repeat 6 "Helloworld12")))
+  ;; => false over 64
 
-  (valid-password? (clojure.string/join "" (repeat 10 "Helloworld12")))
-  ;; => true less then 128
+  (valid-password? (clojure.string/join "" (repeat 5 "Helloworld12")))
+  ;; => true less then 64
 
 ;; Must have one upper case
   (valid-password? "helloworld12")
@@ -102,7 +102,7 @@
 
 (defn password->invalid-password-msg
   [password]
-  (str "Invalid Password:'" password "'. Passwords must be between 12 and 128 chars and contain at least 1 upper case letter and number. "))
+  (str "Invalid Password:'" password "'. Passwords must be between 12 and 64 chars and contain at least 1 upper case letter and number. "))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Authentication & Session Management


### PR DESCRIPTION
As the title and ticket says, the server needs to verify passwords are between 12 and 128 chars with one upper case and one number. 

@sifbiri this is a draft atm beause i want to quickly check with you that the verify password functionality should only be attached in two places `add-new-user` and `set-user-password`

Also, can you glance at my regex and verify password logic? Does it have any issues? this can be subtle sometimes so i want a couple quick eyes on it.