### PR TITLE
PYR1-1512 Stop leaking sequential user PK to the browser

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -852,8 +852,6 @@
    (->> (call-sql "get_org_member_users" (if (= user-role "super_admin")
                                            (org-uuid->id org-uuid)
                                            organization-id))
-        ;; Intentionally omit the sequential user PK: it is never used by the
-        ;; caller and must not reach the browser (PYR1-1512 enumeration hardening).
         (mapv (fn [{:keys [full_name email user_role org_membership_status]}]
                 {:full-name         full_name
                  :email             email
@@ -871,8 +869,6 @@
   "Returns a vector of all users in the DB."
   [_]
   (->> (call-sql "get_all_users")
-       ;; Intentionally omit the sequential user PK: no caller reads it and it must
-       ;; not reach the browser (PYR1-1512 enumeration hardening).
        (mapv (fn [{:keys [email name settings match_drop_access email_verified
                           last_login_date user_role org_membership_status organization_name]}]
                {:email                 email

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -871,10 +871,11 @@
   "Returns a vector of all users in the DB."
   [_]
   (->> (call-sql "get_all_users")
-       (mapv (fn [{:keys [user_uid email name settings match_drop_access email_verified
+       ;; Intentionally omit the sequential user PK: no caller reads it and it must
+       ;; not reach the browser (PYR1-1512 enumeration hardening).
+       (mapv (fn [{:keys [email name settings match_drop_access email_verified
                           last_login_date user_role org_membership_status organization_name]}]
-               {:user-id               user_uid
-                :email                 email
+               {:email                 email
                 :name                  name
                 :settings              settings
                 :match-drop-access     match_drop_access

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -882,6 +882,27 @@
                 :organization-name     organization_name}))
        (data-response)))
 
+^:rct/test
+(comment
+  ;; --- No sequential user PK reaches the browser (PYR1-1512) ---
+  ;; Seed data: user 1 (admin@pyr.dev) is organization_admin of org 1;
+  ;; user 2 (user@pyr.dev) is a member of org 1.
+
+  ;; get-all-users returns every user keyed by email and never exposes the
+  ;; sequential user PK.
+  (let [users (-> (get-all-users {}) :body read-string)]
+    [(some #(contains? % :user-id) users)
+     (contains? (set (map :email users)) "admin@pyr.dev")])
+  ;=> [nil true]
+
+  ;; get-org-member-users lists an org's members keyed by email, never the PK.
+  (let [members (-> (get-org-member-users {:organization-id 1 :user-role "organization_admin"})
+                    :body read-string)]
+    [(some #(contains? % :user-id) members)
+     (contains? (set (map :email members)) "user@pyr.dev")])
+  ;=> [nil true]
+  )
+
 (defn get-password-set-date
   [{:keys [user-id]}]
   (let [row         (sql-primitive (call-sql "get_password_set_date" user-id))

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -852,9 +852,10 @@
    (->> (call-sql "get_org_member_users" (if (= user-role "super_admin")
                                            (org-uuid->id org-uuid)
                                            organization-id))
-        (mapv (fn [{:keys [user_id full_name email user_role org_membership_status]}]
-                {:user-id           user_id
-                 :full-name         full_name
+        ;; Intentionally omit the sequential user PK: it is never used by the
+        ;; caller and must not reach the browser (PYR1-1512 enumeration hardening).
+        (mapv (fn [{:keys [full_name email user_role org_membership_status]}]
+                {:full-name         full_name
                  :email             email
                  :user-role         user_role
                  :membership-status org_membership_status}))

--- a/src/clj/pyregence/handlers.clj
+++ b/src/clj/pyregence/handlers.clj
@@ -15,18 +15,23 @@
             [triangulum.worker   :refer [start-workers!]]))
 
 (defn render-page
-  "Wraps triangulum's render-page so the sequential :organization-id PK is
-   stripped from the session before it is serialized into the page. The internal
-   org id must never reach the browser (PYR1-1512 enumeration hardening) -- the
-   client addresses organizations by their public uuid instead, and never reads
-   :organization-id. The stored server-side session is unaffected: GET page
-   renders do not set a :session key on the response, so wrap-session leaves the
-   persisted session -- and its :organization-id, which server-side org-scoped
-   authorization relies on -- intact."
+  "Wraps triangulum's render-page so the sequential :user-id and :organization-id
+   PKs are stripped from the session before it is serialized into the page, and a
+   :logged-in? boolean is substituted for the client to use in place of :user-id.
+   These internal ids must never reach the browser (PYR1-1512 enumeration
+   hardening) -- the client addresses users and orgs by other means (org uuid,
+   email) and never reads the raw PKs. The stored server-side session is
+   unaffected: GET page renders do not set a :session key on the response, so
+   wrap-session leaves the persisted session -- and its :user-id / :organization-id,
+   which server-side authorization relies on -- intact."
   [uri]
   (let [handler (views/render-page uri)]
     (fn [request]
-      (handler (update request :session dissoc :organization-id)))))
+      (handler (update request :session
+                       (fn [session]
+                         (-> session
+                             (assoc :logged-in? (some? (:user-id session)))
+                             (dissoc :user-id :organization-id))))))))
 
 (def not-found-handler (comp #(assoc % :status 404) (render-page "/not-found")))
 

--- a/src/cljs/pyregence/components/map_controls/tool_bar.cljs
+++ b/src/cljs/pyregence/components/map_controls/tool_bar.cljs
@@ -86,7 +86,7 @@
 ;; Root component
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn tool-bar [set-show-info! get-any-level-key user-id]
+(defn tool-bar [set-show-info! get-any-level-key logged-in?]
   (fn [_]
     [:div#tool-bar {:style ($/combine $/tool $/tool-bar {:top "16px"})}
      (->> [[:info
@@ -99,7 +99,7 @@
                  (gtag-tool-clicked @!/show-info? "point-information"))
             @!/show-info?]
            (when (and (c/feature-enabled? :match-drop) ; enabled in `config.edn`
-                      (number? user-id)                ; logged in user
+                      logged-in?                       ; logged in user
                       @!/match-drop-access?            ; user has match drop access
                       (not @!/mobile?))                ; screen size isn't mobile
              [:flame
@@ -121,7 +121,7 @@
                    (reset! !/show-weather-station? false)
                    (gtag-tool-clicked @!/show-camera? "camera"))
               @!/show-camera?])
-           (when (number? user-id)
+           (when logged-in?
             [:weather-station
              "Show weather stations"
              #(do

--- a/src/cljs/pyregence/components/settings/pages/admin.cljs
+++ b/src/cljs/pyregence/components/settings/pages/admin.cljs
@@ -47,13 +47,12 @@
                                                          :justify-content "center"
                                                          :color           (if v "green" "red")}}
                                           (if v "✓" "✗")])))]
-                                [{:field "user-id"               :headerName "User ID"               :filter false :width 110}
-                                 {:field "organization-name"     :headerName "Org Name"              :filter "agTextColumnFilter"}
-                                 {:field "match-drop-access"     :headerName "Match Drop?"           :filter false :width 150
+                                [{:field "organization-name" :headerName "Org Name" :filter "agTextColumnFilter"}
+                                 {:field        "match-drop-access" :headerName "Match Drop?" :filter false :width 150
                                   :editable     true
                                   :cellRenderer "agCheckboxCellRenderer"}
-                                 {:field "email-verified"        :headerName "Email Verified?"       :filter false :width 150 :cellRenderer boolean-renderer}
-                                 {:field "last-login-date"       :headerName "Last Login Date"       :filter "agDateColumnFilter" :width 300}
-                                 {:field "settings"              :headerName "Settings"              :filter false :width 200 :autoHeight true
+                                 {:field "email-verified" :headerName "Email Verified?" :filter false :width 150 :cellRenderer boolean-renderer}
+                                 {:field "last-login-date" :headerName "Last Login Date" :filter "agDateColumnFilter" :width 300}
+                                 {:field "settings" :headerName "Settings" :filter false :width 200 :autoHeight true
                                   :cellStyle
                                   #js {:whiteSpace "normal" :lineHeight "1.4" :overflow "visible" :textAlign "left"}}])))]}]])

--- a/src/cljs/pyregence/pages/near_term_forecast.cljs
+++ b/src/cljs/pyregence/pages/near_term_forecast.cljs
@@ -990,7 +990,7 @@
 ;; UI Components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- control-layer [user-id user-email]
+(defn- control-layer [logged-in? user-email]
   (let [my-box (r/atom #js {})
         ref    (react/createRef)]
     (r/create-class
@@ -1038,7 +1038,7 @@
          [tool-bar
           set-show-info!
           get-any-level-key
-          user-id]
+          logged-in?]
          [scale-bar (get-any-level-key :time-slider?)]
          (when-not @!/mobile? [mouse-lng-lat])
          [zoom-bar
@@ -1194,7 +1194,7 @@
 
 (defn root-component
   "Component definition for the \"Near Term\" and \"Long Term\" Forecast Pages."
-  [{:keys [user-id user-role user-email] :as params}]
+  [{:keys [logged-in? user-role user-email] :as params}]
   (r/create-class
    {:component-did-mount
     (fn [_]
@@ -1216,7 +1216,7 @@
        [nav-bar {:capabilities       @!/capabilities
                  :current-forecast   @!/*forecast
                  :is-admin?          (roles-who-can-see-admin-btn user-role)
-                 :logged-in?         user-id
+                 :logged-in?         logged-in?
                  :mobile?            @!/mobile?
                  :user-orgs-list     @!/user-orgs-list
                  :on-forecast-select select-forecast!
@@ -1225,6 +1225,6 @@
         (when (and @mb/the-map
                    (not-empty @!/capabilities)
                    (not-empty @!/*params))
-          [control-layer user-id user-email])
+          [control-layer logged-in? user-email])
         [map-layer]
         [pop-up]]])}))

--- a/src/sql/functions/organization_functions.sql
+++ b/src/sql/functions/organization_functions.sql
@@ -183,15 +183,15 @@ $$;
 --------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION get_org_member_users(_org_id integer)
  RETURNS TABLE (
-    user_id               integer,
     full_name             text,
     email                 text,
     user_role             user_role,
     org_membership_status org_membership_status
  ) AS $$
-
+    -- The sequential user_uid PK is intentionally not selected: nothing needs it
+    -- client-side (user actions key off email) and it must not reach the browser
+    -- (PYR1-1512 enumeration hardening).
     SELECT
-        user_uid,
         name AS full_name,
         email,
         user_role,

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -315,6 +315,9 @@ CREATE OR REPLACE FUNCTION get_all_users()
   org_membership_status org_membership_status,
   organization_name     text
  ) AS $$
+    -- The sequential user_uid PK is intentionally not selected: nothing needs it
+    -- client-side (user actions key off email) and it must not reach the browser
+    -- (PYR1-1512 enumeration hardening).
     SELECT
       u.email,
       u.name,

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -305,7 +305,6 @@ $$ LANGUAGE SQL;
 --------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION get_all_users()
  RETURNS TABLE (
-  user_uid              integer,
   email                 text,
   name                  text,
   settings              text,
@@ -317,7 +316,6 @@ CREATE OR REPLACE FUNCTION get_all_users()
   organization_name     text
  ) AS $$
     SELECT
-      u.user_uid,
       u.email,
       u.name,
       u.settings,


### PR DESCRIPTION
## Purpose
Stop exposing the sequential `users` table PK to the browser (PYR1-1512 enumeration hardening). The internal `user_uid` was reaching the client in three places, none of which needed it: the client only ever used it as a logged-in flag, and all user mutations key off email. It is now stripped at every leak site.

- **Session:** `render-page` strips `:user-id` (and `:organization-id`) from the session before it is serialized into the inline page script, substituting a `:logged-in?` boolean. The stored server-side session is untouched, so server-side authorization is unaffected. The client (`tool-bar`, forecast pages) now consumes `:logged-in?` instead of `(number? user-id)`.
- **`get_org_member_users`:** dropped `:user-id` from the payload (no caller read it).
- **`get_all_users`:** dropped the PK from the SQL function, the handler payload, and the "User ID" column of the admin users table.

## Related Issues
Closes PYR1-1512

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing

#### Module Impacted
Misc. (Admin settings > Users table), Toolbars (Match Drop / Weather Station gating)

#### Role
Admin, User

#### Steps
1. Log in and open the admin Users table; confirm it renders with no "User ID" column and all rows/filters work.
2. Inspect the serialized session in the page source; confirm no `:user-id` is present and `:logged-in?` is `true`.
3. As a logged-in user with Match Drop access, confirm the Match Drop and Weather Station tools still appear in the toolbar.

#### Desired Outcome
The sequential user PK never reaches the browser, and all logged-in gating, admin user management, and org member listing continue to work.
