### PR TITLE
PYR1-1512 Stop exposing sequential org_layer_id to the browser

### DIFF
--- a/src/sql/functions/organization_functions.sql
+++ b/src/sql/functions/organization_functions.sql
@@ -192,12 +192,12 @@ $$ LANGUAGE SQL;
 --------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION get_user_layers_list(_user_id integer)
  RETURNS TABLE (
-    org_layer_id integer,
     layer_path   text,
     layer_config text
  ) AS $$
+    -- Only layer_path/layer_config are consumed by the browser; the sequential
+    -- org_layer_uid PK is intentionally not exposed (PYR1-1512 enumeration hardening).
     SELECT
-        ol.org_layer_uid AS org_layer_id,
         ol.layer_path,
         ol.layer_config
     FROM users u


### PR DESCRIPTION
## Purpose
`get_user_layers_list` returned `org_layer_uid` (the sequential `organization_layers` primary key) to the browser as `org_layer_id`, even though the client only consumes `layer_path`/`layer_config`. There is no inbound lookup, update, or delete keyed on the org-layer id, so this PK served no purpose on the wire and only leaked a predictable, enumerable identifier.

This PR drops `org_layer_id` from the function's return so no `organization_layers` PK reaches the client. Because nothing references the id, no unpredictable uuid handle is needed as a replacement.

## Related Issues
Closes PYR1-1512

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Layers

#### Role
User (member of an organization with configured org layers)

#### Steps
1. Log in as a user belonging to an organization that has organization layers configured.
2. Load the forecast page so the client fetches the user's organization layers.
3. Confirm the organization layers still appear and are selectable/renderable.
4. Inspect the `get-user-layers` response payload and confirm it contains only `layer_path`/`layer_config` and no `org_layer_id`.

#### Desired Outcome
Organization layers continue to work exactly as before, and the response no longer includes the sequential `org_layer_id` PK.

---

## Screenshots
N/A - no UI changes.
