### PR TITLE
PYR1-1548 touch ups

### DIFF
--- a/src/cljs/pyregence/components/password/validations.cljs
+++ b/src/cljs/pyregence/components/password/validations.cljs
@@ -7,9 +7,9 @@
   [password]
   [{:validation/text   "One number."
     :validation/valid? (boolean (re-find #"\d" password))}
-   {:validation/text   "One lowercase."
+   {:validation/text   "One lowercase letter."
     :validation/valid? (boolean (re-find #"[a-z]" password))}
-   {:validation/text   "One uppercase."
+   {:validation/text   "One uppercase letter."
     :validation/valid? (boolean (re-find #"[A-Z]" password))}
    {:validation/text   "At least 12 characters."
     :validation/valid? (<= 12 (count password))}

--- a/src/cljs/pyregence/components/utils.cljs
+++ b/src/cljs/pyregence/components/utils.cljs
@@ -172,7 +172,8 @@
           (merge
            {:display         "flex"
             :justify-content "center"
-            :align-content   "center"}
+            :align-content   "center"
+            :overflow        "auto"}
            (if @!/mobile?
              {:height "100%"
               :width  "100%"}

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -61,7 +61,7 @@
                           "Your password must be at least 12 characters long.")
 
                         (when (< 64 (count @password))
-                          "Your password must be less then 64 characters long.")
+                          "Your password must be less than 64 characters long.")
 
                         (when-not (= @password @re-password)
                           "The passwords you have entered do not match.")

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -57,8 +57,11 @@
                         (when-not (= @email @re-email)
                           "The emails you have entered do not match.")
 
-                        (when (< (count @password) 8)
-                          "Your password must be at least 8 characters long.")
+                        (when (< (count @password) 12)
+                          "Your password must be at least 12 characters long.")
+
+                        (when (< 64 (count @password))
+                          "Your password must be less then 64 characters long.")
 
                         (when-not (= @password @re-password)
                           "The passwords you have entered do not match.")

--- a/src/cljs/pyregence/pages/register.cljs
+++ b/src/cljs/pyregence/pages/register.cljs
@@ -57,12 +57,6 @@
                         (when-not (= @email @re-email)
                           "The emails you have entered do not match.")
 
-                        (when (< (count @password) 12)
-                          "Your password must be at least 12 characters long.")
-
-                        (when (< 64 (count @password))
-                          "Your password must be less than 64 characters long.")
-
                         (when-not (= @password @re-password)
                           "The passwords you have entered do not match.")
 


### PR DESCRIPTION
This PR is to address the following requests:

> Toast for missing Uppercase letters should read: Your password must have at least one uppercase letter.” << it’s just missing the word “letter”.

> Same for lowercase letters.

Added the word letter to both messages


> Toast for Password 8 and under characters long says the following: “Your password must be at least 8 characters long.”

> Anything under 12 characters should explain what they need to have at least 12 characters.

I assume we just want a toast saying the password needs to be over 12 characters (or letters...)

> Now that we have the explainer underneath the password entry box, I am unable to scroll to the bottom of the page and I can't see the submit button when I'm still entering my password. Once both fields are filled out and validation text goes away, I’m able to submit. If possible it would be nice to change in this ticket, however, I am open to creating a separate bug ticket since it is related to the UI rendering and not the password policy enforcement itself. Just let me know.

I fixed this by adding an overflow. PLEASE test any page that this touches. ill do it myself to. thanks!!!