### PR TITLE
PYR1-1568 Treat a dead cookie as anonymous on add-new-user and get-fire-names

### DIFF
--- a/src/clj/pyregence/authentication.clj
+++ b/src/clj/pyregence/authentication.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string             :as str]
             [pyregence.email            :as email]
             [pyregence.marketplace      :as marketplace]
+            [pyregence.session          :as session]
             [pyregence.totp             :as totp]
             [pyregence.utils            :refer [nil-on-error ->uuid]]
             [triangulum.config          :refer [get-config]]
@@ -764,7 +765,8 @@
                      (or (:org-id org-name-or-opts)
                          (get org-name-or-opts "org-id")))
           org-name         (when (and (string? org-name) (seq org-name)) org-name)
-          {:keys [user-role]} session
+          ;; Public signup too, so this can't be liveness-gated at the route.
+          user-role        (when (session/live? session) (:user-role session))
           default-settings (pr-str {:timezone :utc})
           new-user-id      (nil-on-error
                             (sql-primitive (call-sql "add_new_user"
@@ -804,6 +806,29 @@
       (cond-> response
         (and new-user-id org-name (:marketplace-signup session))
         (assoc :session (assoc-in session [:marketplace-signup :org-name] org-name))))))
+
+^:rct/test
+(comment
+  ;; `cutoff` is the user's invalidation stamp, 0 = never logged out.
+  (let [now          (System/currentTimeMillis)
+        assigns-org? (fn [session cutoff opts]
+                       (let [calls (atom [])]
+                         (with-redefs [call-sql (fn [& args]
+                                                  (swap! calls conj (first args))
+                                                  (case (first args)
+                                                    "add_new_user"                    [{:add_new_user 42}]
+                                                    "get_user_session_invalidated_at" [{:get_user_session_invalidated_at cutoff}]
+                                                    nil))]
+                           (add-new-user session "a@b.com" "A" "Abcdefgh1234" opts)
+                           (boolean (some #{"add_org_user"} @calls)))))
+        admin        {:user-id 1 :user-role "super_admin" :created-at (- now 1000) :last-active now}]
+    ;; timed-out admin, logged-out admin, live admin, then anonymous signup
+    [(assigns-org? (assoc admin :last-active (- now 1000000000)) 0 {:org-id 3})
+     (assigns-org? admin now {:org-id 3})
+     (assigns-org? admin 0 {:org-id 3})
+     (assigns-org? {} 0 {})])
+  ;=> [false false true false]
+  )
 
 (defn get-current-user-settings
   "Returns settings for the current user."

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -5,6 +5,7 @@
    [clojure.edn         :as edn]
    [clojure.set         :as set]
    [clojure.string      :as str]
+   [pyregence.session   :as session]
    [triangulum.config   :refer [get-config]]
    [triangulum.database :refer [call-sql]]
    [triangulum.logging  :refer [log log-str]]
@@ -425,7 +426,8 @@
     :match-drops      {:match-drop-name {:opt-label \"Match Drop Name\" :filter-set #{\"match-drop-forecast\", \"match-drop-name\"} :auto-zoom? true :geoserver-key :match-drop} ...}
     :wui-active-fires {:wui-fire-name   {:opt-label \"WUI Fire Name\"   :filter-set #{\"fire-spread-forecast\", \"wui-fire-name\"}  :auto-zoom? true :geoserver-key :psps}       ...}}"
   [session]
-  (let [{:keys [user-id match-drop-access?]} session
+  ;; The map is public, so this can't be liveness-gated at the route.
+  (let [{:keys [user-id match-drop-access?]} (when (session/live? session) session)
         match-drop-names                     (when match-drop-access?
                                                (->> (call-sql "get_user_match_names" user-id)
                                                     (reduce (fn [acc row]
@@ -475,6 +477,27 @@
                     :else acc)))
               {:active-fires {} :match-drops {}}))
         (assoc :wui-active-fires (or wui-active-fires {})))))
+
+^:rct/test
+(comment
+  ;; `cutoff` is the user's invalidation stamp, 0 = never logged out.
+  (let [now          (System/currentTimeMillis)
+        reads-names? (fn [session cutoff]
+                       (let [calls (atom [])
+                             saved @layers]
+                         (with-redefs [call-sql   (fn [& args] (swap! calls conj (first args)) [{:get_user_session_invalidated_at cutoff}])
+                                       get-config (fn [& _] nil)]
+                           (reset! layers {})
+                           (get-fire-names session)
+                           (reset! layers saved)
+                           (boolean (some #{"get_user_match_names"} @calls)))))
+        live         {:user-id 1 :match-drop-access? true :created-at (- now 1000) :last-active now}]
+    ;; timed out, logged out, then live
+    [(reads-names? (assoc live :last-active (- now 1000000000)) 0)
+     (reads-names? live now)
+     (reads-names? live 0)])
+  ;=> [false false true]
+  )
 
 (defn get-user-layers [session]
   (data-response (call-sql "get_user_layers_list" (:user-id session))))

--- a/src/clj/pyregence/capabilities.clj
+++ b/src/clj/pyregence/capabilities.clj
@@ -426,9 +426,10 @@
     :match-drops      {:match-drop-name {:opt-label \"Match Drop Name\" :filter-set #{\"match-drop-forecast\", \"match-drop-name\"} :auto-zoom? true :geoserver-key :match-drop} ...}
     :wui-active-fires {:wui-fire-name   {:opt-label \"WUI Fire Name\"   :filter-set #{\"fire-spread-forecast\", \"wui-fire-name\"}  :auto-zoom? true :geoserver-key :psps}       ...}}"
   [session]
-  ;; The map is public, so this can't be liveness-gated at the route.
-  (let [{:keys [user-id match-drop-access?]} (when (session/live? session) session)
-        match-drop-names                     (when match-drop-access?
+  ;; The map is public, so this can't be gated at the route. live? goes last to keep its
+  ;; query off callers who get no names anyway.
+  (let [{:keys [user-id match-drop-access?]} session
+        match-drop-names                     (when (and match-drop-access? (session/live? session))
                                                (->> (call-sql "get_user_match_names" user-id)
                                                     (reduce (fn [acc row]
                                                               (assoc acc

--- a/src/clj/pyregence/handlers.clj
+++ b/src/clj/pyregence/handlers.clj
@@ -4,6 +4,7 @@
             [clojure.repl        :refer [demunge]]
             [clojure.string      :as    str]
             [nrepl.server        :as    nrepl-server]
+            [pyregence.session   :as    session]
             [ring.util.codec     :refer [url-encode]]
             [ring.util.response  :refer [redirect]]
             [triangulum.config   :refer [get-config]]
@@ -87,82 +88,16 @@
   [tier]
   (not (isa? subscription-hierarchy tier :tier2-pro)))
 
-;; Session liveness
-
-(def ^:private default-idle-timeout-min     15)  ; NIST 800-63B AAL3 / PCI DSS 8.2.8
-(def ^:private default-absolute-timeout-min 420) ; 7 h
-
-(defn- session-expired?
-  "Fail-closed: a session missing either timestamp counts as expired; an unauthenticated one never expires."
-  [{:keys [user-id created-at last-active]} now idle-ms absolute-ms]
-  (boolean (when user-id
-             (or (nil? created-at)
-                 (nil? last-active)
-                 (> (- now created-at)  absolute-ms)
-                 (> (- now last-active) idle-ms)))))
-
-(defn- timeout-ms
-  [config-key default-min]
-  (* 60000 (or (get-config config-key) default-min)))
-
-(defn- session-timed-out?
-  [session now]
-  (session-expired? session now
-                    (timeout-ms :pyregence.auth/idle-timeout-min     default-idle-timeout-min)
-                    (timeout-ms :pyregence.auth/absolute-timeout-min default-absolute-timeout-min)))
-
-(defn- session-invalidated?
-  "Created strictly before the user's invalidation point (set on logout / newer login).
-   Strict `<` so a fresh login at the same instant survives; invalidated-at 0 = never."
-  [{:keys [user-id created-at]} invalidated-at]
-  (boolean (and user-id created-at (pos? invalidated-at) (< created-at invalidated-at))))
-
-(defn- session-revoked?
-  "A nil lookup (e.g. a deleted user) counts as not invalidated rather than crashing."
-  [{:keys [user-id] :as session}]
-  (boolean
-   (and user-id
-        (session-invalidated? session (or (sql-primitive (call-sql "get_user_session_invalidated_at" user-id)) 0)))))
-
 (defn redirect-handler
   "Sends a dead session (timed out or revoked) to log in again; only a live user who genuinely
-   lacks the role is told so. Defined below the liveness predicates so it can use them."
+   lacks the role is told so."
   [{:keys [session query-string uri] :as _request}]
-  (let [full-url (url-encode (str uri (when query-string (str "?" query-string))))
-        live?    (and (:user-id session)
-                      (not (session-timed-out? session (System/currentTimeMillis)))
-                      (not (session-revoked? session)))]
-    (if live?
+  (let [full-url (url-encode (str uri (when query-string (str "?" query-string))))]
+    (if (session/live? session)
       (redirect (str "/?flash_message=You do not have permission to access "
                      full-url))
       (redirect (str "/login?flash_message=You must login to see "
                      full-url)))))
-
-^:rct/test
-(comment
-  ;; idle 15 min = 900000 ms ; absolute 7 h = 25200000 ms (the production defaults)
-  (session-expired? {:user-id 1 :created-at 1000000000000 :last-active 1000000000000} 1000000000000 900000 25200000)
-  ;=> false
-  (session-expired? {:user-id 1 :created-at 1000000000000 :last-active 999999000000} 1000000000000 900000 25200000)
-  ;=> true
-  (session-expired? {:user-id 1 :created-at 999970000000 :last-active 1000000000000} 1000000000000 900000 25200000)
-  ;=> true
-  (session-expired? {:user-id 1} 1000000000000 900000 25200000)
-  ;=> true
-  (session-expired? {} 1000000000000 900000 25200000)
-  ;=> false
-
-  (session-invalidated? {:user-id 1 :created-at 1000} 0)
-  ;=> false
-  (session-invalidated? {:user-id 1 :created-at 1000} 2000)
-  ;=> true
-  (session-invalidated? {:user-id 1 :created-at 3000} 2000)
-  ;=> false
-  (session-invalidated? {:user-id 1 :created-at 2000} 2000)
-  ;=> false
-  (session-invalidated? {:created-at 1000} 2000)
-  ;=> false
-  )
 
 ^:rct/test
 (comment
@@ -233,8 +168,8 @@
   [{:keys [session] :as request} auth-type]
   (if (and (requires-live-session? auth-type)
            (:user-id session)
-           (or (session-timed-out? session (System/currentTimeMillis))
-               (session-revoked? session)))
+           (or (session/timed-out? session (System/currentTimeMillis))
+               (session/revoked? session)))
     false
     (authorized? request auth-type)))
 
@@ -363,7 +298,7 @@
       (let [now (System/currentTimeMillis)]
         (if (and (:user-id session)
                  (not (contains? response :session))
-                 (not (session-timed-out? session now)))
+                 (not (session/timed-out? session now)))
           (assoc response :session (assoc session :last-active now))
           response)))))
 

--- a/src/clj/pyregence/session.clj
+++ b/src/clj/pyregence/session.clj
@@ -8,7 +8,7 @@
 (def ^:private default-idle-timeout-min     15)  ; NIST 800-63B AAL3 / PCI DSS 8.2.8
 (def ^:private default-absolute-timeout-min 420) ; 7 h
 
-(defn expired?
+(defn- expired?
   "Fail-closed: a session missing either timestamp counts as expired; an unauthenticated one never expires."
   [{:keys [user-id created-at last-active]} now idle-ms absolute-ms]
   (boolean (when user-id
@@ -28,7 +28,7 @@
             (timeout-ms :pyregence.auth/idle-timeout-min     default-idle-timeout-min)
             (timeout-ms :pyregence.auth/absolute-timeout-min default-absolute-timeout-min)))
 
-(defn invalidated?
+(defn- invalidated?
   "Created strictly before the user's invalidation point (set on logout / newer login).
    Strict `<` so a fresh login at the same instant survives; invalidated-at 0 = never."
   [{:keys [user-id created-at]} invalidated-at]
@@ -40,8 +40,9 @@
   [{:keys [user-id] :as session}]
   (boolean
    (and user-id
-        (invalidated? session (or (:get_user_session_invalidated_at
-                                   (first (call-sql "get_user_session_invalidated_at" user-id)))
+        (invalidated? session (or (some-> (call-sql "get_user_session_invalidated_at" user-id)
+                                          (ffirst)
+                                          (val))
                                   0)))))
 
 (defn live?

--- a/src/clj/pyregence/session.clj
+++ b/src/clj/pyregence/session.clj
@@ -1,0 +1,95 @@
+(ns pyregence.session
+  "Session liveness. Sessions are stateless signed cookies, so one is dead when its stamps
+   fall outside the configured timeouts or it predates the user's invalidation cutoff.
+   `live?` is what a public route asks, since the auth gate cannot enforce liveness for it."
+  (:require [triangulum.config   :refer [get-config]]
+            [triangulum.database :refer [call-sql]]))
+
+(def ^:private default-idle-timeout-min     15)  ; NIST 800-63B AAL3 / PCI DSS 8.2.8
+(def ^:private default-absolute-timeout-min 420) ; 7 h
+
+(defn expired?
+  "Fail-closed: a session missing either timestamp counts as expired; an unauthenticated one never expires."
+  [{:keys [user-id created-at last-active]} now idle-ms absolute-ms]
+  (boolean (when user-id
+             (or (nil? created-at)
+                 (nil? last-active)
+                 (> (- now created-at)  absolute-ms)
+                 (> (- now last-active) idle-ms)))))
+
+(defn- timeout-ms
+  [config-key default-min]
+  (* 60000 (or (get-config config-key) default-min)))
+
+(defn timed-out?
+  "Whether the session is past its configured idle or absolute timeout as of `now`."
+  [session now]
+  (expired? session now
+            (timeout-ms :pyregence.auth/idle-timeout-min     default-idle-timeout-min)
+            (timeout-ms :pyregence.auth/absolute-timeout-min default-absolute-timeout-min)))
+
+(defn invalidated?
+  "Created strictly before the user's invalidation point (set on logout / newer login).
+   Strict `<` so a fresh login at the same instant survives; invalidated-at 0 = never."
+  [{:keys [user-id created-at]} invalidated-at]
+  (boolean (and user-id created-at (pos? invalidated-at) (< created-at invalidated-at))))
+
+(defn revoked?
+  "Invalidated server-side (logout / newer login). A missing lookup, nil or no row at all,
+   counts as not invalidated rather than crashing."
+  [{:keys [user-id] :as session}]
+  (boolean
+   (and user-id
+        (invalidated? session (or (:get_user_session_invalidated_at
+                                   (first (call-sql "get_user_session_invalidated_at" user-id)))
+                                  0)))))
+
+(defn live?
+  "Authenticated and neither timed out nor revoked. A public route should treat a session
+   as anonymous unless this is true."
+  [session]
+  (boolean
+   (and (:user-id session)
+        (not (timed-out? session (System/currentTimeMillis)))
+        (not (revoked? session)))))
+
+^:rct/test
+(comment
+  ;; idle 15 min = 900000 ms ; absolute 7 h = 25200000 ms (the production defaults)
+  (expired? {:user-id 1 :created-at 1000000000000 :last-active 1000000000000} 1000000000000 900000 25200000)
+  ;=> false
+  (expired? {:user-id 1 :created-at 1000000000000 :last-active 999999000000} 1000000000000 900000 25200000)
+  ;=> true
+  (expired? {:user-id 1 :created-at 999970000000 :last-active 1000000000000} 1000000000000 900000 25200000)
+  ;=> true
+  (expired? {:user-id 1} 1000000000000 900000 25200000)
+  ;=> true
+  (expired? {} 1000000000000 900000 25200000)
+  ;=> false
+
+  (invalidated? {:user-id 1 :created-at 1000} 0)
+  ;=> false
+  (invalidated? {:user-id 1 :created-at 1000} 2000)
+  ;=> true
+  (invalidated? {:user-id 1 :created-at 3000} 2000)
+  ;=> false
+  (invalidated? {:user-id 1 :created-at 2000} 2000)
+  ;=> false
+  (invalidated? {:created-at 1000} 2000)
+  ;=> false
+
+  ;; call-sql stubbed to 0 = never logged out.
+  (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at 0}])]
+    (let [now (System/currentTimeMillis)]
+      ;; anonymous, fresh, then timed out
+      [(live? {})
+       (live? {:user-id 1 :created-at now :last-active now})
+       (live? {:user-id 1 :created-at (- now 1000000000) :last-active (- now 1000000000)})]))
+  ;=> [false true false]
+
+  ;; Logout revokes without timing out, so the clock alone cannot catch it.
+  (let [now (System/currentTimeMillis)]
+    (with-redefs [call-sql (fn [& _] [{:get_user_session_invalidated_at now}])]
+      (live? {:user-id 1 :created-at (- now 1000) :last-active now})))
+  ;=> false
+  )


### PR DESCRIPTION
## Description
After you log out, two pages still believed your old cookie.

Since #1134 most routes check a session is alive before trusting it, but these two can't.
`add-new-user` also backs the public Register page and `get-fire-names` feeds the public map, so
neither can require a login. A logged-out admin could still add a user to an organization, and a
logged-out cookie could still see that person's match-drop names. Both now check first and treat a
dead cookie as anonymous, which each page already handles.

Tests cover logging out and timing out. Removing either guard, or narrowing `live?` to timeouts
only, fails the suite.

`bb test`, `bb test-clj` and clj-kondo are green. Also checked over HTTP: a dead admin cookie
posting `{:org-id 2}` gets a 403, the same cookie live gets a 200, and signup is unaffected.