### PR TITLE
PYR1-1207 Login throttling review fixes

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -20,7 +20,8 @@
   (loop []
     ;; 5 minutes
     (Thread/sleep (* 1000 60 5))
-    (reset! user-email->failed-login-attempts {})))
+    (reset! user-email->failed-login-attempts {})
+    (recur)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -1,5 +1,6 @@
 (ns pyregence.authentication
-  (:require [pyregence.email            :as email]
+  (:require [clojure.string             :as str]
+            [pyregence.email            :as email]
             [pyregence.marketplace      :as marketplace]
             [pyregence.totp             :as totp]
             [pyregence.utils            :refer [nil-on-error ->uuid]]
@@ -13,6 +14,12 @@
             [java.text SimpleDateFormat]))
 
 (defonce user-email->failed-login-attempts (atom {}))
+
+(defn- normalize-email
+  "Lower-cases and trims an email so throttle lookups match the identity the
+   DB authenticates against (verify_user_login uses lower_trim)."
+  [email]
+  (-> email str/lower-case str/trim))
 
 ;;TODO As an improvement, this could be made to be user-email specific
 (defn reset-user-email->failed-login-attempts!
@@ -140,7 +147,8 @@
 (defn log-in
   "Authenticates user and determines 2FA requirements."
   [session email password]
-  (let [failed-login-attempts  (@user-email->failed-login-attempts email 0)]
+  (let [normalized-email      (normalize-email email)
+        failed-login-attempts (@user-email->failed-login-attempts normalized-email 0)]
     (if (<= 6 failed-login-attempts)
       (data-response {:failed-login-attempts failed-login-attempts} {:status 429})
       (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]
@@ -151,7 +159,7 @@
             :email (do (email/send-email! nil email :2fa)
                        (data-response {:email email :require-2fa true :method "email"}))
             (successful-login user session)))
-        (data-response {:failed-login-attempts ((swap! user-email->failed-login-attempts update email (fnil inc 0)) email)}
+        (data-response {:failed-login-attempts ((swap! user-email->failed-login-attempts update normalized-email (fnil inc 0)) normalized-email)}
                        {:status 403})))))
 
 (defn marketplace-sso-login
@@ -213,7 +221,7 @@
     (data-response password->invalid-password-msg  {:status 400})
     (if-let [user (first (call-sql "set_user_password" {:log? false} email password token))]
       (do
-        (swap! user-email->failed-login-attempts dissoc email)
+        (swap! user-email->failed-login-attempts dissoc (normalize-email email))
         (successful-login user session))
       (data-response "Invalid or expired reset token" {:status 403}))))
 
@@ -725,7 +733,7 @@
                            {:status 403})
             (do
               ;; reset login attempts in case this account exceeded the max login attempts
-              (swap! user-email->failed-login-attempts dissoc email)
+              (swap! user-email->failed-login-attempts dissoc (normalize-email email))
               (cond
             ;; If org-id is provided, we explicitly assign the org (must be super_admin or organization_admin)
             ;; This happens when a super_admin or org_admin is manually adding a user via the admin page

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -27,8 +27,7 @@
   (loop []
     ;; 5 minutes
     (Thread/sleep (* 1000 60 5))
-    (reset! user-email->failed-login-attempts {})
-    (recur)))
+    (reset! user-email->failed-login-attempts {})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions

--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -140,7 +140,6 @@
   "Authenticates user and determines 2FA requirements."
   [session email password]
   (let [failed-login-attempts  (@user-email->failed-login-attempts email 0)]
-    ;;TODO sync max max-failed-login-attempts value with client
     (if (<= 6 failed-login-attempts)
       (data-response {:failed-login-attempts failed-login-attempts} {:status 429})
       (if-let [user (first (call-sql "verify_user_login" {:log? false} email password))]

--- a/src/cljs/pyregence/pages/login.cljs
+++ b/src/cljs/pyregence/pages/login.cljs
@@ -28,8 +28,8 @@
 (defn- log-in! []
   (go
     ;;TODO consider validating email before sending it.
-    (let [{:keys [success body]} (<! (u-async/call-clj-async! "log-in" @email @password))
-          {:keys [require-2fa email method failed-login-attempts]} (edn/read-string body)]
+    (let [{:keys [success status body]} (<! (u-async/call-clj-async! "log-in" @email @password))
+          {:keys [require-2fa email method]} (edn/read-string body)]
       (if success
         (if require-2fa
             ;; 2FA is required, redirect to 2FA verification page
@@ -40,7 +40,9 @@
             (u-browser/jump-to-url! url)
             (gtag "log-in" {})))
         (toast-message!
-         (if (<= 6 failed-login-attempts)
+         ;; The server returns 429 once the account is locked; keep the lock
+         ;; decision server-side so the client and server can't drift out of sync.
+         (if (= status 429)
            ["Account locked due to multiple unsuccessful attempts."
             "Please try again in 5 minutes or reset your password by clicking 'Forgot Password?'."]
            ["Invalid login credentials. Please try again."


### PR DESCRIPTION
## Purpose
Addresses review feedback on the login-throttling PR. Three fixes, all scoped to the throttling logic:

- **Reset job never repeated.** `reset-user-email->failed-login-attempts!` used a `loop` with no `recur`, so it ran a single iteration (sleep 5 min, reset once, return) and the future then exited. The counter was wiped only once after startup and never again, so any locked-out account stayed locked until a process restart. Added the missing `recur`.
- **Throttle bypass via email casing/whitespace.** The DB authenticates by `lower_trim(email)`, but the throttle atom was keyed by the raw client string, so `Foo@bar.com`, `foo@bar.com`, and `" foo@bar.com "` were three separate counters against one account. Introduced a `normalize-email` helper (`lower-case` + `trim`) and key every read/`swap!`/`dissoc` through it.
- **Client lockout message off-by-one.** The client re-derived "locked" from the returned attempt count, firing one request before the server actually locks. It now keys the message off the server's `429` status, removing the duplicated threshold and making the server the single source of truth.

## Related Issues
Closes PYR1-1207

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `PYR1-### Did something here`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)
- [x] For any large features/rearchitecting of the codebase, the relevant `docs` were updated (e.g. updating `docs/pyrecast-database.md` when adding a new DB table)

## Testing
#### Module Impacted
Misc. > Login

#### Role
Visitor

#### Steps
1. Attempt to log in with a valid email and a wrong password 6 times; each attempt shows the generic "Invalid login credentials" message.
2. On the 7th attempt, confirm the server returns `429` and the UI shows the "Account locked" message.
3. Repeat step 1 varying the email casing/whitespace (e.g. `User@x.com`, ` user@x.com `); confirm the attempts still count against the same account (locked on the 7th combined attempt), not reset per variant.
4. Wait 5 minutes and confirm the counter clears again (i.e. the reset job keeps running, not just once).

#### Desired Outcome
Six real attempts are allowed per account; the account locks on the 7th with a `429`; casing/whitespace variants cannot buy extra attempts; and the counter is cleared every 5 minutes on an ongoing basis.

## Screenshots
N/A
