### PR TITLE
PYR1-1536 Make CFFDRS 2024 source always selectable

### DIFF
--- a/src/cljs/pyregence/config.cljs
+++ b/src/cljs/pyregence/config.cljs
@@ -276,9 +276,8 @@
                                                             [:strong "CFFDRS 2024"]
                                                             " - Canadian Forest Fire Danger Rating System. Details coming soon."]
                                                :options    (array-map
-                                                            :cffdrs-2024          {:opt-label    "CFFDRS 2024"
-                                                                                   :filter       "cffdrs-2024"
-                                                                                   :disabled-for #{:fbfm40 :cc :ch :cbh :cbd}}
+                                                            :cffdrs-2024          {:opt-label "CFFDRS 2024"
+                                                                                   :filter    "cffdrs-2024"}
                                                             :landfire-2.5.0       {:opt-label    "LANDFIRE 2.5.0 (2025 capable)"
                                                                                    :filter       "landfire-2.5.0"
                                                                                    :disabled-for #{:asp :slp :dem}}


### PR DESCRIPTION
## Purpose
Make the **CFFDRS 2024** source in the Fuels tab always selectable.

Previously the `:cffdrs-2024` source option carried `:disabled-for #{:fbfm40 :cc :ch :cbh :cbd}`, so it was greyed out whenever one of those incompatible layers was selected. Since the default layer is `fbfm40`, the source was unclickable by default.

Removing the `:disabled-for` set makes the source always selectable. The existing `auto-switch-disabled-params!` logic already handles the fallout: selecting CFFDRS 2024 while on an incompatible layer automatically switches the layer to the first compatible option (`fbp`), keeping the tab in a valid state. The reverse guard (disabling incompatible layers once CFFDRS 2024 is active) is left intact.

## Related Issues
Closes PYR1-1536

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Side Panel > Fuels tab (Source dropdown)

#### Role
Visitor

#### Steps
1. Open the Fuels tab.
2. Open the **Source** dropdown.
3. Select **CFFDRS 2024**.

#### Desired Outcome
- CFFDRS 2024 is clickable/selectable from the Source dropdown regardless of the currently selected layer.
- On selecting it while an incompatible layer (e.g. Fire Behavior Fuel Model 40) is active, the layer auto-switches to a compatible option and the tab remains in a valid state.

## Screenshots

<img width="450" height="590" alt="image" src="https://github.com/user-attachments/assets/057cad42-dd7c-4403-9afb-2f437300b62c" />

