### PR TITLE
PYR1-1559  Enable Secure session cookies and HSTS. Bump triangulum

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -47,6 +47,9 @@
  :triangulum.handler/bad-tokens            #{".php"}
  :triangulum.handler/private-request-keys  #{:auth-token :password :re-password}
  :triangulum.handler/private-response-keys #{}
+ ;; Secure needs HTTPS; on plain-HTTP local dev set :secure false or the browser drops the cookie.
+ :triangulum.handler/session-cookie-attrs  {:secure true :same-site :lax}
+ :triangulum.handler/hsts?                 true
 
  ;; views (app)
  :triangulum.views/title            {:en "Wildfire Forecasts"}

--- a/deps.edn
+++ b/deps.edn
@@ -27,7 +27,7 @@
            seancorfield/next.jdbc                           {:mvn/version "1.1.569"}
            semantic-csv/semantic-csv                        {:mvn/version "0.2.1-alpha1"}
            sig-gis/triangulum                               {:git/url "https://github.com/sig-gis/triangulum"
-                                                             :git/sha "6044e8db232e786854616fafca3b06d9287a8a6a"}}
+                                                             :git/sha "800d8add4140da9d4d615976444283db50a8eed8"}}
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :build-uberjar    {:exec-fn   pyregence.packaging/build-uberjar!
                               :exec-args {:app-name      pyregence


### PR DESCRIPTION
## Purpose
Bumps triangulum and turns on its HTTPS hardening: Secure session cookies, HSTS, and Server-header suppression.

Staging and prod need the same two keys in their deployed `config.edn` to take effect. Plain-HTTP dev should set `:secure false`.