### PR TITLE
PYR1-1547 Seed dev-data orgs on paid tiers

### DIFF
--- a/src/sql/dev_data/dev_data.sql
+++ b/src/sql/dev_data/dev_data.sql
@@ -1,13 +1,17 @@
 -- NAMESPACE: dev-data
 
+-- All real organizations are on a paid tier (Pro or Enterprise); tier1/free is
+-- reserved for individual members who don't belong to an org. Seed orgs on a
+-- paid tier so the org-admin flows (member management, etc.) are exercisable
+-- locally instead of 403ing under the tier2-pro route gate.
 INSERT INTO organizations
-    (organization_uid, org_unique_id, org_name, email_domains, auto_add, auto_accept)
+    (organization_uid, org_unique_id, org_name, email_domains, auto_add, auto_accept, subscription_tier)
 VALUES
-    (1, 'development', 'Development', '@pyr.dev', TRUE, TRUE),
-    (2, 'delete-me', 'Delete Me Inc.', '@deleteme.com,@remove.com', TRUE, FALSE),
-    (3, 'update-me', 'Update My Setttings and Company', '@updateme.com', FALSE, TRUE),
-    (4, 'sig', 'Spatial Informatics Group', '@sig-gis.com', TRUE, TRUE),
-    (5, 'pyregence-consortium', 'Pyregence Consortium', '', FALSE, FALSE);
+    (1, 'development', 'Development', '@pyr.dev', TRUE, TRUE, 'tier2_pro'),
+    (2, 'delete-me', 'Delete Me Inc.', '@deleteme.com,@remove.com', TRUE, FALSE, 'tier2_pro'),
+    (3, 'update-me', 'Update My Setttings and Company', '@updateme.com', FALSE, TRUE, 'tier2_pro'),
+    (4, 'sig', 'Spatial Informatics Group', '@sig-gis.com', TRUE, TRUE, 'tier2_pro'),
+    (5, 'pyregence-consortium', 'Pyregence Consortium', '', FALSE, FALSE, 'tier3_enterprise');
 
 INSERT INTO users
     (user_uid, email, name, password, email_verified, match_drop_access, settings, user_role, org_membership_status, organization_rid)

--- a/test/pyregence/routing_test.clj
+++ b/test/pyregence/routing_test.clj
@@ -1,0 +1,84 @@
+(ns pyregence.routing-test
+  (:require
+   [clojure.test         :refer [deftest is testing]]
+   [pyregence.handlers   :as    handlers]
+   [pyregence.routing    :refer [routes]]
+   [triangulum.config    :as    config]))
+
+;; -----------------------------------------------------------------------------
+;; Org member-management gate (PYR1-1547)
+;; -----------------------------------------------------------------------------
+;;
+;; Managing org members is intentionally a paid capability: every real
+;; organization is on a paid tier (Pro or Enterprise), and tier1/free is
+;; reserved for individual members who don't belong to an org. These routes are
+;; therefore gated on `#{:organization-admin :tier2-pro :token}`, evaluated with
+;; AND semantics - the caller must be an accepted org-admin AND on a paid
+;; (>= tier2-pro) tier AND present a valid token. Super-admins and account
+;; managers bypass the tier check.
+
+(def ^:private member-management-routes
+  [[:post "/clj/get-org-member-users"]
+   [:post "/clj/add-org-users"]
+   [:post "/clj/update-users-roles"]
+   [:post "/clj/update-users-status"]
+   [:post "/clj/update-org-info"]])
+
+(deftest member-management-routes-require-admin-and-paid-tier
+  (doseq [route member-management-routes]
+    (testing (str route " gate")
+      (let [auth-type (get-in routes [route :auth-type])]
+        (is (= #{:organization-admin :tier2-pro :token} auth-type)
+            "should require an org-admin, on a paid tier, with a valid token")))))
+
+;; -----------------------------------------------------------------------------
+;; route-authenticator behaviour for the member-management gate
+;; -----------------------------------------------------------------------------
+
+(def ^:private gate #{:organization-admin :tier2-pro :token})
+(def ^:private valid-token "test-auth-token")
+
+(defn- request
+  "Build a minimal Ring request for `route-authenticator`. Omitting :org-id keeps
+   current-subscription-tier off the DB and falling back to the session tier."
+  [{:keys [role membership tier token]}]
+  {:headers (when token {"authorization" (str "Bearer " token)})
+   :session (cond-> {}
+              role       (assoc :user-role role)
+              membership (assoc :org-membership-status membership)
+              tier       (assoc :subscription-tier tier))})
+
+(deftest member-management-gate-behaviour
+  (with-redefs [config/get-config (fn [& _] valid-token)]
+    (testing "org-admin on a paid tier (Pro) passes"
+      (is (true? (handlers/route-authenticator
+                  (request {:role "organization_admin" :membership "accepted"
+                            :tier "tier2_pro" :token valid-token})
+                  gate))))
+
+    (testing "org-admin on tier1/free is blocked (the reported ticket scenario)"
+      (is (false? (handlers/route-authenticator
+                   (request {:role "organization_admin" :membership "accepted"
+                             :tier "tier1_free_registered" :token valid-token})
+                   gate))))
+
+    (testing "super-admin bypasses the tier check"
+      (is (true? (handlers/route-authenticator
+                  (request {:role "super_admin" :token valid-token})
+                  gate))))
+
+    (testing "account-manager bypasses the tier check"
+      (is (true? (handlers/route-authenticator
+                  (request {:role "account_manager" :token valid-token})
+                  gate))))
+
+    (testing "a plain member (individual, no org) is blocked"
+      (is (false? (handlers/route-authenticator
+                   (request {:role "member" :token valid-token})
+                   gate))))
+
+    (testing "a paid-tier org-admin without a valid token is blocked"
+      (is (false? (handlers/route-authenticator
+                   (request {:role "organization_admin" :membership "accepted"
+                             :tier "tier2_pro" :token "wrong-token"})
+                   gate))))))


### PR DESCRIPTION
## Purpose
Member management (Organization Settings -> Member User-List) is gated behind the `tier2-pro` route authenticator, which is correct: every real organization is on a paid tier (Pro or Enterprise), and tier1/free is reserved for individual members who don't belong to an org.

The seeded "Development" org, however, was inserted without a `subscription_tier` and defaulted to `tier1_free_registered`. Its org-admin (`admin@pyr.dev`) therefore hit a 403 from the tier gate, breaking the org-admin flows in every local/dev environment.

This seeds all dev-data orgs on a paid tier so dev mirrors production:
- Orgs 1-4 on `tier2_pro`
- Pyregence Consortium on `tier3_enterprise` (so both paid tiers are exercised locally)

Also adds a `pyregence.routing-test` that pins the intended gate semantics: an org-admin on a paid tier passes, a tier1/free org-admin is blocked, and super-admins / account-managers bypass the tier check.

The route gate itself is unchanged.

## Related Issues
Closes PYR1-1547

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Misc. > Organization Settings (Member User-List)

#### Role
Admin (organization admin)

#### Steps
1. Rebuild the dev database with dev data: `bb dev-data`.
2. Log in as `admin@pyr.dev` (password `admin`).
3. Open Organization Settings -> Member User-List.

#### Desired Outcome
The member list loads (no 403 / "Unable to load users: Forbidden" toast), because the Development org is now on a paid tier.

---

## Screenshots
N/A (dev-data + test only)
