### PR TITLE
PYR1-1511 Session security: invalidation, timeouts, single session

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -129,6 +129,9 @@
                                                      :psps        {:username "<username>" :password "<password>"}}
  :pyregence.weather-stations/get-observation-stations-every-n-minutes 1440 ;; once a day
  :pyregence.email/verification-token-expiry-minutes 15
+ ;; Bounds (pentest AC): idle < 30, absolute < 8 h.
+ :pyregence.auth/idle-timeout-min                   15
+ :pyregence.auth/absolute-timeout-min               420
  :pyregence.match-drop/match-drop                   {:sig3-auth      "<AUTH_TOKEN>"
                                                      :sig3-env       "<dev | prod | stg>"
                                                      :max-queue-size 5}

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -21,16 +21,19 @@
    This is the single source of truth for session structure."
   [user-data]
   (when user-data
-    (data-response "" {:session (merge {:match-drop-access?    (:match_drop_access user-data)
-                                        :user-email            (:user_email user-data)
-                                        :user-id               (:user_id user-data)
-                                        :user-name             (:user_name user-data)
-                                        :user-role             (:user_role user-data)
-                                        :organization-id       (:organization_rid user-data)
-                                        :org-membership-status (:org_membership_status user-data)
-                                        :subscription-tier     (:subscription_tier user-data)
-                                        :marketplace-status    (:marketplace_status user-data)}
-                                       (get-config :app :client-keys))})))
+    (let [now (System/currentTimeMillis)]
+      (data-response "" {:session (merge {:match-drop-access?    (:match_drop_access user-data)
+                                          :user-email            (:user_email user-data)
+                                          :user-id               (:user_id user-data)
+                                          :user-name             (:user_name user-data)
+                                          :user-role             (:user_role user-data)
+                                          :organization-id       (:organization_rid user-data)
+                                          :org-membership-status (:org_membership_status user-data)
+                                          :subscription-tier     (:subscription_tier user-data)
+                                          :marketplace-status    (:marketplace_status user-data)
+                                          :created-at            now
+                                          :last-active           now}
+                                         (get-config :app :client-keys))}))))
 
 (defn- parse-user-settings
   "Safely parses user settings from EDN string, returning empty map on error."
@@ -123,6 +126,8 @@
   ([{:keys [user_id user_email] :as user} request-session]
    (call-sql "set_users_last_login_date_to_now" user_id)
    (marketplace/complete-signup! request-session user_email)
+   ;; A new login invalidates the user's prior sessions (single active session)
+   (call-sql "set_user_session_invalidated_at" user_id (System/currentTimeMillis))
    (create-session-from-user-data user)))
 
 (defn log-in
@@ -188,7 +193,39 @@
   ;=>> {:status 200 :body string?}
   )
 
-(defn log-out [_] (data-response "" {:session nil}))
+(defn log-out
+  "Logs the user out: invalidates all of their sessions server-side,
+   clears the session cookie, and asks the browser to drop client-side state."
+  [{:keys [user-id]}]
+  (when user-id
+    (call-sql "set_user_session_invalidated_at" user-id (System/currentTimeMillis)))
+  (-> (data-response "" {:session nil})
+      (assoc-in [:headers "Clear-Site-Data"] "\"cache\", \"cookies\", \"storage\"")))
+
+^:rct/test
+(comment
+  ;; Logout drops the cookie (:session nil), sends Clear-Site-Data, and stamps the cutoff at now
+  ;; for that user. A zero or stale stamp would silently stop invalidating anything.
+  (let [calls  (atom [])
+        before (System/currentTimeMillis)]
+    (with-redefs [call-sql (fn [& args] (swap! calls conj (vec args)) nil)]
+      (let [resp       (log-out {:user-id 7})
+            [f uid ts] (first @calls)]
+        [(contains? resp :session)
+         (:session resp)
+         (get-in resp [:headers "Clear-Site-Data"])
+         f
+         uid
+         (>= ts before)])))
+  ;=> [true nil "\"cache\", \"cookies\", \"storage\"" "set_user_session_invalidated_at" 7 true]
+
+  ;; A guest logout still clears client state but writes nothing (no user-id).
+  (let [calls (atom [])]
+    (with-redefs [call-sql (fn [& args] (swap! calls conj (vec args)) nil)]
+      (let [resp (log-out {})]
+        [(get-in resp [:headers "Clear-Site-Data"]) (count @calls)])))
+  ;=> ["\"cache\", \"cookies\", \"storage\"" 0]
+  )
 
 (defn set-user-password
   "Sets a new password for user with valid reset token."

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -199,7 +199,11 @@
   [{:keys [user-id]}]
   (when user-id
     (call-sql "set_user_session_invalidated_at" user-id (System/currentTimeMillis)))
+  ;; :session nil re-seals an empty cookie but Ring's cookie-store emits no expiry, so the browser
+  ;; keeps it; :session-cookie-attrs {:max-age 0} makes wrap-session send Max-Age=0 to delete it.
+  ;; Must be assoc'ed on the response: utils/data-response only passes through :status/:type/:session.
   (-> (data-response "" {:session nil})
+      (assoc :session-cookie-attrs {:max-age 0})
       (assoc-in [:headers "Clear-Site-Data"] "\"cache\", \"cookies\", \"storage\"")))
 
 ^:rct/test
@@ -213,11 +217,12 @@
             [f uid ts] (first @calls)]
         [(contains? resp :session)
          (:session resp)
+         (:session-cookie-attrs resp)
          (get-in resp [:headers "Clear-Site-Data"])
          f
          uid
          (>= ts before)])))
-  ;=> [true nil "\"cache\", \"cookies\", \"storage\"" "set_user_session_invalidated_at" 7 true]
+  ;=> [true nil {:max-age 0} "\"cache\", \"cookies\", \"storage\"" "set_user_session_invalidated_at" 7 true]
 
   ;; A guest logout still clears client state but writes nothing (no user-id).
   (let [calls (atom [])]

--- a/src/clj/pyregence/handlers.clj
+++ b/src/clj/pyregence/handlers.clj
@@ -35,14 +35,6 @@
 
 (def not-found-handler (comp #(assoc % :status 404) (render-page "/not-found")))
 
-(defn redirect-handler [{:keys [session query-string uri] :as _request}]
-  (let [full-url (url-encode (str uri (when query-string (str "?" query-string))))]
-    (if (:user-id session)
-      (redirect (str "/?flash_message=You do not have permission to access "
-                     full-url))
-      (redirect (str "/login?flash_message=You must login to see "
-                     full-url)))))
-
 (def role-hierarchy
   (-> (make-hierarchy)
       (derive :super-admin         :organization-admin)
@@ -95,50 +87,233 @@
   [tier]
   (not (isa? subscription-hierarchy tier :tier2-pro)))
 
+;; Session liveness
+
+(def ^:private default-idle-timeout-min     15)  ; NIST 800-63B AAL3 / PCI DSS 8.2.8
+(def ^:private default-absolute-timeout-min 420) ; 7 h
+
+(defn- session-expired?
+  "Fail-closed: a session missing either timestamp counts as expired; an unauthenticated one never expires."
+  [{:keys [user-id created-at last-active]} now idle-ms absolute-ms]
+  (boolean (when user-id
+             (or (nil? created-at)
+                 (nil? last-active)
+                 (> (- now created-at)  absolute-ms)
+                 (> (- now last-active) idle-ms)))))
+
+(defn- timeout-ms
+  [config-key default-min]
+  (* 60000 (or (get-config config-key) default-min)))
+
+(defn- session-timed-out?
+  [session now]
+  (session-expired? session now
+                    (timeout-ms :pyregence.auth/idle-timeout-min     default-idle-timeout-min)
+                    (timeout-ms :pyregence.auth/absolute-timeout-min default-absolute-timeout-min)))
+
+(defn- session-invalidated?
+  "Created strictly before the user's invalidation point (set on logout / newer login).
+   Strict `<` so a fresh login at the same instant survives; invalidated-at 0 = never."
+  [{:keys [user-id created-at]} invalidated-at]
+  (boolean (and user-id created-at (pos? invalidated-at) (< created-at invalidated-at))))
+
+(defn- session-revoked?
+  "A nil lookup (e.g. a deleted user) counts as not invalidated rather than crashing."
+  [{:keys [user-id] :as session}]
+  (boolean
+   (and user-id
+        (session-invalidated? session (or (sql-primitive (call-sql "get_user_session_invalidated_at" user-id)) 0)))))
+
+(defn redirect-handler
+  "Sends a dead session (timed out or revoked) to log in again; only a live user who genuinely
+   lacks the role is told so. Defined below the liveness predicates so it can use them."
+  [{:keys [session query-string uri] :as _request}]
+  (let [full-url (url-encode (str uri (when query-string (str "?" query-string))))
+        live?    (and (:user-id session)
+                      (not (session-timed-out? session (System/currentTimeMillis)))
+                      (not (session-revoked? session)))]
+    (if live?
+      (redirect (str "/?flash_message=You do not have permission to access "
+                     full-url))
+      (redirect (str "/login?flash_message=You must login to see "
+                     full-url)))))
+
+^:rct/test
+(comment
+  ;; idle 15 min = 900000 ms ; absolute 7 h = 25200000 ms (the production defaults)
+  (session-expired? {:user-id 1 :created-at 1000000000000 :last-active 1000000000000} 1000000000000 900000 25200000)
+  ;=> false
+  (session-expired? {:user-id 1 :created-at 1000000000000 :last-active 999999000000} 1000000000000 900000 25200000)
+  ;=> true
+  (session-expired? {:user-id 1 :created-at 999970000000 :last-active 1000000000000} 1000000000000 900000 25200000)
+  ;=> true
+  (session-expired? {:user-id 1} 1000000000000 900000 25200000)
+  ;=> true
+  (session-expired? {} 1000000000000 900000 25200000)
+  ;=> false
+
+  (session-invalidated? {:user-id 1 :created-at 1000} 0)
+  ;=> false
+  (session-invalidated? {:user-id 1 :created-at 1000} 2000)
+  ;=> true
+  (session-invalidated? {:user-id 1 :created-at 3000} 2000)
+  ;=> false
+  (session-invalidated? {:user-id 1 :created-at 2000} 2000)
+  ;=> false
+  (session-invalidated? {:created-at 1000} 2000)
+  ;=> false
+  )
+
+^:rct/test
+(comment
+  ;; A dead session still carries a :user-id, so the redirect must ask about liveness, not just
+  ;; presence, or an expired user is wrongly told they lack permission.
+  ;; Cases: anonymous, timed out, live. true = sent to /login, false = told "no permission".
+  (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at 0}])]
+    (let [now (System/currentTimeMillis)
+          to  (fn [session] (-> (redirect-handler {:session session :uri "/account-settings"})
+                                (get-in [:headers "Location"])
+                                (str/starts-with? "/login")))]
+      [(to {})
+       (to {:user-id 1 :created-at (- now 1000000000) :last-active (- now 1000000000)})
+       (to {:user-id 1 :created-at now :last-active now})]))
+  ;=> [true true false]
+  )
+
+(defn- auth-types
+  [auth-type]
+  (if (keyword? auth-type) [auth-type] auth-type))
+
 ;; TODO add (some? (:user-id session)) check to all routes to ensure user is logged in?
-(defn route-authenticator [{:keys [headers session]} auth-type]
+(defn- authorized?
+  "Pure authorization: whether the session satisfies every required auth-type.
+   Liveness is checked separately in route-authenticator."
+  [{:keys [headers session]} auth-type]
   (let [org-membership-status  (:org-membership-status session nil)
         has-match-drop-access? (:match-drop-access? session)
         user-role              (session-user-role session)
         subscription-tier      (delay (current-subscription-tier session))
-        ;; Extract Bearer token from Authorization header
         bearer-token           (some->> (get headers "authorization")
                                         (re-find #"(?i)^Bearer\s+(.+)$")
                                         second)
         valid-token?           (= bearer-token (get-config :triangulum.views/client-keys :auth-token))
         super-admin?           (isa? role-hierarchy user-role :super-admin)
         account-manager?       (isa? role-hierarchy user-role :account-manager)]
-    (every? (fn [auth-type]
-              (case auth-type
+    (every? (fn [one-auth-type]
+              (case one-auth-type
                 :token               valid-token? ; TODO: generate token per user and validate it cryptographically
                 :match-drop          has-match-drop-access?
-                ;; Roles
                 :super-admin         super-admin?
-                :account-manager     (isa? role-hierarchy user-role :account-manager)
-                :organization-admin  (or super-admin? ; we need this extra check because super-admins don't have an associated org, and thus their org-membership-status is none
+                :account-manager     account-manager?
+                :organization-admin  (or super-admin? ; super-admins have no org, so org-membership-status is none
                                          account-manager?
                                          (and (isa? role-hierarchy user-role :organization-admin)
                                               (= org-membership-status "accepted")))
-                :organization-member (or super-admin? ; we need this extra check because super-admins don't have an associated org, and thus their org-membership-status is none
+                :organization-member (or super-admin? ; super-admins have no org, so org-membership-status is none
                                          account-manager?
                                          (and (isa? role-hierarchy user-role :organization-member)
                                               (= org-membership-status "accepted")))
                 :member              (isa? role-hierarchy user-role :member)
-                ;; Subscription Tiers (super admins have access to all tiers)
-                :tier3-enterprise      (or super-admin?
-                                           account-manager?
-                                           (isa? subscription-hierarchy @subscription-tier :tier3-enterprise))
-                :tier2-pro             (or super-admin?
-                                           account-manager?
-                                           (isa? subscription-hierarchy @subscription-tier :tier2-pro))
-                :tier1-basic-paid      (or super-admin?
-                                           account-manager?
-                                           (isa? subscription-hierarchy @subscription-tier :tier1-basic-paid))
-                :tier1-free-registered (or super-admin?
-                                           account-manager?
-                                           (isa? subscription-hierarchy @subscription-tier :tier1-free-registered))
+                ;; super-admins / account-managers have access to all tiers
+                (:tier3-enterprise :tier2-pro :tier1-basic-paid :tier1-free-registered)
+                (or super-admin?
+                    account-manager?
+                    (isa? subscription-hierarchy @subscription-tier one-auth-type))
                 true))
-            (if (keyword? auth-type) [auth-type] auth-type))))
+            (auth-types auth-type))))
+
+(defn- requires-live-session?
+  "Session-consulting auth-types (role, tier, match-drop) enforce liveness; token-only routes skip
+   it, so a stale cookie can still log out or re-login."
+  [auth-type]
+  (not-every? #{:token} (auth-types auth-type)))
+
+(defn route-authenticator
+  "Rejects a timed-out or revoked (logout / newer login) session before authorizing."
+  [{:keys [session] :as request} auth-type]
+  (if (and (requires-live-session? auth-type)
+           (:user-id session)
+           (or (session-timed-out? session (System/currentTimeMillis))
+               (session-revoked? session)))
+    false
+    (authorized? request auth-type)))
+
+^:rct/test
+(comment
+  ;; invalidation lookup stubbed to 0 = never, isolating the timeout path.
+  (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at 0}])]
+    (let [now     (System/currentTimeMillis)
+          fresh   {:user-id 1 :user-role "organization_member" :org-membership-status "accepted"
+                   :created-at now :last-active now}
+          expired (assoc fresh :last-active (- now 1000000000))]
+      [(route-authenticator {:session fresh}   :member)
+       (route-authenticator {:session expired} :member)]))
+  ;=> [true false]
+
+  ;; The absolute cap, through the real config wiring: idle-fresh but 8 h old is out, 6 h old is in.
+  ;; Every other case here is idle-stale, so it short-circuits before the absolute branch is reached.
+  (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at 0}])]
+    (let [now  (System/currentTimeMillis)
+          sess (fn [age-h] {:user-id 1 :user-role "member"
+                            :created-at (- now (* age-h 3600000)) :last-active now})]
+      [(route-authenticator {:session (sess 8)} :member)
+       (route-authenticator {:session (sess 6)} :member)]))
+  ;=> [false true]
+
+  ;; a since-deleted user's lingering session: the lookup returns nil -> treated as
+  ;; not invalidated, no NullPointerException.
+  (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at nil}])]
+    (let [now (System/currentTimeMillis)]
+      (route-authenticator {:session {:user-id 999 :user-role "member" :created-at now :last-active now}} :member)))
+  ;=> true
+
+  ;; a plain member does not satisfy :tier2-pro (guards authorized?'s trailing `true` default).
+  (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at 0}])]
+    (let [now (System/currentTimeMillis)]
+      (route-authenticator {:session {:user-id 1 :user-role "member" :created-at now :last-active now}} :tier2-pro)))
+  ;=> false
+
+  ;; a timed-out session still reaches a token-only route (logout/login stay usable),
+  ;; but is rejected on a session route.
+  (with-redefs [call-sql   (fn [& _] [{:get_user_session_invalidated_at 0}])
+                get-config (fn [k & _] (when (= k :triangulum.views/client-keys) "tok"))]
+    (let [now     (System/currentTimeMillis)
+          expired {:user-id 1 :user-role "member" :created-at (- now 1000000000) :last-active (- now 1000000000)}
+          req     {:session expired :headers {"authorization" "Bearer tok"}}]
+      [(route-authenticator req :token)
+       (route-authenticator req :member)]))
+  ;=> [true false]
+
+  (requires-live-session? :token)
+  ;=> false
+  (requires-live-session? :member)
+  ;=> true
+  (requires-live-session? #{:member :token})
+  ;=> true
+
+  ;; a set auth-type requires every element: #{:token :super-admin} denies a plain member even with a
+  ;; valid token (a map literal would fall through to authorized?'s `true` default and admit anyone).
+  (with-redefs [call-sql   (fn [& _] [{:get_user_session_invalidated_at 0}])
+                get-config (fn [k & _] (when (= k :triangulum.views/client-keys) "tok"))]
+    (let [now    (System/currentTimeMillis)
+          member {:session {:user-id 5 :user-role "member" :created-at now :last-active now}
+                  :headers {"authorization" "Bearer tok"}}]
+      (route-authenticator member #{:token :super-admin})))
+  ;=> false
+
+  ;; a session created before the invalidation point is rejected even within its timeouts...
+  (let [now (System/currentTimeMillis)]
+    (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at now}])]
+      (route-authenticator {:session {:user-id 1 :user-role "member"
+                                      :created-at (- now 100000) :last-active now}} :member)))
+  ;=> false
+  ;; ...but a fresh login (created at the instant it set the point) survives.
+  (let [now (System/currentTimeMillis)]
+    (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at now}])]
+      (route-authenticator {:session {:user-id 1 :user-role "member"
+                                      :created-at now :last-active now}} :member)))
+  ;=> true
+  )
 
 (defn- fn->sym [f]
   (-> (str f)
@@ -177,11 +352,46 @@
     (let [clj-args   (if (= content-type "application/edn")
                        (:clj-args params [])
                        (json/read-str (:clj-args params "[]")))
-          clj-result (apply function session clj-args)]
+          clj-result (apply function session clj-args)
+          response   (if (:status clj-result)
+                       clj-result
+                       (data-response clj-result {:type (if (= content-type "application/edn") :edn :json)}))]
       (log-str "CLJ Call: " (cons (fn->sym function) clj-args))
-      (if (:status clj-result)
-        clj-result
-        (data-response clj-result {:type (if (= content-type "application/edn") :edn :json)})))))
+      ;; Refresh idle timer, unless the wrapped fn already set :session (log-in/log-out) or the
+      ;; session is already expired: token-only routes skip the liveness gate, so refreshing one
+      ;; there would resurrect a dead session.
+      (let [now (System/currentTimeMillis)]
+        (if (and (:user-id session)
+                 (not (contains? response :session))
+                 (not (session-timed-out? session now)))
+          (assoc response :session (assoc session :last-active now))
+          response)))))
+
+^:rct/test
+(comment
+  ;; A live call moves :last-active forward (idle timer) and keeps :created-at (absolute anchor).
+  (let [now  (System/currentTimeMillis)
+        resp ((clj-handler (fn [_session & _] {:status 200 :body "ok"}))
+              {:content-type "application/edn" :params {:clj-args "[]"}
+               :session {:user-id 1 :created-at now :last-active (- now 1000)}})]
+    [(> (get-in resp [:session :last-active]) (- now 1000))
+     (= (get-in resp [:session :created-at]) now)])
+  ;=> [true true]
+  ;; An expired session is never refreshed: token-only routes skip the liveness gate, so a
+  ;; refresh there would resurrect it.
+  (let [old (- (System/currentTimeMillis) 1000000000)]
+    (contains? ((clj-handler (fn [_session & _] {:status 200 :body "ok"}))
+                {:content-type "application/edn" :params {:clj-args "[]"}
+                 :session {:user-id 1 :created-at old :last-active old}})
+               :session))
+  ;=> false
+  ;; ...but a handler that sets :session itself (log-in/log-out) is passed through, not re-attached.
+  (let [now (System/currentTimeMillis)]
+    (:session ((clj-handler (fn [_session & _] {:status 200 :session nil}))
+               {:content-type "application/edn" :params {:clj-args "[]"}
+                :session {:user-id 1 :created-at now :last-active now}})))
+  ;=> nil
+  )
 
 ;; Figwheel
 

--- a/src/clj/pyregence/routing.clj
+++ b/src/clj/pyregence/routing.clj
@@ -127,7 +127,7 @@
                                                      :auth-type #{:account-manager :token}
                                                      :auth-action :block}
    [:post "/clj/get-current-user-organization"]      {:handler (clj-handler authentication/get-current-user-organization)
-                                                     :auth-type :token
+                                                     :auth-type #{:member :token}
                                                      :auth-action :block}
    [:post "/clj/get-org-member-users"]               {:handler (clj-handler authentication/get-org-member-users)
                                                      :auth-type #{:organization-admin :tier2-pro :token}

--- a/src/sql/changes/2026-06-09-add-session-invalidated-at.sql
+++ b/src/sql/changes/2026-06-09-add-session-invalidated-at.sql
@@ -1,0 +1,2 @@
+-- Epoch ms cutoff for server-side session invalidation. Sessions created before it are rejected.
+ALTER TABLE users ADD session_invalidated_at bigint NOT NULL DEFAULT 0;

--- a/src/sql/functions/user_functions.sql
+++ b/src/sql/functions/user_functions.sql
@@ -535,6 +535,21 @@ RETURNS timestamptz AS $$
     WHERE user_uid = _user_id;
 $$ LANGUAGE SQL;
 
+-- Mark all of a user's sessions invalidated as of _ts (epoch ms).
+CREATE OR REPLACE FUNCTION set_user_session_invalidated_at(_user_id integer, _ts bigint)
+RETURNS void AS $$
+    UPDATE users
+    SET session_invalidated_at = _ts
+    WHERE user_uid = _user_id;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION get_user_session_invalidated_at(_user_id integer)
+RETURNS bigint AS $$
+    SELECT session_invalidated_at
+    FROM users
+    WHERE user_uid = _user_id;
+$$ LANGUAGE SQL;
+
 --------------------------------------------------------------------------------
 -- Marketplace Provisioning
 --------------------------------------------------------------------------------

--- a/src/sql/tables/user_tables.sql
+++ b/src/sql/tables/user_tables.sql
@@ -39,7 +39,8 @@ CREATE TABLE users (
     organization_rid       integer references organizations(organization_uid),
     password_set_date      TIMESTAMP WITH TIME ZONE DEFAULT NULL,
     procurement_account_id text,
-    google_user_identity   text
+    google_user_identity   text,
+    session_invalidated_at bigint NOT NULL DEFAULT 0
 );
 
 ALTER TABLE users


### PR DESCRIPTION
## Purpose

Logout didn't really revoke access. Sessions are stateless cookies with no server-side record, so once one was issued the server couldn't kill it - a copied cookie outlived logout, sessions never expired, and one account could stay logged in everywhere. Pentest findings, under epic PYR1-1511.

The fix lets the server reject a dead session. `route-authenticator` checks two things: a per-user cutoff (`users.session_invalidated_at`, epoch ms) that rejects any session older than it, and `:created-at` / `:last-active` stamps against idle and absolute timeouts. Logout and login move the cutoff to now. Only login-required routes are gated, so login, logout, reset and 2FA stay reachable with a stale cookie.

- 1513 - logout moves the cutoff, so a replayed pre-logout cookie stops working (log-out-everywhere for free).
- 1514 - logout also clears the cookie and sends `Clear-Site-Data`. Same acceptance criteria as 1513.
- 1515 - sessions time out at 15 min idle / 7 h absolute (configurable, inside the AC). Activity keeps the idle clock alive; an expired session is never refreshed.
- 1519 - a new login drops the older sessions. A strict `<` lets the fresh login survive its own bump.
- 1562 - the org endpoint was token-only and leaked a logged-out cookie its org data and any geoserver credentials. Now it needs a live session.

Also points a dead session to `/login`, extracts an `auth-types` helper, and folds the four subscription-tier cases into one.

`bb test`, `bb test-clj`, and clj-kondo are green, with a live run against a real database.

Deploy: `bb migrate` (column) then `bb functions` (SQL); `bb deploy` runs functions, a fresh build needs neither. 

**Heads-up:** everyone is logged out once at deploy, since older cookies have no timestamps and fail closed.