### PR TITLE
PYR1-1536 Fix incompatible Fuels tab default after CFFDRS 2024

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -219,7 +219,11 @@
                                                                      :no-convert      #{:cfo}
                                                                      :reverse-legend? true
                                                                      :disabled-for    #{:cecs :cffdrs-2024}})}
-                                  :model      {:opt-label  "Source"
+                                  :model      {:opt-label      "Source"
+                                               ;; cffdrs-2024 is first in :options (so it renders at the top),
+                                               ;; but it is incompatible with the default :fbfm40 layer. Pin the
+                                               ;; default source to LANDFIRE 2.5.0 so the Fuels tab opens compatible.
+                                               :default-option :landfire-2.5.0
                                                :hover-text [:p {:style {:margin-bottom "0"}}
                                                             [:strong "LANDFIRE"]
                                                             " –  Stock data provided by "


### PR DESCRIPTION
## Purpose
The CFFDRS 2024 Source was added as the first option in the Fuels tab `:model` dropdown. Since the resolved default for a param falls back to the first option, CFFDRS 2024 became the default Source. It is incompatible with the default `fbfm40` layer (each lists the other in its `:disabled-for` set), and the disabled-param reconciler only runs on user dropdown changes, so the Fuels tab opened in a broken, incompatible state.

This pins the default Source to LANDFIRE 2.5.0 via `:default-option`, so the tab opens on a compatible layer/source pair. CFFDRS 2024 remains at the top of the Source dropdown and fully selectable.

## Related Issues
Closes PYR1-1536

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Layers > Fuels

#### Role
Visitor

#### Steps
1. Load the near-term forecast map.
2. Open the Fuels tab.

#### Desired Outcome
The Fuels tab opens with Source = LANDFIRE 2.5.0 (2025 capable) and Layer = Fire Behavior Fuel Model 40, showing a valid layer instead of an incompatible/blank state. CFFDRS 2024 is still available at the top of the Source dropdown.

## Screenshots
N/A
