### PR TITLE
PYR1-1207/add login throttling to pyrecast webapp and apis

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -115,9 +115,12 @@
                               :triangulum.worker/stop  pyregence.jobs/stop-clean-up-service!}
                              {:triangulum.worker/name  "marketplace-subscriber"
                               :triangulum.worker/start pyregence.marketplace.pubsub/start-subscriber!
-                              :triangulum.worker/stop  pyregence.marketplace.pubsub/stop-subscriber!}]
+                              :triangulum.worker/stop  pyregence.marketplace.pubsub/stop-subscriber!}
+                             {:triangulum.worker/name  "reset-user-email->failed-login-attempts"
+                              :triangulum.worker/start pyregence.jobs/start-reset-user-email->failed-login-attempts!
+                              :triangulum.worker/stop  pyregence.jobs/stop-reset-user-email->failed-login-attempts!}]
 
- ;;; Pyrecast
+;;; Pyrecast
  :pyregence.cameras/alert-west-api-key              "<api-key>"
  ;; Credentials used to list workspaces (REST API) and query GetCapabilities per
  ;; GeoServer. Omit a GeoServer's entry entirely to query it anonymously (a

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -12,6 +12,17 @@
             [java.security SecureRandom]
             [java.text SimpleDateFormat]))
 
+;; TODO this will need a
+;; 4 attempts 0 time
+;; 2 attempts 10 second
+;; 2 30 second
+;; 2 90  exceptional
+;; 2 360 exceptional
+
+;TODO make a less dumb one tomorrow
+;;TODO will need to get reset
+(def user-email->failed-login-attempts (atom {}))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -125,18 +136,24 @@
    (marketplace/complete-signup! request-session user_email)
    (create-session-from-user-data user)))
 
+;;TODO this will have to store failed login attempts per user.
 (defn log-in
   "Authenticates user and determines 2FA requirements."
   [session email password]
-  (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
-    (let [user-id    (:user_id user)
-          two-factor (:two-factor (get-user-settings user-id))]
-      (case two-factor
-        :totp  (data-response {:email email :require-2fa true :method "totp"})
-        :email (do (email/send-email! nil email :2fa)
-                   (data-response {:email email :require-2fa true :method "email"}))
-        (successful-login user session)))
-    (data-response "" {:status 403})))
+  (def args [session email password])
+  ;;TODO not nested if block
+  (if (< 2 (@user-email->failed-login-attempts email 0))
+    (data-response "" {:status 429})
+    (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
+      (let [user-id    (:user_id user)
+            two-factor (:two-factor (get-user-settings user-id))]
+        (case two-factor
+          :totp  (data-response {:email email :require-2fa true :method "totp"})
+          :email (do (email/send-email! nil email :2fa)
+                     (data-response {:email email :require-2fa true :method "email"}))
+          (successful-login user session)))
+      (data-response "" {:status 403
+                         :failed-login-attempts (swap! user-email->failed-login-attempts update email (fnil inc 0))}))))
 
 (defn marketplace-sso-login
   "Marketplace SSO entry point. Validates JWT, auto-logs in or redirects to 2FA.

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -207,7 +207,9 @@
   (if-not (valid-password? password)
     (data-response password->invalid-password-msg  {:status 400})
     (if-let [user (first (call-sql "set_user_password" {:log? false} email password token))]
-      (successful-login user session)
+      (do
+        (swap! user-email->failed-login-attempts dissoc email)
+        (successful-login user session))
       (data-response "Invalid or expired reset token" {:status 403}))))
 
 (defn verify-user-email

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -1,5 +1,6 @@
 (ns pyregence.authentication
-  (:require [pyregence.email            :as email]
+  (:require [clojure.string             :as str]
+            [pyregence.email            :as email]
             [pyregence.marketplace      :as marketplace]
             [pyregence.totp             :as totp]
             [pyregence.utils            :refer [nil-on-error ->uuid]]
@@ -13,6 +14,12 @@
             [java.text SimpleDateFormat]))
 
 (defonce user-email->failed-login-attempts (atom {}))
+
+(defn- normalize-email
+  "Lower-cases and trims an email so throttle lookups match the identity the
+   DB authenticates against (verify_user_login uses lower_trim)."
+  [email]
+  (-> email str/lower-case str/trim))
 
 ;;TODO As an improvement, this could be made to be user-email specific
 (defn reset-user-email->failed-login-attempts!
@@ -144,8 +151,8 @@
 (defn log-in
   "Authenticates user and determines 2FA requirements."
   [session email password]
-  (let [failed-login-attempts  (@user-email->failed-login-attempts email 0)]
-    ;;TODO sync max max-failed-login-attempts value with client
+  (let [normalized-email      (normalize-email email)
+        failed-login-attempts (@user-email->failed-login-attempts normalized-email 0)]
     (if (<= 6 failed-login-attempts)
       (data-response {:failed-login-attempts failed-login-attempts} {:status 429})
       (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
@@ -156,7 +163,7 @@
             :email (do (email/send-email! nil email :2fa)
                        (data-response {:email email :require-2fa true :method "email"}))
             (successful-login user session)))
-        (data-response {:failed-login-attempts ((swap! user-email->failed-login-attempts update email (fnil inc 0)) email)}
+        (data-response {:failed-login-attempts ((swap! user-email->failed-login-attempts update normalized-email (fnil inc 0)) normalized-email)}
                        {:status 403})))))
 
 (defn marketplace-sso-login
@@ -218,7 +225,7 @@
     (data-response password->invalid-password-msg  {:status 400})
     (if-let [user (first (call-sql "set_user_password" {:log? false} email password token))]
       (do
-        (swap! user-email->failed-login-attempts dissoc email)
+        (swap! user-email->failed-login-attempts dissoc (normalize-email email))
         (successful-login user session))
       (data-response "Invalid or expired reset token" {:status 403}))))
 
@@ -730,7 +737,7 @@
                            {:status 403})
             (do
               ;; reset login attempts in case this account exceeded the max login attempts
-              (swap! user-email->failed-login-attempts dissoc email)
+              (swap! user-email->failed-login-attempts dissoc (normalize-email email))
               (cond
             ;; If org-id is provided, we explicitly assign the org (must be super_admin or organization_admin)
             ;; This happens when a super_admin or org_admin is manually adding a user via the admin page

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -17,10 +17,15 @@
 ;;TODO As an improvement, this could be made to be user-email specific
 (defn reset-user-email->failed-login-attempts!
   []
-  (loop []
-    ;; 5 minutes
-    (Thread/sleep (* 1000 60 5))
-    (reset! user-email->failed-login-attempts {})))
+  (future
+    (loop []
+      ;; 5 minutes
+      (Thread/sleep (* 1000 ;; 1s
+                       60   ;; 1m
+                       5    ;; 5m
+                       ))
+      (reset! user-email->failed-login-attempts {})
+      (recur))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -131,7 +131,6 @@
 (defn log-in
   "Authenticates user and determines 2FA requirements."
   [session email password]
-  (def args [session email password])
   (let [failed-login-attempts  (@user-email->failed-login-attempts email 0)]
     ;;TODO sync max max-failed-login-attempts value with client
     (if (<= 5 failed-login-attempts)

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -14,6 +14,19 @@
 
 (defonce user-email->failed-login-attempts (atom {}))
 
+(comment
+  (@user-email->failed-login-attempts "dverlee@sig-gis.com")
+  ;; => 1
+
+  (@user-email->failed-login-attempts "dverlee@sig-gis.com")
+  ;; => 5
+
+  (@user-email->failed-login-attempts "dverlee@sig-gis.com")
+  ;; => nil
+
+;;
+  )
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -715,26 +728,29 @@
           (if-not new-user-id
             (data-response (str "Failed to create the new user with name " user-name " and email " email)
                            {:status 403})
-            (cond
+            (do
+              ;; reset login attempts in case this account exceeded the max login attempts
+              (swap! user-email->failed-login-attempts dissoc email)
+              (cond
             ;; If org-id is provided, we explicitly assign the org (must be super_admin or organization_admin)
             ;; This happens when a super_admin or org_admin is manually adding a user via the admin page
             ;; The new user will have a user_role of organization_member and a user_status of active
-              org-id
-              (if (or (= user-role "super_admin")
-                      (= user-role "organization_admin"))
-                (do
-                  (call-sql "add_org_user" org-id new-user-id)
-                  (data-response "User created and added to organization."))
-                (data-response "User does not have permission to assign users to this organization."
-                               {:status 403}))
+                org-id
+                (if (or (= user-role "super_admin")
+                        (= user-role "organization_admin"))
+                  (do
+                    (call-sql "add_org_user" org-id new-user-id)
+                    (data-response "User created and added to organization."))
+                  (data-response "User does not have permission to assign users to this organization."
+                                 {:status 403}))
 
             ;; No org-id provided — use email domain-based auto-assignment (dependent on org auto_add settings)
-              :else
-              (let [domain (re-find #"@{1}.+" email)]
-                (if (call-sql "auto_add_org_user" new-user-id domain)
-                  (data-response "User created and added to an organization by email domain (when auto_add is true for that organization).")
-                  (data-response "User created successfully but something went wrong when calling auto_add_org_user."
-                                 {:status 403})))))]
+                :else
+                (let [domain (re-find #"@{1}.+" email)]
+                  (if (call-sql "auto_add_org_user" new-user-id domain)
+                    (data-response "User created and added to an organization by email domain (when auto_add is true for that organization).")
+                    (data-response "User created successfully but something went wrong when calling auto_add_org_user."
+                                   {:status 403}))))))]
     ;; Stash org-name in session for marketplace provisioning
       (cond-> response
         (and new-user-id org-name (:marketplace-signup session))

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -14,19 +14,6 @@
 
 (defonce user-email->failed-login-attempts (atom {}))
 
-(comment
-  (@user-email->failed-login-attempts "dverlee@sig-gis.com")
-  ;; => 1
-
-  (@user-email->failed-login-attempts "dverlee@sig-gis.com")
-  ;; => 5
-
-  (@user-email->failed-login-attempts "dverlee@sig-gis.com")
-  ;; => nil
-
-;;
-  )
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -140,7 +140,7 @@
   [session email password]
   (let [failed-login-attempts  (@user-email->failed-login-attempts email 0)]
     ;;TODO sync max max-failed-login-attempts value with client
-    (if (<= 5 failed-login-attempts)
+    (if (<= 6 failed-login-attempts)
       (data-response {:failed-login-attempts failed-login-attempts} {:status 429})
       (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
         (let [user-id    (:user_id user)

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -12,8 +12,6 @@
             [java.security SecureRandom]
             [java.text SimpleDateFormat]))
 
-;; TODO consider a better password attempt policy then 5 tries then you have to reset your password.
-;; Do some research.
 (defonce user-email->failed-login-attempts (atom {}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -14,6 +14,13 @@
 
 (defonce user-email->failed-login-attempts (atom {}))
 
+(defn reset-user-email->failed-login-attempts!
+  []
+  (loop []
+    ;; 5 minutes
+    (Thread/sleep (* 1000 60 5))
+    (reset! user-email->failed-login-attempts {})))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -12,16 +12,9 @@
             [java.security SecureRandom]
             [java.text SimpleDateFormat]))
 
-;; TODO this will need a
-;; 4 attempts 0 time
-;; 2 attempts 10 second
-;; 2 30 second
-;; 2 90  exceptional
-;; 2 360 exceptional
-
-;TODO make a less dumb one tomorrow
-;;TODO will need to get reset
-(def user-email->failed-login-attempts (atom {}))
+;; TODO consider a better password attempt policy then 5 tries then you have to reset your password.
+;; Do some research.
+(defonce user-email->failed-login-attempts (atom {}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions
@@ -141,19 +134,20 @@
   "Authenticates user and determines 2FA requirements."
   [session email password]
   (def args [session email password])
-  ;;TODO not nested if block
-  (if (< 2 (@user-email->failed-login-attempts email 0))
-    (data-response "" {:status 429})
-    (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
-      (let [user-id    (:user_id user)
-            two-factor (:two-factor (get-user-settings user-id))]
-        (case two-factor
-          :totp  (data-response {:email email :require-2fa true :method "totp"})
-          :email (do (email/send-email! nil email :2fa)
-                     (data-response {:email email :require-2fa true :method "email"}))
-          (successful-login user session)))
-      (data-response "" {:status 403
-                         :failed-login-attempts (swap! user-email->failed-login-attempts update email (fnil inc 0))}))))
+  (let [failed-login-attempts  (@user-email->failed-login-attempts email 0)]
+    ;;TODO sync max max-failed-login-attempts value with client
+    (if (<= 5 failed-login-attempts)
+      (data-response {:failed-login-attempts failed-login-attempts} {:status 429})
+      (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
+        (let [user-id    (:user_id user)
+              two-factor (:two-factor (get-user-settings user-id))]
+          (case two-factor
+            :totp  (data-response {:email email :require-2fa true :method "totp"})
+            :email (do (email/send-email! nil email :2fa)
+                       (data-response {:email email :require-2fa true :method "email"}))
+            (successful-login user session)))
+        (data-response {:failed-login-attempts ((swap! user-email->failed-login-attempts update email (fnil inc 0)) email)}
+                       {:status 403})))))
 
 (defn marketplace-sso-login
   "Marketplace SSO entry point. Validates JWT, auto-logs in or redirects to 2FA.

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -14,6 +14,7 @@
 
 (defonce user-email->failed-login-attempts (atom {}))
 
+;;TODO As an improvement, this could be made to be user-email specific
 (defn reset-user-email->failed-login-attempts!
   []
   (loop []

--- a/src/clj/pyregence/jobs.clj
+++ b/src/clj/pyregence/jobs.clj
@@ -64,6 +64,7 @@
 
 (defn start-reset-user-email->failed-login-attempts! []
   (future
+    (log-str "Reset failed login attempt counter every five minutes.")
     (reset-user-email->failed-login-attempts!)))
 
 (defn stop-reset-user-email->failed-login-attempts! [fut]

--- a/src/clj/pyregence/jobs.clj
+++ b/src/clj/pyregence/jobs.clj
@@ -4,6 +4,7 @@
             [clojure.string             :as str]
             [pyregence.capabilities     :refer [set-all-capabilities!]]
             [pyregence.weather-stations :refer [periodically-get-observation-stations-in-the-background!]]
+            [pyregence.authentication   :refer [reset-user-email->failed-login-attempts!]]
             [triangulum.config          :refer [get-config]]
             [triangulum.logging         :refer [log-str]]))
 
@@ -58,4 +59,12 @@
     (periodically-get-observation-stations-in-the-background!)))
 
 (defn stop-get-weather-stations! [fut]
+  (future-cancel fut))
+
+
+(defn start-reset-user-email->failed-login-attempts! []
+  (future
+    (reset-user-email->failed-login-attempts!)))
+
+(defn stop-reset-user-email->failed-login-attempts! [fut]
   (future-cancel fut))

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -40,6 +40,7 @@
               (u-browser/jump-to-url! url)
               (gtag "log-in" {}))))
         ;; Login failed
+        ;; TODO add the backoff logic based on data will have to add in the response?
         ;; TODO, it would be helpful to show the user which of the two errors it actually is.
         (toast-message! ["Invalid login credentials. Please try again."
                          "If you feel this is an error, check your email for the verification email."])))))

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -28,8 +28,8 @@
 (defn- log-in! []
   (go
     ;;TODO consider validating email before sending it.
-    (let [{:keys [success body]} (<! (u-async/call-clj-async! "log-in" @email @password))
-          {:keys [require-2fa email method failed-login-attempts]} (edn/read-string body)]
+    (let [{:keys [success status body]} (<! (u-async/call-clj-async! "log-in" @email @password))
+          {:keys [require-2fa email method]} (edn/read-string body)]
       (if success
         (if require-2fa
             ;; 2FA is required, redirect to 2FA verification page
@@ -40,7 +40,9 @@
             (u-browser/jump-to-url! url)
             (gtag "log-in" {})))
         (toast-message!
-         (if (<= 6 failed-login-attempts)
+         ;; The server returns 429 once the account is locked; keep the lock
+         ;; decision server-side so the client and server can't drift out of sync.
+         (if (= status 429)
            ["Account locked due to multiple unsuccessful attempts."
             "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]
            ["Invalid login credentials. Please try again."

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -28,23 +28,23 @@
 (defn- log-in! []
   (go
     ;;TODO consider validating email before sending it.
-    (let [{:keys [success body]} (<! (u-async/call-clj-async! "log-in" @email @password))]
-      (let [{:keys [require-2fa email method failed-login-attempts] :as body} (edn/read-string body)]
-        (if success
-          (if require-2fa
+    (let [{:keys [success body]} (<! (u-async/call-clj-async! "log-in" @email @password))
+          {:keys [require-2fa email method failed-login-attempts]} (edn/read-string body)]
+      (if success
+        (if require-2fa
             ;; 2FA is required, redirect to 2FA verification page
-            (u-browser/jump-to-url! (str "/verify-2fa?email=" email "&method=" method))
+          (u-browser/jump-to-url! (str "/verify-2fa?email=" email "&method=" method))
             ;; Normal login success
-            (let [url (:redirect-from (u-browser/get-session-storage) "/forecast")]
-              (u-browser/clear-session-storage!)
-              (u-browser/jump-to-url! url)
-              (gtag "log-in" {})))
-          (toast-message!
-           (if (<= 6 failed-login-attempts)
-             ["Account locked due to multiple unsuccessful attempts."
-              "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]
-             ["Invalid login credentials. Please try again."
-              "If you feel this is an error, check your email for the verification email."])))))))
+          (let [url (:redirect-from (u-browser/get-session-storage) "/forecast")]
+            (u-browser/clear-session-storage!)
+            (u-browser/jump-to-url! url)
+            (gtag "log-in" {})))
+        (toast-message!
+         (if (<= 6 failed-login-attempts)
+           ["Account locked due to multiple unsuccessful attempts."
+            "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]
+           ["Invalid login credentials. Please try again."
+            "If you feel this is an error, check your email for the verification email."]))))))
 
 (defn- request-password! []
   (go

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -20,7 +20,6 @@
 (defonce forgot?  (r/atom false))
 (defonce email    (r/atom ""))
 (defonce password (r/atom ""))
-(defonce failed-login-attempts (r/atom nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; API Calls
@@ -30,7 +29,7 @@
   (go
     ;;TODO consider validating email before sending it.
     (let [{:keys [success body]} (<! (u-async/call-clj-async! "log-in" @email @password))]
-      (let [{:keys [require-2fa email method] :as body} (edn/read-string body)]
+      (let [{:keys [require-2fa email method failed-login-attempts] :as body} (edn/read-string body)]
         (if success
           (if require-2fa
             ;; 2FA is required, redirect to 2FA verification page
@@ -40,12 +39,12 @@
               (u-browser/clear-session-storage!)
               (u-browser/jump-to-url! url)
               (gtag "log-in" {})))
-          ;; Login failed
-          ;; TODO, it would be helpful to show the user which of the two errors it actually is.
-          (do
-            (reset! failed-login-attempts (:failed-login-attempts body))
-            (toast-message! ["Invalid login credentials. Please try again."
-                             "If you feel this is an error, check your email for the verification email."])))))))
+          (toast-message!
+           (if (<= 6 failed-login-attempts)
+             ["Account locked due to multiple unsuccessful attempts."
+              "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]
+             ["Invalid login credentials. Please try again."
+              "If you feel this is an error, check your email for the verification email."])))))))
 
 (defn- request-password! []
   (go
@@ -101,17 +100,6 @@
                                                    :placeholder "Enter Password"
                                                    :on-change   #(reset! password (-> % .-target .-value))
                                                    :value       @password}]
-                             (when-let [fla @failed-login-attempts]
-                               ;; TODO sync max max-failed-login-attempts value with server.
-                               ;; It's actually 6 attempts because 0 to 1 counts as an attempt.
-                               (let [max-fla 5]
-                                 [:div {:style {:color       ($/color-picker :error-red)
-                                                :font-weight "bold"
-                                                ;;TODO consider moving this to the top level card
-                                                :width  "300px"}}
-                                  (if (<= 1 fla max-fla)
-                                    [:p (str "This account has " (- (inc max-fla) fla) " more login attempts before it will need a password reset.")]
-                                    [:p "This account has exceeded the max login attempts and will need it's password reset by clicking the link 'Forgot Password?' below."])]))
                              [:a {:href     "#"
                                   :on-click #(reset! forgot? true)
                                   :style    {:color     color

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -20,6 +20,7 @@
 (defonce forgot?  (r/atom false))
 (defonce email    (r/atom ""))
 (defonce password (r/atom ""))
+(defonce failed-login-attempts (r/atom nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; API Calls
@@ -28,22 +29,23 @@
 (defn- log-in! []
   (go
     ;;TODO consider validating email before sending it.
-    (let [response (<! (u-async/call-clj-async! "log-in" @email @password))]
-      (if (:success response)
-        (let [resp-data (edn/read-string (:body response))]
-          (if (:require-2fa resp-data)
+    (let [{:keys [success body]} (<! (u-async/call-clj-async! "log-in" @email @password))]
+      (let [{:keys [require-2fa email method] :as body} (edn/read-string body)]
+        (if success
+          (if require-2fa
             ;; 2FA is required, redirect to 2FA verification page
-            (u-browser/jump-to-url! (str "/verify-2fa?email=" (:email resp-data) "&method=" (:method resp-data)))
+            (u-browser/jump-to-url! (str "/verify-2fa?email=" email "&method=" method))
             ;; Normal login success
             (let [url (:redirect-from (u-browser/get-session-storage) "/forecast")]
               (u-browser/clear-session-storage!)
               (u-browser/jump-to-url! url)
-              (gtag "log-in" {}))))
-        ;; Login failed
-        ;; TODO add the backoff logic based on data will have to add in the response?
-        ;; TODO, it would be helpful to show the user which of the two errors it actually is.
-        (toast-message! ["Invalid login credentials. Please try again."
-                         "If you feel this is an error, check your email for the verification email."])))))
+              (gtag "log-in" {})))
+          ;; Login failed
+          ;; TODO, it would be helpful to show the user which of the two errors it actually is.
+          (do
+            (reset! failed-login-attempts (:failed-login-attempts body))
+            (toast-message! ["Invalid login credentials. Please try again."
+                             "If you feel this is an error, check your email for the verification email."])))))))
 
 (defn- request-password! []
   (go
@@ -82,13 +84,13 @@
          (fn []
            (let [color         ($/color-picker :primary-main-orange)
                  email-cmpt    (fn [] [utils/input-labeled {:label        "Email"
-                                                           :placeholder "Enter Email Address"
-                                                           :on-change   #(reset! email (-> % .-target .-value))
-                                                           :value       @email}])
+                                                            :placeholder "Enter Email Address"
+                                                            :on-change   #(reset! email (-> % .-target .-value))
+                                                            :value       @email}])
                  register-cmpt (fn [] [:p "Don't have an account? "
-                                      [:a {:href  "/register"
-                                           :style {:color color}}
-                                       [:u "Register Here."]]])]
+                                       [:a {:href  "/register"
+                                            :style {:color color}}
+                                        [:u "Register Here."]]])]
              (if-not @forgot?
                [utils/card {:title "LOGIN"
                             :children
@@ -104,6 +106,12 @@
                                   :style    {:color     color
                                              :underline true}}
                               [:u "Forgot Password?"]]
+                             (when-let [fla @failed-login-attempts]
+                               ;;TODO sync max max-failed-login-attempts value with server.
+                               (let [max-fla 5]
+                                 (if (< 1 fla max-fla)
+                                   [:p "Tries before lockout: " (- max-fla fla)]
+                                   [:p "Account locked. Please reset password using 'Forgot Password' link."])))
                              [buttons/primary {:text     "Login"
                                                :on-click log-in!}]
                              [register-cmpt]]}]

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -103,8 +103,8 @@
                                                    :value       @password}]
                              (when-let [fla @failed-login-attempts]
                                ;; TODO sync max max-failed-login-attempts value with server.
-                               ;; It's actually 5 attempts because 0 to 1 counts as an attempt.
-                               (let [max-fla 4]
+                               ;; It's actually 6 attempts because 0 to 1 counts as an attempt.
+                               (let [max-fla 5]
                                  [:div {:style {:color       ($/color-picker :error-red)
                                                 :font-weight "bold"}}
                                   (if (<= 1 fla max-fla)

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -106,7 +106,9 @@
                                ;; It's actually 6 attempts because 0 to 1 counts as an attempt.
                                (let [max-fla 5]
                                  [:div {:style {:color       ($/color-picker :error-red)
-                                                :font-weight "bold"}}
+                                                :font-weight "bold"
+                                                ;;TODO consider moving this to the top level card
+                                                :width  "300px"}}
                                   (if (<= 1 fla max-fla)
                                     [:p (str "This account has " (- (inc max-fla) fla) " more login attempts before it will need a password reset.")]
                                     [:p "This account has exceeded the max login attempts and will need it's password reset by clicking the link 'Forgot Password?' below."])]))

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -41,7 +41,7 @@
             (gtag "log-in" {})))
         (toast-message!
          (if (= status 429)
-           ["Account locked due to multiple unsuccessful attempts."
+           ["Account was locked due to multiple unsuccessful attempts."
             "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]
            ["Invalid login credentials. Please try again."
             "If you feel this is an error, check your email for the verification email."]))))))

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -40,8 +40,6 @@
             (u-browser/jump-to-url! url)
             (gtag "log-in" {})))
         (toast-message!
-         ;; The server returns 429 once the account is locked; keep the lock
-         ;; decision server-side so the client and server can't drift out of sync.
          (if (= status 429)
            ["Account locked due to multiple unsuccessful attempts."
             "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -102,13 +102,14 @@
                                                    :on-change   #(reset! password (-> % .-target .-value))
                                                    :value       @password}]
                              (when-let [fla @failed-login-attempts]
-                               ;;TODO sync max max-failed-login-attempts value with server.
-                               (let [max-fla 5]
-                                 (if (< 1 fla max-fla)
-                                   [:p {:style {:color "red"}}
-                                    (str "This account has " (- max-fla fla) " login attempts before it will need a password reset.")]
-                                   [:p {:style {:color "red"}}
-                                    "This account has exceeded the max login attempts and will need it's password reset by clicking the link 'Forgot Password?' below."])))
+                               ;; TODO sync max max-failed-login-attempts value with server.
+                               ;; It's actually 5 attempts because 0 to 1 counts as an attempt.
+                               (let [max-fla 4]
+                                 [:div {:style {:color       ($/color-picker :error-red)
+                                                :font-weight "bold"}}
+                                  (if (<= 1 fla max-fla)
+                                    [:p (str "This account has " (- (inc max-fla) fla) " more login attempts before it will need a password reset.")]
+                                    [:p "This account has exceeded the max login attempts and will need it's password reset by clicking the link 'Forgot Password?' below."])]))
                              [:a {:href     "#"
                                   :on-click #(reset! forgot? true)
                                   :style    {:color     color

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -101,17 +101,19 @@
                                                    :placeholder "Enter Password"
                                                    :on-change   #(reset! password (-> % .-target .-value))
                                                    :value       @password}]
+                             (when-let [fla @failed-login-attempts]
+                               ;;TODO sync max max-failed-login-attempts value with server.
+                               (let [max-fla 5]
+                                 (if (< 1 fla max-fla)
+                                   [:p {:style {:color "red"}}
+                                    (str "This account has " (- max-fla fla) " login attempts before it will need a password reset.")]
+                                   [:p {:style {:color "red"}}
+                                    "This account has exceeded the max login attempts and will need it's password reset by clicking the link 'Forgot Password?' below."])))
                              [:a {:href     "#"
                                   :on-click #(reset! forgot? true)
                                   :style    {:color     color
                                              :underline true}}
                               [:u "Forgot Password?"]]
-                             (when-let [fla @failed-login-attempts]
-                               ;;TODO sync max max-failed-login-attempts value with server.
-                               (let [max-fla 5]
-                                 (if (< 1 fla max-fla)
-                                   [:p "Tries before lockout: " (- max-fla fla)]
-                                   [:p "Account locked. Please reset password using 'Forgot Password' link."])))
                              [buttons/primary {:text     "Login"
                                                :on-click log-in!}]
                              [register-cmpt]]}]


### PR DESCRIPTION
Now 6 invalid login attempts into an account will lock the user out until they reset the password via 'forgot password'.

Note this will need to be deployed alongside this [PR ](
                             )to update the deployment repo to have the pyregence config.edn changes to add:

```clojure
:triangulum.worker/workers
{:triangulum.worker/name  "reset-user-email->failed-login-attempts"
  :triangulum.worker/start pyregence.jobs/start-reset-user-email->failed-login-attempts!
  :triangulum.worker/stop  pyregence.jobs/stop-reset-user-email->failed-login-attempts!}
```